### PR TITLE
Don't save paths starting with /start, since they cannot be resumed

### DIFF
--- a/desktop/server/index.js
+++ b/desktop/server/index.js
@@ -8,6 +8,7 @@ const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 const url = require( 'url' );
 const debug = require( 'debug' )( 'desktop:runapp' );
+const startsWith = require( 'lodash/string/startsWith' );
 
 /**
  * Internal dependencies
@@ -51,7 +52,9 @@ function showAppWindow() {
 	mainWindow.on( 'close', function() {
 		let currentURL = mainWindow.webContents.getURL();
 		let parsedURL = url.parse( currentURL );
-		Settings.saveSetting( settingConstants.LAST_LOCATION, parsedURL.pathname );
+		if ( ! startsWith( parsedURL.pathname, '/start' ) ) { // Don't attempt to resume the signup flow
+			Settings.saveSetting( settingConstants.LAST_LOCATION, parsedURL.pathname );
+		}
 	} );
 
 	mainWindow.on( 'closed', function() {


### PR DESCRIPTION
The signup flow can't be resumed in the desktop app, so we shouldn't save these routes in `LAST_LOCATION`.

The original idea was to exclude all routes when logged out. I couldn't find a way to determine if the user was logged in, and I noticed that the signup flow couldn't be resumed when the use was logged in either, so this fix seems better.

Fixes #82
 
#### Testing instructions - Logged out

1. Run `git checkout fix/82-dont-save-signup-routes` and start your server
1. Run `git checkout add/signup-in-desktop` from within `/calypso`
2. Ensure you are logged out of the app
2. Navigate part way though the signup flow
3. Close the app
4. Reopen the app and assert that you see the login page

#### Testing instructions - Logged in (in signup)

1. Run `git checkout fix/82-dont-save-signup-routes` and start your server
1. Run `git checkout add/signup-in-desktop` from within `/calypso`
2. Ensure you are logged in to the app
2. Navigate part way though the signup flow
3. Close the app
4. Reopen the app and assert that you are taken to the last page you had open (before the signup flow)

#### Testing instructions - Logged in (not in signup)

1. Run `git checkout fix/82-dont-save-signup-routes` and start your server
1. Run `git checkout add/signup-in-desktop` from within `/calypso`
2. Ensure you are logged in to the app
2. Navigate to a page in Calypso that isn't in the signup flow
3. Close the app
4. Reopen the app and assert that you are taken to the last page you had open

#### Reviews

- [x] Code
- [x] Product