### PR TITLE
Checkout: Make it possible to expose jQuery for paygate.js script

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "debug": "^2.2.0",
     "express": "^4.13.3",
     "jade": "^1.11.0",
+    "jquery": "1.11.3",
     "lodash.debounce": "^4.0.0",
     "portscanner": "^1.0.0",
     "spellchecker": "^3.1.3",


### PR DESCRIPTION
Fix for https://github.com/Automattic/wp-calypso/issues/3405.

It fixes the following issue:

> When I click the Pay button after filling the credit card details, a blue notice saying "Submitting payment" appears but nothing happens. I've tried several times and users are not charged, and nothing happens even after waiting 3-5 minutes.

This is a well known bug when using Electron:
https://github.com/atom/electron/issues/254

### Testing
1. Checkout `fix/3405-paygate-broken-dekstop` branch in `calypso` folder. See: https://github.com/Automattic/wp-calypso/pull/3456.
2. Checkout `update/make-it-possible-to-pay-with-card` branch in main folder.
3. Execute `make run`.
4. Try to purchase any upgrade.
5. Provide data for new credit card to finalise purchase.

/cc @peterbutler @scruffian @fabianapsimoes 