### PR TITLE
Attempt to fix icons in GNOME

### DIFF
--- a/resource/build-scripts/package-linux.js
+++ b/resource/build-scripts/package-linux.js
@@ -25,11 +25,13 @@ var onErrorBail = function( error ) {
 };
 
 // copy build into place for packaging
-cp.execSync( "rm -rf release/tmp ", onErrorBail ); // clean start
-cp.execSync( "mkdir -p release/tmp/usr/local ", onErrorBail );
-cp.execSync( "mkdir -p release/tmp/usr/share/applications ", onErrorBail );
-cp.execSync( "cp -r release/WordPress.com-linux-x64 release/tmp/usr/local/WordPress.com", onErrorBail );
-cp.execSync( "cp resource/linux/wordpress-com.desktop release/tmp/usr/share/applications/", onErrorBail );
+cp.execSync( "rm -rf release/tmp", onErrorBail ); // clean start
+cp.execSync( "mkdir -p release/tmp/usr/share/applications", onErrorBail );
+cp.execSync( "mkdir -p release/tmp/usr/share/pixmaps", onErrorBail );
+cp.execSync( "cp -r release/WordPress.com-linux-x64 release/tmp/usr/share/wpcom", onErrorBail );
+cp.execSync( "mv release/tmp/usr/share/wpcom/WordPress.com release/tmp/usr/share/wpcom/wpcom", onErrorBail );	// rename binary to wpcom
+cp.execSync( "cp resource/linux/wpcom.desktop release/tmp/usr/share/applications/", onErrorBail );
+cp.execSync( "cp resource/app-icon/icon_256x256.png release/tmp/usr/share/pixmaps/wpcom.png", onErrorBail );
 
 var cmd = [
 	'fpm',

--- a/resource/linux/wordpress-com.desktop
+++ b/resource/linux/wordpress-com.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Name=WordPress.com
-Comment=WordPress.com Desktop Client
-Exec=/usr/local/WordPress.com/WordPress.com
-Icon=/usr/local/WordPress.com/WordPress.png
-Type=Application
-StartupNotify=true
-Categories=GNOME;GTK;Utility;

--- a/resource/linux/wpcom.desktop
+++ b/resource/linux/wpcom.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=WordPress.com
+Comment=WordPress.com Desktop Client
+Generic Name=Blog Admin Client
+Exec=/usr/share/wpcom/wpcom
+Icon=wpcom
+Type=Application
+StartupNotify=true
+Categories=Development

--- a/resource/linux/wpcom.desktop
+++ b/resource/linux/wpcom.desktop
@@ -1,9 +1,8 @@
 [Desktop Entry]
 Name=WordPress.com
 Comment=WordPress.com Desktop Client
-Generic Name=Blog Admin Client
 Exec=/usr/share/wpcom/wpcom
 Icon=wpcom
 Type=Application
 StartupNotify=true
-Categories=Development
+Categories=Development;


### PR DESCRIPTION
For #24 

1. Moved install location to `/usr/share/wpcom`
2. Rename binary executable to `wpcom`
3. Copied icon file to `/usr/share/pixmaps/wpcom.png`

Researching the issue, I came across the executable and
icon filenames should be the same, appears to make no difference.