### PR TITLE
process.exit with code 1 on uncaughtException

### DIFF
--- a/desktop/env.js
+++ b/desktop/env.js
@@ -33,7 +33,7 @@ process.on( 'uncaughtException', function( error ) {
 		error.stack
 	);
 
-	process.exit();
+	process.exit( 1 );
 } );
 
 // If debug is enabled then setup the debug target


### PR DESCRIPTION
Default is success, which is not true here.