### PR TITLE
Remove unused CSS

### DIFF
--- a/public_desktop/wordpress-desktop.css
+++ b/public_desktop/wordpress-desktop.css
@@ -129,11 +129,7 @@ html.desktop-auth .button-emphasis {
 
 html.is-desktop,
 html.is-desktop body,
-#wpcom,
-.logged-out-auth,
-.logged-out-auth .wp-content,
-.logged-out-auth .wp-primary,
-.logged-out-auth .auth-login {
+#wpcom {
 	height: 100%;
 }
 


### PR DESCRIPTION
`.logged-out-auth` was removed from Calypso in https://github.com/Automattic/wp-calypso/pull/2964, in favor of CSS that targets a specific section (e.g. `.is-section-login`).

**Testing**
- Assert that the styles of the login screen remain unchanged (i.e. that the page isn't broken).