### PR TITLE
Fix #20 - When closing Linux windows, app not quit

### DIFF
--- a/desktop/lib/platform/index.js
+++ b/desktop/lib/platform/index.js
@@ -21,6 +21,9 @@ Platform.prototype.setMainWindow = function( mainWindow ) {
 		PlatformHandler = require( './mac' );
 	} else if ( this.isWindows() ) {
 		PlatformHandler = require( './windows' );
+	} else if ( this.isLinux() ) {
+		console.log("Linux Platform Handler!");
+		PlatformHanlder = require( './linux' );
 	}
 
 	if ( PlatformHandler ) {
@@ -69,6 +72,7 @@ Platform.prototype.isWindows10 = function() {
 };
 
 Platform.prototype.isLinux = function() {
+	console.log("Process Platform: " + process.platform);
 	return process.platform === 'linux';
 };
 

--- a/desktop/lib/platform/index.js
+++ b/desktop/lib/platform/index.js
@@ -22,8 +22,7 @@ Platform.prototype.setMainWindow = function( mainWindow ) {
 	} else if ( this.isWindows() ) {
 		PlatformHandler = require( './windows' );
 	} else if ( this.isLinux() ) {
-		console.log("Linux Platform Handler!");
-		PlatformHanlder = require( './linux' );
+		PlatformHandler = require( './linux' );
 	}
 
 	if ( PlatformHandler ) {
@@ -72,7 +71,6 @@ Platform.prototype.isWindows10 = function() {
 };
 
 Platform.prototype.isLinux = function() {
-	console.log("Process Platform: " + process.platform);
 	return process.platform === 'linux';
 };
 

--- a/desktop/lib/platform/linux/README.md
+++ b/desktop/lib/platform/linux/README.md
@@ -1,0 +1,10 @@
+Linux Platform
+==========
+
+Provides any Linux specific platform features.
+
+
+## Closing & Quitting
+
+The app will quit when close, Mac and Windows is minimized.
+

--- a/desktop/lib/platform/linux/index.js
+++ b/desktop/lib/platform/linux/index.js
@@ -5,21 +5,17 @@
  */
 const electron = require( 'electron' );
 const app = electron.app;
-const Menu = electron.Menu;
-const debug = require( 'debug' )( 'platform:mac' );
+const debug = require( 'debug' )( 'platform:linux' );
 
 /**
  * Internal dependencies
  */
-const appQuit = require( 'lib/app-quit' );
-const menuSetter = require( 'lib/menu-setter' );
 
 function LinuxPlatform( mainWindow ) {
 	this.window = mainWindow;
 
 	app.on( 'activate', function() {
 		debug( 'Window activated' );
-
 		mainWindow.show();
 		mainWindow.focus();
 	} );
@@ -41,6 +37,5 @@ LinuxPlatform.prototype.restore = function() {
 
 	this.window.show();
 }
-
 
 module.exports = LinuxPlatform;

--- a/desktop/lib/platform/linux/index.js
+++ b/desktop/lib/platform/linux/index.js
@@ -1,0 +1,46 @@
+'use strict';
+
+/**
+ * External Dependencies
+ */
+const electron = require( 'electron' );
+const app = electron.app;
+const Menu = electron.Menu;
+const debug = require( 'debug' )( 'platform:mac' );
+
+/**
+ * Internal dependencies
+ */
+const appQuit = require( 'lib/app-quit' );
+const menuSetter = require( 'lib/menu-setter' );
+
+function LinuxPlatform( mainWindow ) {
+	this.window = mainWindow;
+
+	app.on( 'activate', function() {
+		debug( 'Window activated' );
+
+		mainWindow.show();
+		mainWindow.focus();
+	} );
+
+	app.on( 'window-all-closed', function() {
+		debug( 'All windows closed, shutting down' );
+		app.quit();
+	} );
+
+	mainWindow.on( 'close', function( ev ) {
+		app.quit();
+	} );
+}
+
+LinuxPlatform.prototype.restore = function() {
+	if ( this.window.isMinimized() ) {
+		this.window.restore();
+	}
+
+	this.window.show();
+}
+
+
+module.exports = LinuxPlatform;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "WordPressDesktop",
   "productName": "WordPress.com",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "repostitory": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"


### PR DESCRIPTION
The Mac and Windows build will minimize to Dock and Tray, while on Linux, when closing the app we want the app to quit. Otherwise, it won't restart when trying to run.

