### PR TITLE
Revert "Checkout: Make it possible to expose jQuery for paygate.js script"

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "debug": "^2.2.0",
     "express": "^4.13.3",
     "jade": "^1.11.0",
-    "jquery": "1.11.3",
     "lodash.debounce": "^4.0.0",
     "portscanner": "^1.0.0",
     "spellchecker": "^3.1.3",


### PR DESCRIPTION
Reverts Automattic/wp-desktop#93.

We need to add this dependency on wp-calypso side to avoid build warnings.