### PR TITLE
Add/98 report issue link

### DIFF
--- a/desktop/lib/calypso-commands/index.js
+++ b/desktop/lib/calypso-commands/index.js
@@ -31,6 +31,11 @@ module.exports = {
 		mainWindow.webContents.send( 'toggle-notification-bar' );
 	},
 
+	showHelp: function( mainWindow ) {
+		debug( 'showHelp triggered' );
+		mainWindow.webContents.send( 'page-help' );
+	},
+
 	signOut: function( mainWindow ) {
 		debug( 'signOut triggered' );
 		mainWindow.webContents.send( 'signout' );

--- a/desktop/lib/menu/help-menu.js
+++ b/desktop/lib/menu/help-menu.js
@@ -35,12 +35,6 @@ module.exports = function( mainWindow ) {
 			}
 		},
 		{
-			label: 'Support docs',
-			click: function() {
-				shell.openExternal( 'https://support.wordpress.com' );
-			}
-		},
-		{
 			label: 'Forums',
 			click: function() {
 				shell.openExternal( 'https://forums.wordpress.com/' );

--- a/desktop/lib/menu/help-menu.js
+++ b/desktop/lib/menu/help-menu.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 const shell = require( 'electron' ).shell;
+const ipc = require( 'lib/calypso-commands' );
 
 /**
  * Internal dependencies
@@ -24,31 +25,32 @@ if ( platform.isWindows() || platform.isLinux() ) {
 	menuItems.push( { type: 'separator' } );
 }
 
-menuItems = menuItems.concat( [
-	{
-		label: 'Support',
-		click: function() {
-			shell.openExternal( 'https://support.wordpress.com' );
-		}
-	},
-	{
-		label: 'Forums',
-		click: function() {
-			shell.openExternal( 'https://forums.wordpress.com/' );
-		}
-	},
-	{
-		label: 'Report an Issue...',
-		click: function() {
-			shell.openExternal( 'https://github.com/Automattic/wp-desktop/issues' );
-		}
-	},
-	{
-		label: 'Privacy Policy',
-		click: function() {
-			shell.openExternal( 'https://automattic.com/privacy/' );
-		}
-	},
-] );
-
-module.exports = menuItems;
+module.exports = function( mainWindow ) {
+	return menuItems.concat( [
+		{
+			label: 'How can we help?',
+			click: function() {
+				mainWindow.show();
+				ipc.showHelp( mainWindow );
+			}
+		},
+		{
+			label: 'Support docs',
+			click: function() {
+				shell.openExternal( 'https://support.wordpress.com' );
+			}
+		},
+		{
+			label: 'Forums',
+			click: function() {
+				shell.openExternal( 'https://forums.wordpress.com/' );
+			}
+		},
+		{
+			label: 'Privacy Policy',
+			click: function() {
+				shell.openExternal( 'https://automattic.com/privacy/' );
+			}
+		},
+	] );
+}

--- a/desktop/lib/menu/main-menu.js
+++ b/desktop/lib/menu/main-menu.js
@@ -28,7 +28,7 @@ module.exports = function( app, mainWindow ) {
 		{
 			label: 'Help',
 			role: 'help',
-			submenu: helpMenu
+			submenu: helpMenu( mainWindow )
 		}
 	];
 


### PR DESCRIPTION
Switch Help link to go within app to /help page, the web equivalent is: https://wordpress.com/help
Dependent on https://github.com/Automattic/wp-calypso/pull/3571