### PR TITLE
Add empty function for Linux, showNotificationsBadge

### DIFF
--- a/desktop/lib/platform/linux/index.js
+++ b/desktop/lib/platform/linux/index.js
@@ -38,6 +38,10 @@ LinuxPlatform.prototype.restore = function() {
 	this.window.show();
 }
 
+LinuxPlatform.prototype.showNotificationsBadge = function( count, bounceEnabled ) {
+	// no op
+};
+
 LinuxPlatform.prototype.clearNotificationsBadge = function() {
 	// no op
 };


### PR DESCRIPTION
Missed a platform specific function which functionality does not exist on Linux, but still gets called so need to create a no op placeholder.

Fixes #85 - Bug surfaces when an unread notification exists when launching the app