### PR TITLE
Add RMDir to uninstall to remove AppData

### DIFF
--- a/resource/build-config/windows-nsi.tpl
+++ b/resource/build-config/windows-nsi.tpl
@@ -104,6 +104,10 @@ Section "Uninstall"
   rmDir  "$SMPROGRAMS\${APP_DIR}"
   delete "$DESKTOP\${APP_NAME}.lnk"
 
-
   DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"
+
+  # Delete AppData, only works for current user
+  SetShellVarContext current
+  RMDir /r "$APPDATA\${APP_NAME}"
+
 SectionEnd


### PR DESCRIPTION
Remove AppData\Roaming\WordPress.com directory on uninstall. This fixes
the issue with corrupt user data, or staying logged in after an
uninstall. Properly cleans up after itself.