### PR TITLE
Track user's last location

### DIFF
--- a/desktop/lib/settings/constants.js
+++ b/desktop/lib/settings/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+	LAST_LOCATION: 'last-location'
+}

--- a/desktop/server/index.js
+++ b/desktop/server/index.js
@@ -6,6 +6,7 @@
 const electron = require( 'electron' );
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
+const url = require( 'url' );
 const debug = require( 'debug' )( 'desktop:runapp' );
 
 /**
@@ -14,6 +15,7 @@ const debug = require( 'debug' )( 'desktop:runapp' );
 const Config = require( 'lib/config' );
 const server = require( './server' );
 const Settings = require( 'lib/settings' );
+const settingConstants = require( 'lib/settings/constants' );
 const cookieAuth = require( 'lib/cookie-auth' );
 const appInstance = require( 'lib/app-instance' );
 const platform = require( 'lib/platform' );
@@ -25,7 +27,11 @@ const System = require( 'lib/system' );
 var mainWindow = null;
 
 function showAppWindow() {
-	const appUrl = Config.server_url + ':' + Config.server_port;
+	let appUrl = Config.server_url + ':' + Config.server_port;
+	let lastLocation = Settings.getSetting( settingConstants.LAST_LOCATION );
+	if ( lastLocation ) {
+		appUrl += lastLocation;
+	}
 
 	debug( 'Loading app (' + appUrl + ') in mainWindow' );
 
@@ -41,6 +47,12 @@ function showAppWindow() {
 
 	mainWindow.loadURL( appUrl );
 	//mainWindow.openDevTools();
+
+	mainWindow.on( 'close', function() {
+		let currentURL = mainWindow.webContents.getURL();
+		let parsedURL = url.parse( currentURL );
+		Settings.saveSetting( settingConstants.LAST_LOCATION, parsedURL.pathname );
+	} );
 
 	mainWindow.on( 'closed', function() {
 		debug( 'Window closed' );


### PR DESCRIPTION
Store the user's last location in settings and navigate to that when they re-open the app.

## To Test

- Start app
- Navigate somewhere
- Exit app
- Restart app
- Ensure the app opens at your same location you exited

/cc @jasmussen