### PR TITLE
Drop lodash; use native startsWith

### DIFF
--- a/desktop/server/index.js
+++ b/desktop/server/index.js
@@ -52,7 +52,7 @@ function showAppWindow() {
 	mainWindow.on( 'close', function() {
 		let currentURL = mainWindow.webContents.getURL();
 		let parsedURL = url.parse( currentURL );
-		if ( ! startsWith( parsedURL.pathname, '/start' ) ) { // Don't attempt to resume the signup flow
+		if ( ! parsedURL.pathname.startsWith( '/start' ) ) { // Don't attempt to resume the signup flow
 			Settings.saveSetting( settingConstants.LAST_LOCATION, parsedURL.pathname );
 		}
 	} );


### PR DESCRIPTION
This interestingly worked even though lodash is not a dependency for the desktop app because we bundle calypso as well, which does include lodash.