### PR TITLE
On build, cp build-desktop.js to build.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ run-mas: config-mas package
 build: install
 	@echo "Building Calypso (Desktop on branch $(RED)$(CALYPSO_BRANCH)$(RESET))"
 	@CALYPSO_ENV=desktop make build -C $(THIS_DIR)/calypso/
+	@cp $(THIS_DIR)/calypso/public/build-desktop.js $(THIS_DIR)/calypso/public/build.js
 	@rm $(THIS_DIR)/calypso/public/devmodules.*
 
 build-if-not-exists:


### PR DESCRIPTION
#66 changed desktop layout to use build.js instead but only created the file during packaging. This creates the file during `build` too.

Longer-term, it might just be better to minify the `build-desktop.js` file instead of creating a separate file.