### PR TITLE
Fix #113 - On login page, redirect to en.support.wordpress.com

### DIFF
--- a/desktop/lib/menu/help-menu.js
+++ b/desktop/lib/menu/help-menu.js
@@ -5,7 +5,6 @@
  */
 const shell = require( 'electron' ).shell;
 const ipc = require( 'lib/calypso-commands' );
-const url = require( 'url' );
 
 /**
  * Internal dependencies

--- a/desktop/lib/menu/help-menu.js
+++ b/desktop/lib/menu/help-menu.js
@@ -12,6 +12,7 @@ const url = require( 'url' );
  */
 const platform = require( 'lib/platform' );
 const WindowManager = require( 'lib/window-manager' );
+const state = require( 'lib/state' );
 
 let menuItems = [];
 
@@ -32,12 +33,11 @@ module.exports = function( mainWindow ) {
 			label: 'How can we help?',
 			click: function() {
 				// on login page - user logged out
-				let parsedURL = url.parse( mainWindow.webContents.getURL() );
-				if ( parsedURL.pathname === '/login' ) {
-					shell.openExternal( 'https://en.support.wordpress.com/' );
-				} else {
+				if ( state.isLoggedIn() ) {
 					mainWindow.show();
 					ipc.showHelp( mainWindow );
+				} else {
+					shell.openExternal( 'https://en.support.wordpress.com/' );
 				}
 			}
 		},

--- a/desktop/lib/menu/help-menu.js
+++ b/desktop/lib/menu/help-menu.js
@@ -5,6 +5,7 @@
  */
 const shell = require( 'electron' ).shell;
 const ipc = require( 'lib/calypso-commands' );
+const url = require( 'url' );
 
 /**
  * Internal dependencies
@@ -30,8 +31,14 @@ module.exports = function( mainWindow ) {
 		{
 			label: 'How can we help?',
 			click: function() {
-				mainWindow.show();
-				ipc.showHelp( mainWindow );
+				// on login page - user logged out
+				let parsedURL = url.parse( mainWindow.webContents.getURL() );
+				if ( parsedURL.pathname === '/login' ) {
+					shell.openExternal( 'https://en.support.wordpress.com/' );
+				} else {
+					mainWindow.show();
+					ipc.showHelp( mainWindow );
+				}
 			}
 		},
 		{

--- a/desktop/lib/state/README.md
+++ b/desktop/lib/state/README.md
@@ -1,0 +1,6 @@
+State
+==========
+
+Provides user state functions, initially for logged in state, but easily
+extended to other cases at they rise
+

--- a/desktop/lib/state/index.js
+++ b/desktop/lib/state/index.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * Module variables
+ */
+
+let state = false;
+
+function State() {
+	this.loggedIn = false;
+}
+
+State.prototype.isLoggedIn = function( ) {
+	return this.loggedIn;
+};
+
+State.prototype.login = function( ) {
+	this.loggedIn = true;
+};
+
+State.prototype.logout = function( ) {
+	this.loggedIn = false;
+};
+
+if ( ! state ) {
+	state = new State();
+}
+
+module.exports = state;

--- a/desktop/window-handlers/login-status/index.js
+++ b/desktop/window-handlers/login-status/index.js
@@ -12,6 +12,7 @@ const app = electron.app;
  */
 const menu = require( 'lib/menu' );
 const platform = require( 'lib/platform' );
+const state = require( 'lib/state' );
 
 module.exports = function( mainWindow ) {
 	menu.set( app, mainWindow );
@@ -20,9 +21,11 @@ module.exports = function( mainWindow ) {
 		if ( loggedIn ) {
 			menu.enableLoggedInItems( app, mainWindow );
 			platform.setDockMenu( true );
+			state.login();
 		} else {
 			menu.disableLoggedInItems( app, mainWindow );
 			platform.setDockMenu( false );
+			state.logout();
 		}
 	} );
 }


### PR DESCRIPTION
The new help page within Calypso requires a user to be logged in, which
is obviously not the case when on the /login page. Adds check in Help
Menu if on /login to redirect to external support page.