### PR TITLE
Implement Basic i18n Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ publish/publish-config.js
 publish/node_modules/
 resource/secrets
 build
+public_desktop/languages/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ publish/node_modules/
 resource/secrets
 build
 public_desktop/languages/
+wpcom-desktop-strings.php

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ PACKAGE_WIN32 := @$(NPM_BIN)/electron-builder
 CERT_SPC := $(THIS_DIR)/resource/secrets/automattic-code.spc
 CERT_PVK := $(THIS_DIR)/resource/secrets/automattic-code.pvk
 DESKTOP_PUBLIC_DIR := $(THIS_DIR)/public_desktop
+DESKTOP_JS := $(BUILD_DIR)/desktop.js
 CALYPSO_DIR := $(THIS_DIR)/calypso
 CALYPSO_JS := $(CALYPSO_DIR)/public/build.js
 CALYPSO_JS_STD := $(CALYPSO_DIR)/public/build-desktop.js
@@ -28,6 +29,7 @@ CALYPSO_CHANGES_STD := `find "$(CALYPSO_DIR)" -newer "$(CALYPSO_JS_STD)" \( -nam
 CALYPSO_CHANGES_MAS := `find "$(CALYPSO_DIR)" -newer "$(CALYPSO_JS_MAS)" \( -name "*.js" -o -name "*.jsx" -o -name "*.json" -o -name "*.scss" \) -type f -print -quit | grep -v .min. | wc -l`
 CALYPSO_BRANCH = $(shell git --git-dir ./calypso/.git branch | sed -n -e 's/^\* \(.*\)/\1/p')
 FETCH_TRANSLATIONS_JS = $(THIS_DIR)/resource/i18n/downloader.js
+GET_I18N = $(CALYPSO_DIR)/bin/get-i18n
 WEBPACK_BIN := @$(NPM_BIN)/webpack
 
 # sets to 1 if NPM version is >= 3
@@ -192,6 +194,9 @@ test-osx: osx
 	@NODE_PATH=./release/WordPress.com-darwin-x64-unpackaged/node_modules ELECTRON_PATH=$(NPM_BIN)/electron ./release/WordPress.com-darwin-x64-unpacked/node_modules/electron-mocha/bin/electron-mocha --inline-diffs --timeout 5000 ./resource/test/osx.js
 
 # Misc
+translate: config-release package
+	@$(GET_I18N) ./wpcom-desktop-strings.php wpcom_desktop_i18n_strings $(DESKTOP_JS)
+
 fetch-translations:
 	@echo "Fetching translations"
 	@rm -rf $(DESKTOP_PUBLIC_DIR)/languages

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ PACKAGE_DMG := $(THIS_DIR)/resource/build-scripts/package-dmg.js
 PACKAGE_WIN32 := @$(NPM_BIN)/electron-builder
 CERT_SPC := $(THIS_DIR)/resource/secrets/automattic-code.spc
 CERT_PVK := $(THIS_DIR)/resource/secrets/automattic-code.pvk
+DESKTOP_PUBLIC_DIR := $(THIS_DIR)/public_desktop
 CALYPSO_DIR := $(THIS_DIR)/calypso
 CALYPSO_JS := $(CALYPSO_DIR)/public/build.js
 CALYPSO_JS_STD := $(CALYPSO_DIR)/public/build-desktop.js
@@ -193,6 +194,7 @@ test-osx: osx
 # Misc
 fetch-translations:
 	@echo "Fetching translations"
+	@rm -rf $(DESKTOP_PUBLIC_DIR)/languages
 	@node $(FETCH_TRANSLATIONS_JS)
 	@echo "---"
 

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ test-osx: osx
 # Misc
 translate: config-release package
 	@$(GET_I18N) ./wpcom-desktop-strings.php wpcom_desktop_i18n_strings $(DESKTOP_JS)
+	@echo "Saved to ./wpcom-desktop-strings.php"
 
 fetch-translations:
 	@echo "Fetching translations"

--- a/desktop/lib/i18n/index.js
+++ b/desktop/lib/i18n/index.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * External Dependencies
+ */
+const fs = require( 'fs' );
+const debug = require( 'debug' )( 'desktop:i18n' );
+
+/**
+ * Internal dependencies
+ */
+const assets = require( 'lib/assets' );
+const i18n = require( 'client/lib/mixins/i18n' );
+const config = require( 'server/config' );
+
+function getTranslationsFilePath( locale ) {
+	return assets.getPath( 'languages/' + locale + '.json' );
+}
+
+function loadTranslations( locale ) {
+	let translations = null;
+	let languageFile = getTranslationsFilePath( locale );
+
+	debug( 'Looking for translation file: ' + languageFile );
+	if ( fs.existsSync( languageFile ) ) {
+		try {
+			translations = JSON.parse( fs.readFileSync( languageFile ) );
+			debug( 'Parsed translations' );
+		} catch ( e ) {
+			debug( 'Failed to parse translations file', e );
+		}
+	}
+
+	return translations;
+}
+
+module.exports = {
+	init: function( locale ) {
+		debug( 'Initialize i18n for ' + locale )
+		let translations = null;
+		if ( locale !== config( 'i18n_default_locale_slug' ) ) {
+			translations = loadTranslations( locale );
+		}
+		i18n.initialize( translations );
+	},
+
+	// Pass-through mixin translation functions
+	translate: i18n.translate,
+	moment: i18n.moment,
+	numberFormat: i18n.numberFormat
+};

--- a/desktop/lib/menu/app-menu.js
+++ b/desktop/lib/menu/app-menu.js
@@ -14,6 +14,7 @@ const Settings = require( 'lib/settings' );
 const WindowManager = require( 'lib/window-manager' );
 const platform = require( 'lib/platform' );
 const debugMenu = require( './debug-menu' );
+const i18n = require( 'lib/i18n' );
 
 /**
  * Module variables
@@ -23,7 +24,7 @@ const debugEnabled = Settings.getSettingGroup( Config.debug.enabled_by_default, 
 module.exports = function( app, mainWindow ) {
 	let menuItems = [
 		{
-			label: 'Preferences...',
+			label: i18n.translate( 'Preferences...', { context: 'Desktop App Menu Item' } ),
 			accelerator: 'CmdOrCtrl+,',
 			click: function() {
 				WindowManager.openPreferences();
@@ -33,7 +34,7 @@ module.exports = function( app, mainWindow ) {
 			type: 'separator'
 		},
 		{
-			label: 'Sign Out',
+			label: i18n.translate( 'Sign Out' ),
 			requiresUser: true,
 			enabled: false,
 			id: 'loggedin',
@@ -46,7 +47,7 @@ module.exports = function( app, mainWindow ) {
 			type: 'separator'
 		},
 		{
-			label: 'Quit',
+			label: i18n.translate( 'Quit', { context: 'Desktop App Action' } ),
 			accelerator: 'CmdOrCtrl+Q',
 			click: function() {
 				app.quit();
@@ -57,17 +58,17 @@ module.exports = function( app, mainWindow ) {
 	if ( Config.debug ) {
 		menuItems.splice( 1, 0,
 			{
-				label: 'Debug Mode',
+				label: i18n.translate( 'Debug Mode' ),
 				type: 'checkbox',
 				checked: debugEnabled,
 				click: function( menu ) {
 					Settings.saveSetting( 'debug', menu.checked );
 
 					dialog.showMessageBox( {
-						buttons: [ 'OK' ],
-						title: 'Restart',
-						message: 'Please restart the app for the change to have effect',
-						detail: "Sorry, we're unable to restart it for you right now"
+						buttons: [ i18n.translate( 'OK' ) ],
+						title: i18n.translate( 'Restart' ),
+						message: i18n.translate( 'Please restart the app for the change to have effect' ),
+						detail: i18n.translate( "Sorry, we're unable to restart it for you right now" )
 					} );
 				}
 			}
@@ -82,7 +83,7 @@ module.exports = function( app, mainWindow ) {
 		// Add an 'about' item to the start of the menu, as per OS X standards
 		menuItems.splice( 0, 0,
 			{
-				label: 'About WordPress.com',
+				label: i18n.translate( 'About WordPress.com' ),
 				click: function() {
 					WindowManager.openAbout();
 				}
@@ -95,7 +96,7 @@ module.exports = function( app, mainWindow ) {
 		// Add the standard OS X app items just before the quit
 		menuItems.splice( menuItems.length - 1, 0,
 			{
-				label: 'Services',
+				label: i18n.translate( 'Services', { context: 'Desktop App "Services" Menu Item on OSX' } ),
 				role: 'services',
 				submenu: []
 			},
@@ -103,17 +104,17 @@ module.exports = function( app, mainWindow ) {
 				type: 'separator'
 			},
 			{
-				label: 'Hide WordPress.com',
+				label: i18n.translate( 'Hide WordPress.com', { context: 'Desktop App Window Action' } ),
 				accelerator: 'Command+H',
 				role: 'hide'
 			},
 			{
-				label: 'Hide Others',
+				label: i18n.translate( 'Hide Others', { context: 'Desktop App Window Action' } ),
 				accelerator: 'Command+Shift+H',
 				role: 'hideothers'
 			},
 			{
-				label: 'Show All',
+				label: i18n.translate( 'Show All', { context: 'Desktop App Window Action' } ),
 				role: 'unhide'
 			},
 			{

--- a/desktop/lib/menu/calypso-menu.js
+++ b/desktop/lib/menu/calypso-menu.js
@@ -4,13 +4,14 @@
  * Internal dependencies
  */
 const ipc = require( 'lib/calypso-commands' );
+const i18n = require( 'lib/i18n' );
 
 module.exports = function( mainWindow, status ) {
 	status = status === 'enabled' ? true : false;
 
 	return [
 		{
-			label: 'My Sites',
+			label: i18n.translate( 'My Sites' ),
 			requiresUser: true,
 			enabled: status,
 			accelerator: 'CmdOrCtrl+1',
@@ -20,7 +21,7 @@ module.exports = function( mainWindow, status ) {
 			}
 		},
 		{
-			label: 'Reader',
+			label: i18n.translate( 'Reader' ),
 			requiresUser: true,
 			enabled: status,
 			accelerator: 'CmdOrCtrl+2',
@@ -30,7 +31,7 @@ module.exports = function( mainWindow, status ) {
 			}
 		},
 		{
-			label: 'My Profile',
+			label: i18n.translate( 'My Profile' ),
 			requiresUser: true,
 			enabled: status,
 			accelerator: 'CmdOrCtrl+3',
@@ -40,7 +41,7 @@ module.exports = function( mainWindow, status ) {
 			}
 		},
 		{
-			label: 'Notifications',
+			label: i18n.translate( 'Notifications' ),
 			requiresUser: true,
 			enabled: status,
 			accelerator: 'CmdOrCtrl+4',
@@ -50,7 +51,7 @@ module.exports = function( mainWindow, status ) {
 			}
 		},
 		{
-			label: 'New Post',
+			label: i18n.translate( 'New Post' ),
 			requiresUser: true,
 			enabled: status,
 			accelerator: 'CmdOrCtrl+N',

--- a/desktop/lib/menu/debug-menu.js
+++ b/desktop/lib/menu/debug-menu.js
@@ -5,9 +5,14 @@
  */
 const BrowserWindow = require( 'electron' ).BrowserWindow;
 
+/**
+ * Internal dependencies
+ */
+const i18n = require( 'lib/i18n' );
+
 module.exports = [
 	{
-		label: 'Reload',
+		label: i18n.translate( 'Reload', { context: 'Desktop App Action' } ),
 		accelerator: 'CmdOrCtrl+R',
 		click: function() {
 			const focusedWindow = BrowserWindow.getFocusedWindow();
@@ -18,7 +23,7 @@ module.exports = [
 		}
 	},
 	{
-		label: 'Developer Tools',
+		label: i18n.translate( 'Developer Tools', { context: 'Desktop App Tool' } ),
 		accelerator: 'Alt+CmdOrCtrl+I',
 		click: function() {
 			const focusedWindow = BrowserWindow.getFocusedWindow();

--- a/desktop/lib/menu/edit-menu.js
+++ b/desktop/lib/menu/edit-menu.js
@@ -1,13 +1,18 @@
 'use strict';
 
+/**
+ * Internal dependencies
+ */
+const i18n = require( 'lib/i18n' );
+
 module.exports = [
 	{
-		label: 'Undo',
+		label: i18n.translate( 'Undo', { context: 'Desktop App Action' } ),
 		accelerator: 'CmdOrCtrl+Z',
 		role: 'undo'
 	},
 	{
-		label: 'Redo',
+		label: i18n.translate( 'Redo', { context: 'Desktop App Action' } ),
 		accelerator: 'Shift+CmdOrCtrl+Z',
 		role: 'redo'
 	},
@@ -15,22 +20,22 @@ module.exports = [
 		type: 'separator'
 	},
 	{
-		label: 'Cut',
+		label: i18n.translate( 'Cut', { context: 'Desktop App Action' } ),
 		accelerator: 'CmdOrCtrl+X',
 		role: 'cut'
 	},
 	{
-		label: 'Copy',
+		label: i18n.translate( 'Copy', { context: 'Desktop App Action' } ),
 		accelerator: 'CmdOrCtrl+C',
 		role: 'copy'
 	},
 	{
-		label: 'Paste',
+		label: i18n.translate( 'Paste', { context: 'Desktop App Action' } ),
 		accelerator: 'CmdOrCtrl+V',
 		role: 'paste'
 	},
 	{
-		label: 'Select All',
+		label: i18n.translate( 'Select All', { context: 'Desktop App Action' } ),
 		accelerator: 'CmdOrCtrl+A',
 		role: 'selectall'
 	}

--- a/desktop/lib/menu/help-menu.js
+++ b/desktop/lib/menu/help-menu.js
@@ -11,12 +11,13 @@ const ipc = require( 'lib/calypso-commands' );
  */
 const platform = require( 'lib/platform' );
 const WindowManager = require( 'lib/window-manager' );
+const i18n = require( 'lib/i18n' );
 
 let menuItems = [];
 
 if ( platform.isWindows() || platform.isLinux() ) {
 	menuItems.push( {
-		label: 'About WordPress.com',
+		label: i18n.translate( 'About WordPress.com' ),
 		click: function() {
 			WindowManager.openAbout();
 		}
@@ -28,20 +29,20 @@ if ( platform.isWindows() || platform.isLinux() ) {
 module.exports = function( mainWindow ) {
 	return menuItems.concat( [
 		{
-			label: 'How can we help?',
+			label: i18n.translate( 'How can we help?' ),
 			click: function() {
 				mainWindow.show();
 				ipc.showHelp( mainWindow );
 			}
 		},
 		{
-			label: 'Forums',
+			label: i18n.translate( 'Forums', { context: 'Link to Support Forums' } ),
 			click: function() {
 				shell.openExternal( 'https://forums.wordpress.com/' );
 			}
 		},
 		{
-			label: 'Privacy Policy',
+			label: i18n.translate( 'Privacy Policy' ),
 			click: function() {
 				shell.openExternal( 'https://automattic.com/privacy/' );
 			}

--- a/desktop/lib/menu/main-menu.js
+++ b/desktop/lib/menu/main-menu.js
@@ -9,24 +9,25 @@ const viewMenu = require( './view-menu' );
 const windowMenu = require( './window-menu' );
 const helpMenu = require( './help-menu' );
 const platform = require( 'lib/platform' );
+const i18n = require( 'lib/i18n' );
 
 module.exports = function( app, mainWindow ) {
 	let menu = [
 		{
-			label: platform.isOSX() ? 'WordPress.com' : 'File',
+			label: platform.isOSX() ? 'WordPress.com' : i18n.translate( 'File', { context: 'Desktop App Menu Item' } ),
 			submenu: appMenu( app, mainWindow )
 		},
 		{
-			label: 'Edit',
+			label: i18n.translate( 'Edit', { context: 'Desktop App Menu Item' } ),
 			submenu: editMenu
 		},
 		{
-			label: 'Window',
+			label: i18n.translate( 'Window', { context: 'Desktop App Menu Item' } ),
 			role: 'window',
 			submenu: windowMenu( mainWindow )
 		},
 		{
-			label: 'Help',
+			label: i18n.translate( 'Help', { context: 'Desktop App Menu Item' } ),
 			role: 'help',
 			submenu: helpMenu( mainWindow )
 		}
@@ -35,7 +36,7 @@ module.exports = function( app, mainWindow ) {
 	if ( platform.isOSX() ) {
 		// OS X needs a view menu for 'enter full screen' - insert just after the edit menu
 		menu.splice( 2, 0, {
-			label: 'View',
+			label: i18n.translate( 'View', { context: 'Desktop App Menu Item' } ),
 			submenu: viewMenu
 		} );
 	}

--- a/desktop/lib/menu/view-menu.js
+++ b/desktop/lib/menu/view-menu.js
@@ -7,6 +7,7 @@ const BrowserWindow = require( 'electron' ).BrowserWindow;
  */
 const Config = require( 'lib/config' );
 const debugMenu = require( './debug-menu' );
+const i18n = require( 'lib/i18n' );
 
 /**
  * Module variables
@@ -19,7 +20,7 @@ if ( Config.debug ) {
 
 menuItems.push(
 	{
-		label: 'Toggle Full Screen',
+		label: i18n.translate( 'Toggle Full Screen', { context: 'Desktop App Action' } ),
 		fullscreen: true,
 		click: function() {
 			const focusedWindow = BrowserWindow.getFocusedWindow();

--- a/desktop/lib/menu/window-menu.js
+++ b/desktop/lib/menu/window-menu.js
@@ -5,6 +5,7 @@
  */
 const calypsoMenu = require( './calypso-menu' );
 const platform = require( 'lib/platform' );
+const i18n = require( 'lib/i18n' );
 
 module.exports = function( mainWindow ) {
 	let menu = calypsoMenu( mainWindow ).concat(
@@ -12,12 +13,12 @@ module.exports = function( mainWindow ) {
 			type: 'separator'
 		},
 		{
-			label: 'Minimize',
+			label: i18n.translate( 'Minimize', { context: 'Desktop App Window Action' } ),
 			accelerator: 'CmdOrCtrl+M',
 			role: 'minimize'
 		},
 		{
-			label: 'Close',
+			label: i18n.translate( 'Close', { context: 'Desktop App Window Action' } ),
 			accelerator: 'CmdOrCtrl+W',
 			role: 'close'
 		}
@@ -25,7 +26,7 @@ module.exports = function( mainWindow ) {
 
 	if ( platform.isOSX() ) {
 		menu.push( { type: 'separator' } );
-		menu.push( { label: 'Bring All to Front', role: 'front' } );
+		menu.push( { label: i18n.translate( 'Bring All to Front', { context: 'Desktop App Window Action' } ), role: 'front' } );
 	}
 
 	return menu

--- a/desktop/server/index.js
+++ b/desktop/server/index.js
@@ -8,7 +8,6 @@ const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 const url = require( 'url' );
 const debug = require( 'debug' )( 'desktop:runapp' );
-const startsWith = require( 'lodash/string/startsWith' );
 
 /**
  * Internal dependencies
@@ -21,6 +20,7 @@ const cookieAuth = require( 'lib/cookie-auth' );
 const appInstance = require( 'lib/app-instance' );
 const platform = require( 'lib/platform' );
 const System = require( 'lib/system' );
+const i18n = require( 'lib/i18n' );
 
 /**
  * Module variables
@@ -33,6 +33,9 @@ function showAppWindow() {
 	if ( lastLocation ) {
 		appUrl += lastLocation;
 	}
+
+	debug( 'Initialize i18n' );
+	i18n.init( app.getLocale() );
 
 	debug( 'Loading app (' + appUrl + ') in mainWindow' );
 

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "mkdirp": "^0.5.1",
     "mv": "^2.1.1",
     "unzip": "^0.1.11",
-    "webpack": "^1.12.12",
-    "xgettext-js": "^0.2.2"
+    "webpack": "^1.12.12"
   },
   "dependencies": {
     "debug": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "start": "make run",
     "build": "make build",
-    "test" : "make test"
+    "test": "make test"
   },
   "keywords": [
     "desktop",
@@ -20,7 +20,7 @@
     "wordpress.com"
   ],
   "engines": {
-      "npm": "^3.5.3"
+    "npm": "^3.5.3"
   },
   "optionalDependencies": {
     "appdmg": "^0.3.4"
@@ -44,7 +44,8 @@
     "mkdirp": "^0.5.1",
     "mv": "^2.1.1",
     "unzip": "^0.1.11",
-    "webpack": "^1.12.12"
+    "webpack": "^1.12.12",
+    "xgettext-js": "^0.2.2"
   },
   "dependencies": {
     "debug": "^2.2.0",

--- a/resource/i18n/downloader.js
+++ b/resource/i18n/downloader.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * External Dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+const superagent = require( 'superagent' );
+
+/**
+ * Internal Dependencies
+ */
+const config = require( '../../calypso/server/config' );
+const languages = config( 'languages' );
+const langDirectory = path.resolve( __dirname, '..', '..', 'public_desktop/languages/' );
+
+try {
+	fs.mkdirSync( langDirectory );
+} catch ( e ) {
+	if ( e.code !== 'EEXIST' ) {
+		console.log( '✗ Failed to create directory with error: ' + e.code );
+		throw e;
+	}
+}
+
+languages.forEach( function( language ) {
+	const langSlug = language.langSlug;
+	const url = 'https://widgets.wp.com/languages/calypso/' + langSlug + '.json';
+
+	superagent.get( url ).end( function( error, response ) {
+		console.log( 'Fetched ' + langSlug + ' (' + url + ')' );
+		if ( error || ! response.ok ) {
+			console.log( '✗ request failed; skipping due to error status: ', error.status );
+			return;
+		}
+
+		let langFile = path.join( langDirectory, langSlug + '.json' );
+		try {
+			fs.writeFileSync( langFile, JSON.stringify( response.body ) );
+			console.log( '✓ saved at ' + path.basename( langFile ) );
+		} catch ( e ) {
+			console.log( '✗ failed to write file for ' + langSlug + ' with error: ' + e.code );
+		}
+	} );
+} );

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -41,7 +41,15 @@ module.exports = {
 	],
 	resolve: {
 		extensions: [ '', '.js', '.jsx' ],
-		modulesDirectories: [ 'node_modules', path.join( __dirname, 'calypso', 'server' ), path.join( __dirname, 'calypso', 'client' ), 'desktop' ]
+		modulesDirectories: [
+			'node_modules',
+			// For require/import resolution within Calypso
+			'calypso/server',
+			'calypso/client',
+			// For require/import within Desktop
+			'calypso',
+			'desktop'
+		]
 	},
 	plugins: [
 		// new webpack.optimize.DedupePlugin(),


### PR DESCRIPTION
This PR has a few pieces:
- Script to fetch translation files during build process.
- Load up translation when system locale doesn't match the default (`en`) and we have a translation file available.
- Use Calypso's i18n mixin to translate text in the Menus.
## To Test
- Run `make fetch-translations` to fetch translation files
- Change your system language to something non-English like Spanish
- Run the app using `make run`.
- Since we don't have translations for a lot of things, many things will still show in English. Most of the Calypso shortcuts in the "Window" menu item. should be translated at least.
- Make sure the client itself matches your Calypso setting.

Then:
- Switch back to English.
- Run the app again using `make run`.
- Make sure everything is in English.
## Future

Other improvements/TODOs for future PRs:
- Implement translations for other parts of the app like Preferences, etc.
- Pass the local translation data through to the client to avoid the remote request.
- Maybe handle mismatch between system and Calypso language settings.

See #8 
