### PR TITLE
Tune positions of icons in DMG file.

### DIFF
--- a/resource/build-config/dmg.json
+++ b/resource/build-config/dmg.json
@@ -12,7 +12,7 @@
 		},
 		{
 			"x": 156,
-			"y": 176,
+			"y": 196,
 			"type": "file",
 			"path": "../../release/WordPress.com-darwin-x64/WordPress.com.app"
 		}

--- a/resource/build-config/dmg.json
+++ b/resource/build-config/dmg.json
@@ -5,14 +5,14 @@
 	"background": "../image/dmg-background/background.png",
 	"contents": [
 		{
-			"x": 480,
-			"y": 240,
+			"x": 486,
+			"y": 176,
 			"type": "link",
 			"path": "/Applications"
 		},
 		{
-			"x": 130,
-			"y": 240,
+			"x": 156,
+			"y": 176,
 			"type": "file",
 			"path": "../../release/WordPress.com-darwin-x64/WordPress.com.app"
 		}


### PR DESCRIPTION
This positions the Applications and WordPress.com app icons better in the DMG file. 