### PR TITLE
Improve build script for Mac App Store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CERT_SPC := $(THIS_DIR)/resource/secrets/automattic-code.spc
 CERT_PVK := $(THIS_DIR)/resource/secrets/automattic-code.pvk
 CALYPSO_DIR := $(THIS_DIR)/calypso
 CALYPSO_JS_STD := $(CALYPSO_DIR)/public/build-desktop.js
-CALYPSO_JS_MAS := $(CALYPSO_DIR)/public/build-desktop.js
+CALYPSO_JS_MAS := $(CALYPSO_DIR)/public/build-desktop-mac-app-store.js
 CALYPSO_CHANGES_STD := `find "$(CALYPSO_DIR)" -newer "$(CALYPSO_JS_STD)" \( -name "*.js" -o -name "*.jsx" -o -name "*.json" -o -name "*.scss" \) -type f -print -quit | grep -v .min. | wc -l`
 CALYPSO_CHANGES_MAS := `find "$(CALYPSO_DIR)" -newer "$(CALYPSO_JS_MAS)" \( -name "*.js" -o -name "*.jsx" -o -name "*.json" -o -name "*.scss" \) -type f -print -quit | grep -v .min. | wc -l`
 CALYPSO_BRANCH = $(shell git --git-dir ./calypso/.git branch | sed -n -e 's/^\* \(.*\)/\1/p')
@@ -36,7 +36,7 @@ run: config-dev build-if-changed
 run-release: config-release build-if-changed
 	$(START_APP)
 
-run-mas: config-mas build-if-changed
+run-mas: config-mas build-mas-if-changed
 	$(START_APP)
 
 # Builds Calypso (desktop)

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ PACKAGE_WIN32 := @$(NPM_BIN)/electron-builder
 CERT_SPC := $(THIS_DIR)/resource/secrets/automattic-code.spc
 CERT_PVK := $(THIS_DIR)/resource/secrets/automattic-code.pvk
 CALYPSO_DIR := $(THIS_DIR)/calypso
+CALYPSO_JS := $(CALYPSO_DIR)/public/build.js
 CALYPSO_JS_STD := $(CALYPSO_DIR)/public/build-desktop.js
 CALYPSO_JS_MAS := $(CALYPSO_DIR)/public/build-desktop-mac-app-store.js
 CALYPSO_CHANGES_STD := `find "$(CALYPSO_DIR)" -newer "$(CALYPSO_JS_STD)" \( -name "*.js" -o -name "*.jsx" -o -name "*.json" -o -name "*.scss" \) -type f -print -quit | grep -v .min. | wc -l`
@@ -31,12 +32,15 @@ secret:
 
 # Just runs Electron with whatever version of Calypso exists
 run: config-dev build-if-changed
+	@cp $(CALYPSO_JS_STD) $(CALYPSO_JS)
 	$(START_APP)
 
 run-release: config-release build-if-changed
+	@cp $(CALYPSO_JS_STD) $(CALYPSO_JS)
 	$(START_APP)
 
 run-mas: config-mas build-mas-if-changed
+	@cp $(CALYPSO_JS_MAS) $(CALYPSO_JS)
 	$(START_APP)
 
 # Builds Calypso (desktop)
@@ -56,10 +60,9 @@ build-mas: install
 	@echo "Building Calypso (Mac App Store on branch $(RED)$(CALYPSO_BRANCH)$(RESET))"
 	@CALYPSO_ENV=desktop-mac-app-store make build -C $(THIS_DIR)/calypso/
 	@rm $(THIS_DIR)/calypso/public/devmodules.*
-	@cp $(CALYPSO_JS_MAS) $(CALYPSO_JS_STD)
 
 build-mas-if-not-exists:
-	@if [ -f $(CALYPSO_JS_MAS) ]; then true; else make build; fi
+	@if [ -f $(CALYPSO_JS_MAS) ]; then true; else make build-mas; fi
 
 build-mas-if-changed: build-mas-if-not-exists
 	@if [ $(CALYPSO_CHANGES_MAS) -eq 0 ]; then true; else make build-mas; fi;

--- a/desktop/env.js
+++ b/desktop/env.js
@@ -22,8 +22,7 @@ const serverPath = path.resolve( path.join( __dirname, '..', 'calypso', 'server'
 const sharedPath = path.resolve( path.join( __dirname, '..', 'calypso', 'shared' ) );
 const desktopPath = path.resolve( path.join( __dirname ) );
 
-// todo should be config.calypso_config - but need Calypso server/desktop.jade to load the correct .js file
-process.env.CALYPSO_ENV = 'desktop';
+process.env.CALYPSO_ENV = config.calypso_config;
 
 // If debug is enabled then setup the debug target
 if ( Settings.isDebug() ) {

--- a/desktop/server/server.js
+++ b/desktop/server/server.js
@@ -35,7 +35,7 @@ function showFailure( app ) {
 }
 
 function startServer( app, startedCallback ) {
-	let appFile = path.resolve( process.cwd(), 'calypso', 'build', 'bundle-desktop.js' ),
+	let appFile = path.resolve( process.cwd(), 'calypso', 'build', `bundle-${ Config.calypso_config }.js` ),
 		env = Object.create( process.env );
 
 	env.PORT = Config.server_port;

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,7 +27,7 @@ So what happens when you `make run`? It's a fairly complicated process so buckle
 - *(renderer)* Calypso provides the 'index' page from `calypso/server/pages/desktop.jade`, which is a standard Calypso start page plus:
   - `public_desktop/wordpress-desktop.css` - any CSS specific to the desktop app
   - `public_desktop/desktop-app.js` - desktop app specific JS and also the Calypso boot code
-  - `calypso/public/build-desktop.js` - a prebuilt Calypso
+  - `calypso/public/build.js` - a prebuilt Calypso
 - *(renderer)* The `desktop-app.js` code runs which sets up various app specific handlers that need to be inside the renderer. It also starts Calypso with `AppBoot()`
 - *(renderer)* The code in `calypso/client/lib/desktop` runs to send and receive IPC messages between the main process and Calypso.
 

--- a/resource/build-config/calypso-ignore.js
+++ b/resource/build-config/calypso-ignore.js
@@ -43,6 +43,7 @@ module.exports = [
 	'node_modules/.bin',
 	'calypso/public/style-debug.css',
 	'calypso/public/style-debug.map',
+	'calypso/public/build-desktop.js',
 	'calypso/public/build-desktop.min.js',
 	'calypso/public/build-logged-out-desktop.js',
 	'calypso/public/build-logged-out-desktop.min.js',


### PR DESCRIPTION
When you try to run Mac App Store version of desktop app it uses default desktop config. This PR fixes that. Additionally it changes the Calypso build script name to allow easy switch between different Desktop app versions: standalone vs Mac App Store. 

This change depends on this change Automattic/wp-calypso/pull/2781. They should be merged with master at the same time.

### Testing
Apply Calypso changes from Automattic/wp-calypso/pull/2781.

1. Execute `make run`.
2. Desktop app should launch with default desktop config.
3. Close app.
4. Execute `make run-mas`.
5. Desktop app should launch with desktop config adjusted for Mac App Store.
6. Close app.
7. Repeat (1) and (2). You should see default app setup again.