### PR TITLE
Disable scroll bounce

### DIFF
--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -90,6 +90,15 @@ function startDesktopApp() {
 		}
 	}
 
+	function preventScrollBounceOSX( e ) {
+		if (
+			( e.deltaY < 0 && document.body.scrollTop === 0 ) ||
+			( e.deltaY > 0 && document.body.scrollTop === document.body.scrollHeight - window.innerHeight )
+		) {
+			e.preventDefault()
+		}
+	}
+
 	debug = gGebug( 'desktop:browser' );
 
 	// Everything is ready, start Calypso
@@ -102,6 +111,10 @@ function startDesktopApp() {
 
 		document.addEventListener( 'keydown', keyboardHandler );
 		document.addEventListener( 'click', preventNewWindow );
+
+		if ( window.navigator.userAgent.indexOf( 'Macintosh' ) !== -1 ) {
+			document.body.addEventListener( 'mousewheel', preventScrollBounceOSX );
+		}
 	}
 
 	// This is called by Calypso


### PR DESCRIPTION
# What are you talking about?

OSX has natively this effect of 'bounce' when you are scrolling to the edge of current window.
I HATE THIS in the app.

![](https://cldup.com/LQ7VNvnEkJ-3000x3000.png)

# Y u no CSS?
It is possible to achieve the same effect in CSS:
```css
html.is-desktop {
overflow:hidden;
}
html.is-desktop body {
overflow: auto;
}
```

But this hides the scrollbar under masterbar and also messes with scrollbar visibility (the scrollbar disappers, but scrolling is still working)

# Better solution
We discussed it with @rralian and decided that even better solution would be to play this video when while scrolling, we
**[push it to the limit / past the point of no return](https://youtu.be/kZu5iDTtNg0?t=24s)**
Unfortunately, this clip is not GPL :/

# Testing
Just scroll with swipe to the edge

CC @adambbecker @johngodley @dmsnell @gziolo 