### PR TITLE
Preference to disable spell check

### DIFF
--- a/desktop-config/config-base.json
+++ b/desktop-config/config-base.json
@@ -59,6 +59,7 @@
 		"proxy-type": "",
 		"proxy-url": "socks5://localhost",
 		"proxy-port": "8080",
-		"proxy-pac": ""
+		"proxy-pac": "",
+		"spellcheck-enabled": true
 	}
 }

--- a/desktop/app-handlers/preferences/index.js
+++ b/desktop/app-handlers/preferences/index.js
@@ -12,20 +12,26 @@ const dialog = electron.dialog;
  */
 const Settings = require( 'lib/settings' );
 
+function promptForRestart( title, message ) {
+	// Warn user they need to restart the app
+	dialog.showMessageBox( {
+		buttons: [ 'Ok' ],
+		title: title,
+		message: message,
+		detail: 'The app needs to be restarted for this to take effect.'
+	}, function() {} );
+}
+
 module.exports = function() {
-	ipc.on( 'preferences-changed-proxy-type', function() {
-		const proxyOptions = {
-			buttons: [ 'Ok' ],
-			title: 'Proxy changed',
-			message: 'You have changed the proxy settings.',
-			detail: 'The app needs to be restarted for this to take effect.'
-		};
-
-		// Warn user they need to restart the app
-		dialog.showMessageBox( proxyOptions, function() {} );
-	} );
-
 	ipc.on( 'preferences-changed', function( event, arg ) {
-		Settings.saveSetting( arg.name, arg.value );
+		let name = arg.name;
+
+		if ( 'proxy-type' === name ) {
+			promptForRestart( 'Proxy changed', 'You have changed the proxy settings.' );
+		} else if ( 'spellcheck-enabled' === name ) {
+			promptForRestart( ( arg.value ? 'Spellchecker enabled' : 'Spellchecker disabled' ), 'You have changed the spellchecker settings.' );
+		}
+
+		Settings.saveSetting( name, arg.value );
 	} );
 };

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -129,6 +129,11 @@ function startDesktopApp() {
 }
 
 function setupSpellchecker( locale ) {
+	if ( !desktop.settings.getSetting( 'spellcheck-enabled' ) ) {
+		debug( 'Spellchecker not enabled; skipping setup' );
+		return;
+	}
+
 	try {
 		spellchecker = electron.remote.require( 'spellchecker' );
 

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -134,6 +134,11 @@ function setupSpellchecker( locale ) {
 		return;
 	}
 
+	if ( locale.toLowerCase() !== 'en-us' ) {
+		debug( 'Disabling spellcheck, temporary only en-us support' );
+		return;
+	}
+
 	try {
 		spellchecker = electron.remote.require( 'spellchecker' );
 

--- a/public_desktop/preferences.html
+++ b/public_desktop/preferences.html
@@ -81,6 +81,12 @@
 <div class="options">
 	<table class="option-group">
 		<tr class="option-notifications">
+			<td class="option-title"><span>Writing: </span></td>
+			<td><label><input type="checkbox" name="spellcheck-enabled"> Enable spell checking </label></td>
+		</tr>
+	</table>
+	<table class="option-group">
+		<tr class="option-notifications">
 			<td class="option-title"><span>Notifications: </span></td>
 			<td><label><input type="checkbox" name="notification-badge"> Show notification badge </label></td>
 		</tr>
@@ -150,7 +156,6 @@
 		}
 
 		[ 'proxy-url', 'proxy-port', 'proxy-pac' ].forEach( function( item ) {
-			console.log( item );
 			document.querySelector( 'input[name=' + item + ']' ).value = settings.getSetting( item );
 		} );
 


### PR DESCRIPTION
Add a new preference to allow disabling spellcheck.

Currently prompts for a restart since we can't un-spellcheck already spellchecked words so better to start with a clean slate.

Reasons outlined in #101