### PR TITLE
Fix #33 - Add Context Menu on Right Click

### DIFF
--- a/desktop/env.js
+++ b/desktop/env.js
@@ -13,6 +13,8 @@ const dialog = require( 'electron' ).dialog;
  */
 const config = require( './lib/config' );
 const Settings = require( './lib/settings' );
+const EditorContextMenu = require( './lib/menu/editor-context-menu' );
+const GeneralContextMenu = require( './lib/menu/general-context-menu' );
 
 /**
  * Module variables
@@ -83,5 +85,8 @@ debug( '========================================================================
 // Define a global 'desktop' variable that can be used in browser windows to access config and settings
 global.desktop = {
 	config: config,
-	settings: Settings
+	settings: Settings,
+	editorContextMenu: EditorContextMenu,
+	generalContextMenu: GeneralContextMenu
 };
+

--- a/desktop/lib/menu/editor-context-menu.js
+++ b/desktop/lib/menu/editor-context-menu.js
@@ -34,11 +34,6 @@ var DEFAULT_MAIN_TPL = [{
   label: 'Paste',
   role: 'paste'
 }, {
-  label: 'Paste and Match Style',
-  click: function() {
-    BrowserWindow.getFocusedWindow().webContents.pasteAndMatchStyle();
-  }
-}, {
   label: 'Select All',
   role: 'selectall'
 }];
@@ -71,6 +66,7 @@ function getTemplate(val, defaultVal) {
     return cloneDeep(defaultVal);
   }
 }
+
 
 /**
  * Builds a context menu suitable for showing in a text editor.

--- a/desktop/lib/menu/editor-context-menu.js
+++ b/desktop/lib/menu/editor-context-menu.js
@@ -8,10 +8,10 @@
 
 var noop = function(){};
 var defaults = require('lodash.defaults');
-var isEmpty = require('lodash.isEmpty');
-var isFunction = require('lodash.isFunction');
-var isArray = require('lodash.isArray');
-var cloneDeep = require('lodash.cloneDeep');
+var isEmpty = require('lodash.isempty');
+var isFunction = require('lodash.isfunction');
+var isArray = require('lodash.isarray');
+var cloneDeep = require('lodash.clonedeep');
 var BrowserWindow = require('electron').BrowserWindow;
 var Menu = require('electron').Menu;
 

--- a/desktop/lib/menu/editor-context-menu.js
+++ b/desktop/lib/menu/editor-context-menu.js
@@ -9,8 +9,6 @@
 var noop = function(){};
 var defaults = require('lodash.defaults');
 var isEmpty = require('lodash.isempty');
-var isFunction = require('lodash.isfunction');
-var isArray = require('lodash.isarray');
 var cloneDeep = require('lodash.clonedeep');
 var BrowserWindow = require('electron').BrowserWindow;
 var Menu = require('electron').Menu;
@@ -48,27 +46,6 @@ var DEFAULT_SUGGESTIONS_TPL = [
 ];
 
 /**
- * if passed a function, invoke it and pass a clone of the default (for safe mutations)
- * if passed an array, use as is
- * otherwise, just return a clone of the default
- * @param val {*}
- * @param defaultVal {Array}
- * @returns {Array}
- */
-function getTemplate(val, defaultVal) {
-  if(isFunction(val)) {
-    return val(cloneDeep(defaultVal));
-  }
-  else if(isArray(val)) {
-    return val;
-  }
-  else {
-    return cloneDeep(defaultVal);
-  }
-}
-
-
-/**
  * Builds a context menu suitable for showing in a text editor.
  *
  * @param {Object=} selection - An object describing the current text selection.
@@ -84,15 +61,15 @@ function getTemplate(val, defaultVal) {
  *    Receives the default suggestions template as a parameter. Should return a template.
  * @return {Menu}
  */
-var buildEditorContextMenu = function(selection, mainTemplate, suggestionsTemplate) {
+var buildEditorContextMenu = function(selection) {
 
   selection = defaults({}, selection, {
     isMisspelled: false,
     spellingSuggestions: []
   });
 
-  var template = getTemplate(mainTemplate, DEFAULT_MAIN_TPL);
-  var suggestionsTpl = getTemplate(suggestionsTemplate, DEFAULT_SUGGESTIONS_TPL);
+  var template = cloneDeep(DEFAULT_MAIN_TPL);
+  var suggestionsTpl = cloneDeep(DEFAULT_SUGGESTIONS_TPL);
 
   if (selection.isMisspelled) {
     var suggestions = selection.spellingSuggestions;

--- a/desktop/lib/menu/editor-context-menu.js
+++ b/desktop/lib/menu/editor-context-menu.js
@@ -1,0 +1,122 @@
+
+/**
+ * Original library:
+ * Author: Jeff Wear, Mixmax, Inc
+ * License: MIT
+ * From: https://github.com/mixmaxhq/electron-editor-context-menu
+ */
+
+var noop = function(){};
+var defaults = require('lodash.defaults');
+var isEmpty = require('lodash.isEmpty');
+var isFunction = require('lodash.isFunction');
+var isArray = require('lodash.isArray');
+var cloneDeep = require('lodash.cloneDeep');
+var BrowserWindow = require('electron').BrowserWindow;
+var Menu = require('electron').Menu;
+
+
+var DEFAULT_MAIN_TPL = [{
+  label: 'Undo',
+  role: 'undo'
+}, {
+  label: 'Redo',
+  role: 'redo'
+}, {
+  type: 'separator'
+}, {
+  label: 'Cut',
+  role: 'cut'
+}, {
+  label: 'Copy',
+  role: 'copy'
+}, {
+  label: 'Paste',
+  role: 'paste'
+}, {
+  label: 'Paste and Match Style',
+  click: function() {
+    BrowserWindow.getFocusedWindow().webContents.pasteAndMatchStyle();
+  }
+}, {
+  label: 'Select All',
+  role: 'selectall'
+}];
+
+var DEFAULT_SUGGESTIONS_TPL = [
+  {
+    label: 'No suggestions',
+    click: noop
+  }, {
+    type: 'separator'
+  }
+];
+
+/**
+ * if passed a function, invoke it and pass a clone of the default (for safe mutations)
+ * if passed an array, use as is
+ * otherwise, just return a clone of the default
+ * @param val {*}
+ * @param defaultVal {Array}
+ * @returns {Array}
+ */
+function getTemplate(val, defaultVal) {
+  if(isFunction(val)) {
+    return val(cloneDeep(defaultVal));
+  }
+  else if(isArray(val)) {
+    return val;
+  }
+  else {
+    return cloneDeep(defaultVal);
+  }
+}
+
+/**
+ * Builds a context menu suitable for showing in a text editor.
+ *
+ * @param {Object=} selection - An object describing the current text selection.
+ *   @property {Boolean=false} isMisspelled - `true` if the selection is
+ *     misspelled, `false` if it is spelled correctly or is not text.
+ *   @property {Array<String>=[]} spellingSuggestions - An array of suggestions
+ *     to show to correct the misspelling. Ignored if `isMisspelled` is `false`.
+ * @param {Function|Array} mainTemplate - Optional. If it's an array, use as is.
+ *    If it's a function, used to customize the template of always-present menu items.
+ *    Receives the default template as a parameter. Should return a template.
+ * @param {Function|Array} suggestionsTemplate - Optional. If it's an array, use as is.
+ *    If it's a function, used to customize the template of spelling suggestion items.
+ *    Receives the default suggestions template as a parameter. Should return a template.
+ * @return {Menu}
+ */
+var buildEditorContextMenu = function(selection, mainTemplate, suggestionsTemplate) {
+
+  selection = defaults({}, selection, {
+    isMisspelled: false,
+    spellingSuggestions: []
+  });
+
+  var template = getTemplate(mainTemplate, DEFAULT_MAIN_TPL);
+  var suggestionsTpl = getTemplate(suggestionsTemplate, DEFAULT_SUGGESTIONS_TPL);
+
+  if (selection.isMisspelled) {
+    var suggestions = selection.spellingSuggestions;
+    if (isEmpty(suggestions)) {
+      template.unshift.apply(template, suggestionsTpl);
+    } else {
+      template.unshift.apply(template, suggestions.map(function(suggestion) {
+        return {
+          label: suggestion,
+          click: function() {
+            BrowserWindow.getFocusedWindow().webContents.replaceMisspelling(suggestion);
+          }
+        };
+      }).concat({
+        type: 'separator'
+      }));
+    }
+  }
+
+  return Menu.buildFromTemplate(template);
+};
+
+module.exports = buildEditorContextMenu;

--- a/desktop/lib/menu/editor-context-menu.js
+++ b/desktop/lib/menu/editor-context-menu.js
@@ -13,23 +13,23 @@ var Menu = require('electron').Menu;
 var platform = require( '../platform' );
 
 var DEFAULT_MAIN_MENU = [{
-  label: 'Cut',
-  role: 'cut'
+	label: 'Cut',
+	role: 'cut'
 }, {
-  label: 'Copy',
-  role: 'copy'
+	label: 'Copy',
+	role: 'copy'
 }, {
-  label: 'Paste',
-  role: 'paste'
+	label: 'Paste',
+	role: 'paste'
 }, {
-  label: 'Select All',
-  role: 'selectall'
+	label: 'Select All',
+	role: 'selectall'
 }];
 
 var NO_SUGGESTIONS_ITEM = [{
-    label: 'No suggestions',
-    click: noop
-  }, { type: 'separator' } ];
+	label: 'No suggestions',
+	click: noop
+}, { type: 'separator' } ];
 
 var DEFINE_MENU_ITEM = [{
 	label: 'Define',
@@ -74,7 +74,7 @@ var buildEditorContextMenu = function(selection) {
 			} ).concat( {
 			  type: 'separator'
 			} ) );
-	  }
+		}
 	} else { // not misspelled, include define menu item
 		if ( platform.isOSX() ) {
 			contextMenu.unshift.apply(contextMenu, DEFINE_MENU_ITEM);

--- a/desktop/lib/menu/editor-context-menu.js
+++ b/desktop/lib/menu/editor-context-menu.js
@@ -10,9 +10,9 @@ var noop = function(){};
 var cloneDeep = require('lodash.clonedeep');
 var BrowserWindow = require('electron').BrowserWindow;
 var Menu = require('electron').Menu;
+var platform = require( '../platform' );
 
-
-var DEFAULT_MAIN_TPL = [{
+var DEFAULT_MAIN_MENU = [{
   label: 'Cut',
   role: 'cut'
 }, {
@@ -26,18 +26,26 @@ var DEFAULT_MAIN_TPL = [{
   role: 'selectall'
 }];
 
-var DEFAULT_SUGGESTIONS_TPL = [
-  {
+var NO_SUGGESTIONS_ITEM = [{
     label: 'No suggestions',
     click: noop
-  }, {
-    type: 'separator'
-  }
-];
+  }, { type: 'separator' } ];
+
+var DEFINE_MENU_ITEM = [{
+	label: 'Define',
+	click: defineTerm,
+	selectable: true,
+	enabled: true
+}, { type: 'separator' } ];
+
+// define term is OSX only
+function defineTerm() {
+	var win = BrowserWindow.getFocusedWindow();
+	win.showDefinitionForSelection();
+}
 
 /**
  * Builds a context menu suitable for showing in a text editor.
- * select
  * @return {Menu}
  */
 var buildEditorContextMenu = function(selection) {
@@ -49,28 +57,31 @@ var buildEditorContextMenu = function(selection) {
 		}
 	}
 
-  var template = cloneDeep(DEFAULT_MAIN_TPL);
-  var suggestionsTpl = cloneDeep(DEFAULT_SUGGESTIONS_TPL);
+	var contextMenu = cloneDeep(DEFAULT_MAIN_MENU);
 
-  if (selection.isMisspelled) {
-    var suggestions = selection.spellingSuggestions;
-    if ( suggestions.length == 0 ) {
-      template.unshift.apply(template, suggestionsTpl);
-    } else {
-      template.unshift.apply(template, suggestions.map(function(suggestion) {
-        return {
-          label: suggestion,
-          click: function() {
-            BrowserWindow.getFocusedWindow().webContents.replaceMisspelling(suggestion);
-          }
-        };
-      }).concat({
-        type: 'separator'
-      }));
-    }
-  }
+	if (selection.isMisspelled) {
+		var suggestions = selection.spellingSuggestions;
+		if ( suggestions.length == 0 ) {
+			contextMenu.unshift.apply(contextMenu, NO_SUGGESTIONS_ITEM);
+		} else {
+			contextMenu.unshift.apply(contextMenu, suggestions.map( function( suggestion ) {
+				return {
+					label: suggestion,
+					click: function() {
+						BrowserWindow.getFocusedWindow().webContents.replaceMisspelling(suggestion);
+					}
+				};
+			} ).concat( {
+			  type: 'separator'
+			} ) );
+	  }
+	} else { // not misspelled, include define menu item
+		if ( platform.isOSX() ) {
+			contextMenu.unshift.apply(contextMenu, DEFINE_MENU_ITEM);
+		}
+	}
 
-  return Menu.buildFromTemplate(template);
+	return Menu.buildFromTemplate(contextMenu);
 };
 
 module.exports = buildEditorContextMenu;

--- a/desktop/lib/menu/editor-context-menu.js
+++ b/desktop/lib/menu/editor-context-menu.js
@@ -8,7 +8,6 @@
 
 var noop = function(){};
 var defaults = require('lodash.defaults');
-var isEmpty = require('lodash.isempty');
 var cloneDeep = require('lodash.clonedeep');
 var BrowserWindow = require('electron').BrowserWindow;
 var Menu = require('electron').Menu;
@@ -73,7 +72,7 @@ var buildEditorContextMenu = function(selection) {
 
   if (selection.isMisspelled) {
     var suggestions = selection.spellingSuggestions;
-    if (isEmpty(suggestions)) {
+    if ( suggestions.length == 0 ) {
       template.unshift.apply(template, suggestionsTpl);
     } else {
       template.unshift.apply(template, suggestions.map(function(suggestion) {

--- a/desktop/lib/menu/editor-context-menu.js
+++ b/desktop/lib/menu/editor-context-menu.js
@@ -7,7 +7,6 @@
  */
 
 var noop = function(){};
-var defaults = require('lodash.defaults');
 var cloneDeep = require('lodash.clonedeep');
 var BrowserWindow = require('electron').BrowserWindow;
 var Menu = require('electron').Menu;
@@ -46,26 +45,17 @@ var DEFAULT_SUGGESTIONS_TPL = [
 
 /**
  * Builds a context menu suitable for showing in a text editor.
- *
- * @param {Object=} selection - An object describing the current text selection.
- *   @property {Boolean=false} isMisspelled - `true` if the selection is
- *     misspelled, `false` if it is spelled correctly or is not text.
- *   @property {Array<String>=[]} spellingSuggestions - An array of suggestions
- *     to show to correct the misspelling. Ignored if `isMisspelled` is `false`.
- * @param {Function|Array} mainTemplate - Optional. If it's an array, use as is.
- *    If it's a function, used to customize the template of always-present menu items.
- *    Receives the default template as a parameter. Should return a template.
- * @param {Function|Array} suggestionsTemplate - Optional. If it's an array, use as is.
- *    If it's a function, used to customize the template of spelling suggestion items.
- *    Receives the default suggestions template as a parameter. Should return a template.
+ * select
  * @return {Menu}
  */
 var buildEditorContextMenu = function(selection) {
 
-  selection = defaults({}, selection, {
-    isMisspelled: false,
-    spellingSuggestions: []
-  });
+	if ( typeof selection === 'undefined' ) {
+		selection = {
+			isMisspelled: false,
+			spellingSuggestions: []
+		}
+	}
 
   var template = cloneDeep(DEFAULT_MAIN_TPL);
   var suggestionsTpl = cloneDeep(DEFAULT_SUGGESTIONS_TPL);

--- a/desktop/lib/menu/editor-context-menu.js
+++ b/desktop/lib/menu/editor-context-menu.js
@@ -13,14 +13,6 @@ var Menu = require('electron').Menu;
 
 
 var DEFAULT_MAIN_TPL = [{
-  label: 'Undo',
-  role: 'undo'
-}, {
-  label: 'Redo',
-  role: 'redo'
-}, {
-  type: 'separator'
-}, {
   label: 'Cut',
   role: 'cut'
 }, {

--- a/desktop/lib/menu/general-context-menu.js
+++ b/desktop/lib/menu/general-context-menu.js
@@ -5,7 +5,7 @@
 
 var Menu = require( 'electron' ).Menu;
 var cloneDeep = require('lodash.clonedeep');
-var BrowserWindow = require('browser-window');
+var BrowserWindow = require('electron').BrowserWindow;
 var platform = require( '../platform' );
 
 // selectable attribute determines if menu item

--- a/desktop/lib/menu/general-context-menu.js
+++ b/desktop/lib/menu/general-context-menu.js
@@ -1,0 +1,16 @@
+/**
+ * General Context Menu
+ * Showed when not in a textarea or editor
+ */
+
+var Menu = require( 'electron' ).Menu;
+
+var DEFAULT_MAIN_TPL = [{
+	label: 'Copy',
+	role: 'copy'
+}];
+
+module.exports = function( selection ) {
+	return Menu.buildFromTemplate( DEFAULT_MAIN_TPL );
+};
+

--- a/desktop/lib/menu/general-context-menu.js
+++ b/desktop/lib/menu/general-context-menu.js
@@ -4,7 +4,7 @@
  */
 
 var Menu = require( 'electron' ).Menu;
-var cloneDeep = require('lodash.cloneDeep');
+var cloneDeep = require('lodash.clonedeep');
 var BrowserWindow = require('browser-window');
 var platform = require( '../platform' );
 

--- a/desktop/lib/menu/general-context-menu.js
+++ b/desktop/lib/menu/general-context-menu.js
@@ -50,7 +50,7 @@ function defineTerm() {
 
 module.exports = function( selectedText ) {
 	var template = {};
-	if ( platform.isOSX() && false ) {
+	if ( platform.isOSX() ) {
 		template = cloneDeep(DEFAULT_OSX_TPL);
 	} else {
 		template = cloneDeep(DEFAULT_MAIN_TPL);

--- a/desktop/lib/menu/general-context-menu.js
+++ b/desktop/lib/menu/general-context-menu.js
@@ -7,10 +7,15 @@ var Menu = require( 'electron' ).Menu;
 
 var DEFAULT_MAIN_TPL = [{
 	label: 'Copy',
-	role: 'copy'
+	role: 'copy',
+	enabled: true
+},{
+	label: 'Minimize',
+	role: 'minimize'
 }];
 
 module.exports = function( selection ) {
+
 	return Menu.buildFromTemplate( DEFAULT_MAIN_TPL );
 };
 

--- a/desktop/lib/menu/general-context-menu.js
+++ b/desktop/lib/menu/general-context-menu.js
@@ -4,18 +4,44 @@
  */
 
 var Menu = require( 'electron' ).Menu;
+var cloneDeep = require('lodash.cloneDeep');
+var BrowserWindow = require('browser-window');
 
+// selectable attribute determines if menu item
+// should only be enabled when text is selected
 var DEFAULT_MAIN_TPL = [{
 	label: 'Copy',
 	role: 'copy',
+	selectable: true,
 	enabled: true
+},{
+	label: 'Define',
+	click: defineTerm,
+	selectable: true,
+	enabled: true
+},{
+	type: 'separator'
 },{
 	label: 'Minimize',
 	role: 'minimize'
 }];
 
-module.exports = function( selection ) {
+function defineTerm() {
+	var win = BrowserWindow.getFocusedWindow();
+	win.showDefinitionForSelection();
+}
 
-	return Menu.buildFromTemplate( DEFAULT_MAIN_TPL );
+module.exports = function( selectedText ) {
+	var template = cloneDeep(DEFAULT_MAIN_TPL);
+
+	template.map( function( item ) {
+		if ( ! selectedText ) {			// if no text is selected
+			if ( item.selectable ) {	// and item is selectable
+				item.enabled = false;	// disable menu item
+			}
+		}
+	});
+
+	return Menu.buildFromTemplate( template );
 };
 

--- a/desktop/lib/menu/general-context-menu.js
+++ b/desktop/lib/menu/general-context-menu.js
@@ -6,10 +6,27 @@
 var Menu = require( 'electron' ).Menu;
 var cloneDeep = require('lodash.cloneDeep');
 var BrowserWindow = require('browser-window');
+var platform = require( '../platform' );
 
 // selectable attribute determines if menu item
 // should only be enabled when text is selected
 var DEFAULT_MAIN_TPL = [{
+	label: 'Copy',
+	role: 'copy',
+	selectable: true,
+	enabled: true
+},{
+	type: 'separator'
+},{
+	label: 'Minimize',
+	role: 'minimize'
+}];
+
+
+// OS X Menu
+// selectable attribute determines if menu item
+// should only be enabled when text is selected
+var DEFAULT_OSX_TPL = [{
 	label: 'Copy',
 	role: 'copy',
 	selectable: true,
@@ -32,7 +49,12 @@ function defineTerm() {
 }
 
 module.exports = function( selectedText ) {
-	var template = cloneDeep(DEFAULT_MAIN_TPL);
+	var template = {};
+	if ( platform.isOSX() && false ) {
+		template = cloneDeep(DEFAULT_OSX_TPL);
+	} else {
+		template = cloneDeep(DEFAULT_MAIN_TPL);
+	}
 
 	template.map( function( item ) {
 		if ( ! selectedText ) {			// if no text is selected

--- a/desktop/server/index.js
+++ b/desktop/server/index.js
@@ -44,6 +44,12 @@ function showAppWindow() {
 
 	mainWindow.webContents.on( 'did-finish-load', function() {
 		mainWindow.webContents.send( 'app-config', Config, Settings.isDebug(), System.getDetails() );
+
+		const ipc = electron.ipcMain;
+		ipc.on( 'mce-context-menu', function( ev ) {
+			mainWindow.send( 'mce-context-menu', ev );
+		});
+
 	} );
 
 	mainWindow.loadURL( appUrl );

--- a/desktop/server/index.js
+++ b/desktop/server/index.js
@@ -46,8 +46,8 @@ function showAppWindow() {
 		mainWindow.webContents.send( 'app-config', Config, Settings.isDebug(), System.getDetails() );
 
 		const ipc = electron.ipcMain;
-		ipc.on( 'mce-context-menu', function( ev ) {
-			mainWindow.send( 'mce-context-menu', ev );
+		ipc.on( 'mce-contextmenu', function( ev ) {
+			mainWindow.send( 'mce-contextmenu', ev );
 		});
 
 	} );

--- a/package.json
+++ b/package.json
@@ -51,7 +51,12 @@
     "electron-editor-context-menu": "^1.1.0",
     "express": "^4.13.3",
     "jade": "^1.11.0",
+    "lodash.clonedeep": "^4.3.0",
     "lodash.debounce": "^4.0.0",
+    "lodash.defaults": "^4.0.1",
+    "lodash.isarray": "^4.0.0",
+    "lodash.isempty": "^4.1.2",
+    "lodash.isfunction": "^3.0.8",
     "portscanner": "^1.0.0",
     "spellchecker": "^3.1.3",
     "superagent": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
+    "electron-editor-context-menu": "^1.1.0",
     "express": "^4.13.3",
     "jade": "^1.11.0",
     "lodash.debounce": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "electron-editor-context-menu": "^1.1.0",
     "express": "^4.13.3",
     "jade": "^1.11.0",
     "lodash.clonedeep": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "lodash.clonedeep": "^4.3.0",
     "lodash.debounce": "^4.0.0",
     "lodash.defaults": "^4.0.1",
-    "lodash.isempty": "^4.1.2",
     "portscanner": "^1.0.0",
     "spellchecker": "^3.1.3",
     "superagent": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -53,9 +53,7 @@
     "lodash.clonedeep": "^4.3.0",
     "lodash.debounce": "^4.0.0",
     "lodash.defaults": "^4.0.1",
-    "lodash.isarray": "^4.0.0",
     "lodash.isempty": "^4.1.2",
-    "lodash.isfunction": "^3.0.8",
     "portscanner": "^1.0.0",
     "spellchecker": "^3.1.3",
     "superagent": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "jade": "^1.11.0",
     "lodash.clonedeep": "^4.3.0",
     "lodash.debounce": "^4.0.0",
-    "lodash.defaults": "^4.0.1",
     "portscanner": "^1.0.0",
     "spellchecker": "^3.1.3",
     "superagent": "^1.4.0"

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -90,21 +90,21 @@ function startDesktopApp() {
 		}
 	}
 	
-	var remote = require( 'electron' ).remote;
-	var buildEditorContextMenu = remote.require('electron-editor-context-menu' );
+	var buildEditorContextMenu = electron.remote.require( '../desktop/lib/menu/editor-context-menu' );
 	function contextMenu( ev ) {
-		if ( ! ev.target.closest( 'textarea, input, [contenteditable="true"]' ) ) {
-			return;
+		var menu = {};
+		if ( ev.target.closest( 'textarea, input, [contenteditable="true"]' ) ) {
+			menu = buildEditorContextMenu();
 		} else {
 			console.log( "Target: " + ev.target.closest );
+			return;
 		}
 
-		var menu = buildEditorContextMenu();
 		// The 'contextmenu' event is emitted after 'selectionchange' has fired but possibly before the 
 		// visible selection has changed. Try to wait to show the menu until after that, otherwise the 
 		// visible selection will update after the menu dismisses and look weird. 
 		setTimeout(function() {
-			menu.popup(remote.getCurrentWindow());
+			menu.popup(electron.remote.getCurrentWindow());
 		}, 30);
 	}
 

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -113,9 +113,9 @@ function startDesktopApp() {
 			menu = buildGeneralContextMenu(selectedText);
 		}
 
-		// The 'contextmenu' event is emitted after 'selectionchange' has fired but possibly before the 
-		// visible selection has changed. Try to wait to show the menu until after that, otherwise the 
-		// visible selection will update after the menu dismisses and look weird. 
+		// The 'contextmenu' event is emitted after 'selectionchange' has fired but possibly before the
+		// visible selection has changed. Try to wait to show the menu until after that, otherwise the
+		// visible selection will update after the menu dismisses and look weird.
 		setTimeout(function() {
 			menu.popup(electron.remote.getCurrentWindow());
 		}, 30);
@@ -131,7 +131,7 @@ function startDesktopApp() {
 
 	debug = gGebug( 'desktop:browser' );
 
-	
+
 	debug( 'Setting up Context Menus' );
 	try {
 		var buildEditorContextMenu = electron.remote.require( '../desktop/lib/menu/editor-context-menu' );
@@ -232,7 +232,7 @@ try {
 
 	ipc.on( 'is-calypso', function() {
 		ipc.send( 'is-calypso-response', document.getElementById( 'wpcom' ) !== null );
-		
+
 	} );
 
 
@@ -244,19 +244,19 @@ try {
 
 				var container = document.querySelector( '#wpcom' );
 				var pinApp = container.querySelector( '.pin-app' );
-		
+
 				if ( ! pinApp ) {
 					var node = document.createElement( 'div' );
 					node.className = 'pin-app';
 					container.appendChild( node );
 					pinApp = container.querySelector( '.pin-app' );
 				}
-	
+
 				var closeButton = '<a href="#" class="pin-app-close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M17.705,7.705l-1.41-1.41L12,10.59L7.705,6.295l-1.41,1.41L10.59,12l-4.295,4.295l1.41,1.41L12,13.41 l4.295,4.295l1.41-1.41L13.41,12L17.705,7.705z"/></svg></a>';
 				var pinAppMsg = "";
-	
+
 				if ( details.platform === "windows" ) {
-					pinAppMsg = "<h2>Keep WordPress.com in your taskbar</h2>" + 
+					pinAppMsg = "<h2>Keep WordPress.com in your taskbar</h2>" +
 					"<p>Drag the icon from your desktop to your taskbar</p>" +
 					'<img src="/desktop/pin-app-taskbar.png" alt="" width="143" height="27" />';
 				} else if ( details.platform === "darwin" && !details.pinned ) {
@@ -266,7 +266,7 @@ try {
 				}
 
 				pinApp.innerHTML = closeButton + pinAppMsg;
-	
+
 				// close button
 				var pinAppClose = container.querySelector( '.pin-app-close' );
 				pinAppClose.onclick = function () {

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -162,7 +162,7 @@ function startDesktopApp() {
 
 			// listen for tinymce IPC event for context menu
 			// required for visual editor since within iframe
-			ipc.on( 'mce-context-menu', contextMenu );
+			ipc.on( 'mce-contextmenu', contextMenu );
 		}
 	}
 

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -91,13 +91,13 @@ function startDesktopApp() {
 	}
 	
 	var buildEditorContextMenu = electron.remote.require( '../desktop/lib/menu/editor-context-menu' );
+	var buildGeneralContextMenu = electron.remote.require( '../desktop/lib/menu/general-context-menu' );
 	function contextMenu( ev ) {
 		var menu = {};
 		if ( ev.target.closest( 'textarea, input, [contenteditable="true"]' ) ) {
 			menu = buildEditorContextMenu();
 		} else {
-			console.log( "Target: " + ev.target.closest );
-			return;
+			menu = buildGeneralContextMenu();
 		}
 
 		// The 'contextmenu' event is emitted after 'selectionchange' has fired but possibly before the 

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -134,8 +134,8 @@ function startDesktopApp() {
 
 	debug( 'Setting up Context Menus' );
 	try {
-		var buildEditorContextMenu = electron.remote.require( '../desktop/lib/menu/editor-context-menu' );
-		var buildGeneralContextMenu = electron.remote.require( '../desktop/lib/menu/general-context-menu' );
+		var buildEditorContextMenu = desktop.editorContextMenu;
+		var buildGeneralContextMenu = desktop.generalContextMenu;
 	} catch (e) {
 		debug( "Error loading context menus", e.message);
 		loadContextMenu = false;

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -92,15 +92,6 @@ function startDesktopApp() {
 		}
 	}
 
-	debug = gGebug( 'desktop:browser' );
-
-	try {
-		var buildEditorContextMenu = electron.remote.require( '../desktop/lib/menu/editor-context-menu' );
-		var buildGeneralContextMenu = electron.remote.require( '../desktop/lib/menu/general-context-menu' );
-	} catch (e) {
-		debug( "Error loading context menus", e.message);
-		loadContextMenu = false;
-	}
 	function contextMenu( ev ) {
 		var menu = {};
 		if ( ev.target.closest( 'textarea, input, [contenteditable="true"]' ) ) {
@@ -123,6 +114,19 @@ function startDesktopApp() {
 			isMisspelled: false,
 			spellingSuggestions: []
 		};
+	}
+
+
+	debug = gGebug( 'desktop:browser' );
+
+	
+	debug( 'Setting up Context Menus' );
+	try {
+		var buildEditorContextMenu = electron.remote.require( '../desktop/lib/menu/editor-context-menu' );
+		var buildGeneralContextMenu = electron.remote.require( '../desktop/lib/menu/general-context-menu' );
+	} catch (e) {
+		debug( "Error loading context menus", e.message);
+		loadContextMenu = false;
 	}
 
 	if ( loadContextMenu ) {

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -89,6 +89,24 @@ function startDesktopApp() {
 			ev.preventDefault();
 		}
 	}
+	
+	var remote = require( 'electron' ).remote;
+	var buildEditorContextMenu = remote.require('electron-editor-context-menu' );
+	function contextMenu( ev ) {
+		if ( ! ev.target.closest( 'textarea, input, [contenteditable="true"]' ) ) {
+			return;
+		} else {
+			console.log( "Target: " + ev.target.closest );
+		}
+
+		var menu = buildEditorContextMenu();
+		// The 'contextmenu' event is emitted after 'selectionchange' has fired but possibly before the 
+		// visible selection has changed. Try to wait to show the menu until after that, otherwise the 
+		// visible selection will update after the menu dismisses and look weird. 
+		setTimeout(function() {
+			menu.popup(remote.getCurrentWindow());
+		}, 30);
+	}
 
 	debug = gGebug( 'desktop:browser' );
 
@@ -102,6 +120,7 @@ function startDesktopApp() {
 
 		document.addEventListener( 'keydown', keyboardHandler );
 		document.addEventListener( 'click', preventNewWindow );
+		document.addEventListener( 'contextmenu', contextMenu );
 	}
 
 	// This is called by Calypso

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -109,7 +109,8 @@ function startDesktopApp() {
 		if ( ev.target.closest( 'textarea, input, [contenteditable="true"]' ) ) {
 			menu = buildEditorContextMenu(selection);
 		} else {
-			menu = buildGeneralContextMenu();
+			var selectedText = window.getSelection().toString();
+			menu = buildGeneralContextMenu(selectedText);
 		}
 
 		// The 'contextmenu' event is emitted after 'selectionchange' has fired but possibly before the 

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -93,7 +93,7 @@ function startDesktopApp() {
 	var remote = require( 'electron' ).remote;
 	var buildEditorContextMenu = remote.require('electron-editor-context-menu' );
 	function contextMenu( ev ) {
-		if ( ! ev.target.closest( 'iframe body, textarea, input, [contenteditable="true"]' ) ) {
+		if ( ! ev.target.closest( 'textarea, input, [contenteditable="true"]' ) ) {
 			return;
 		} else {
 			console.log( "Target: " + ev.target.closest );

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -92,7 +92,6 @@ function startDesktopApp() {
 	}
 	
 	function resetSelection() {
-		console.log("Resetting selection...");
 		selection = {
 			isMisspelled: false,
 			spellingSuggestions: []

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -94,9 +94,21 @@ function startDesktopApp() {
 
 	function contextMenu( ev ) {
 		var menu = {};
-		if ( ev.target.closest( 'textarea, input, [contenteditable="true"]' ) ) {
+		var showEditorMenu = false;
+
+		// check if in visual editor, ipc sends an EventEmitter
+		if ( typeof ev.sender !== 'undefined' )  {
+			showEditorMenu = true;
+		}
+		// check if in textarea or similar
+		else if ( ( typeof ev.target !== 'undefined' ) && ev.target.closest( 'textarea, input, [contenteditable="true"]' ) ) {
+			showEditorMenu = true;
+		}
+
+		if ( showEditorMenu ) {
 			menu = buildEditorContextMenu(selection);
-		} else {
+		}
+		else {
 			var selectedText = window.getSelection().toString();
 			menu = buildGeneralContextMenu(selectedText);
 		}
@@ -147,6 +159,10 @@ function startDesktopApp() {
 
 		if ( loadContextMenu )  {
 			document.addEventListener( 'contextmenu', contextMenu );
+
+			// listen for tinymce IPC event for context menu
+			// required for visual editor since within iframe
+			ipc.on( 'mce-context-menu', contextMenu );
 		}
 	}
 
@@ -216,7 +232,9 @@ try {
 
 	ipc.on( 'is-calypso', function() {
 		ipc.send( 'is-calypso-response', document.getElementById( 'wpcom' ) !== null );
+		
 	} );
+
 
 	ipc.on( 'app-config', function( event, config, debug, details ) {
 
@@ -260,7 +278,7 @@ try {
 	} );
 
 } catch ( e ) {
-	debug( 'Failed to initialize calypso', e );
+	debug( 'Failed to initialize calypso', e.message );
 }
 
 startDesktopApp();

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -93,7 +93,7 @@ function startDesktopApp() {
 	var remote = require( 'electron' ).remote;
 	var buildEditorContextMenu = remote.require('electron-editor-context-menu' );
 	function contextMenu( ev ) {
-		if ( ! ev.target.closest( 'textarea, input, [contenteditable="true"]' ) ) {
+		if ( ! ev.target.closest( 'iframe body, textarea, input, [contenteditable="true"]' ) ) {
 			return;
 		} else {
 			console.log( "Target: " + ev.target.closest );


### PR DESCRIPTION
Add a context menu on right click within textareas, primary the Editor.

* Allow for Cut-Copy-Paste on Right Click
* Include Spelling suggestions on right-click 

Related: #101 