### PR TITLE
Fix/119 spellcheck

### DIFF
--- a/docs/spellchecker.md
+++ b/docs/spellchecker.md
@@ -1,0 +1,42 @@
+
+# Setting up Spellchecker
+
+The spellchecker used is the [node-spellchecker][1] module which is a native
+module that needs to be built for each platform. It is relatively straight
+forward to build, however requires having a build enviornment setup for each
+platform.
+
+So to simplify this, we zip up the built binaries and upload to the `gh-pages`
+branch which is then downloaded and binds when creating a release package, so
+anyone creating a release doesn't need an enviornment only on major upgrades to
+Electron and/or Spellcheck library.
+
+The build process is to run `npm install`, which should run the
+appropriate `node-gyp` commands and create the build in
+`node_modules/spellchecker/build/Release` directory.
+
+This is what we zip up for each platform and upload the zip to Github.
+
+The binding for each platform should be updated to refer to the new zip,
+[darwin.js][2], [linux.js][3], [win32.js][4]
+
+
+
+## Building on Windows
+
+OS X and Linux are pretty straight forward, since most of the pre-requisites are
+already setup and works.
+
+On Windows, you will need to install Python 2.7.x along with Node and Git, I've
+found the Github shell is easiest to work in. Be sure to include python.exe in
+your PATH.
+
+Additionally, you will need Microsoft Visual C++ tools installed, which I found easiest
+to do installing [Visual Studio 2013 SDK][5] and selecting the libraries in the installer.
+
+
+[1]: https://github.com/atom/node-spellchecker
+[2]: https://github.com/Automattic/wp-desktop/blob/master/resource/platform/darwin.js#L58
+[3]: https://github.com/Automattic/wp-desktop/blob/master/resource/platform/linux.js#L35
+[4]: https://github.com/Automattic/wp-desktop/blob/master/resource/platform/win32.js
+[5]: https://www.microsoft.com/en-US/download/details.aspx?id=44914

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lodash.clonedeep": "^4.3.0",
     "lodash.debounce": "^4.0.0",
     "portscanner": "^1.0.0",
-    "spellchecker": "^3.1.3",
+    "spellchecker": "^3.2.3",
     "superagent": "^1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "electron-mocha": "^0.8.0",
     "electron-packager": "^5.2.1",
     "electron-prebuilt": "0.36.8",
+    "electron-rebuild": "^1.1.3",
     "eslint": "^1.7.2",
     "eslint-plugin-react": "^3.14.0",
     "json-loader": "^0.5.4",

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -183,11 +183,12 @@ function startDesktopApp() {
 // hard code wrongly interpreted words in spellchecker
 // electron has a bug with parsing of contractions
 // Ref: https://github.com/atom/electron/issues/1005
-function skipWords( locale, text ) {
-	// locale == 'en-us' already skipped in setup
-	var words = [ 'ain', 'couldn', 'didn', 'doesn', 'hadn', 'hasn', 'mightn', 'mustn', 'needn', 'oughtn', 'shan', 'shouldn', 'wasn', 'weren', 'wouldn'];
-	if ( text in words ) { return true; }
-	return false;
+var wordsToSpellSkip = {
+	'en-us': ['ain', 'couldn', 'didn', 'doesn', 'hadn', 'hasn', 'mightn', 'mustn', 'needn', 'oughtn', 'shan', 'shouldn', 'wasn', 'weren', 'wouldn']
+};
+
+function shouldNotSpellCheckWord( locale, text ) {
+	return ( wordsToSpellSkip[locale.toLowerCase()].indexOf(text) > 0 );
 }
 
 function setupSpellchecker( locale ) {
@@ -206,7 +207,7 @@ function setupSpellchecker( locale ) {
 
 		webFrame.setSpellCheckProvider( locale, false, {
 			spellCheck: function(text) {
-				if ( skipWords( locale, text ) ) {
+				if ( shouldNotSpellCheckWord( locale, text ) ) {
 					return true;
 				}
 

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -180,6 +180,16 @@ function startDesktopApp() {
 	}
 }
 
+// hard code wrongly interpreted words in spellchecker
+// electron has a bug with parsing of contractions
+// Ref: https://github.com/atom/electron/issues/1005
+function skipWords( locale, text ) {
+	// locale == 'en-us' already skipped in setup
+	var words = [ 'ain', 'couldn', 'didn', 'doesn', 'hadn', 'hasn', 'mightn', 'mustn', 'needn', 'oughtn', 'shan', 'shouldn', 'wasn', 'weren', 'wouldn'];
+	if ( text in words ) { return true; }
+	return false;
+}
+
 function setupSpellchecker( locale ) {
 	if ( !desktop.settings.getSetting( 'spellcheck-enabled' ) ) {
 		debug( 'Spellchecker not enabled; skipping setup' );
@@ -196,6 +206,10 @@ function setupSpellchecker( locale ) {
 
 		webFrame.setSpellCheckProvider( locale, false, {
 			spellCheck: function(text) {
+				if ( skipWords( locale, text ) ) {
+					return true;
+				}
+
 				if ( spellchecker.isMisspelled(text) ) {
 					var suggestions = spellchecker.getCorrectionsForMisspelling(text);
 					selection.isMisspelled = true;

--- a/resource/platform/darwin.js
+++ b/resource/platform/darwin.js
@@ -55,5 +55,5 @@ function cleanBuild( appPath, buildOpts ) {
 
 module.exports = {
 	cleaner: cleanBuild,
-	beforeBuild: spellchecker.bind( null, 'http://automattic.github.io/wp-desktop/deps/spellchecker-darwin-v3.0.2-electron-v0.36.0.zip' )
+	beforeBuild: spellchecker.bind( null, 'http://automattic.github.io/wp-desktop/deps/spellchecker-darwin-v3.2.3-electron-v0.36.8.zip' )
 }

--- a/resource/platform/linux.js
+++ b/resource/platform/linux.js
@@ -32,5 +32,5 @@ function cleanBuild( appPath, buildOpts ) {
 
 module.exports = {
 	cleaner: cleanBuild,
-	beforeBuild: spellchecker.bind( null, 'http://automattic.github.io/wordpress-desktop/deps/spellchecker-linux64-v3.2.3-electron-v0.36.8.zip' )
+	beforeBuild: spellchecker.bind( null, 'http://automattic.github.io/wp-desktop/deps/spellchecker-win32-v3.2.3-electron-v0.36.8.zip' )
 }

--- a/resource/platform/linux.js
+++ b/resource/platform/linux.js
@@ -32,5 +32,5 @@ function cleanBuild( appPath, buildOpts ) {
 
 module.exports = {
 	cleaner: cleanBuild,
-	beforeBuild: spellchecker.bind( null, 'http://automattic.github.io/wordpress-desktop/deps/spellchecker-linux64-v1.0.2-electron-v0.35.4.zip' )
+	beforeBuild: spellchecker.bind( null, 'http://automattic.github.io/wordpress-desktop/deps/spellchecker-linux64-v3.2.3-electron-v0.36.8.zip' )
 }

--- a/resource/platform/win32.js
+++ b/resource/platform/win32.js
@@ -34,5 +34,5 @@ function cleanBuild( appPath, buildOpts ) {
 
 module.exports = {
 	cleaner: function() { /* noop */ }, // cleanBuild,
-	beforeBuild: spellchecker.bind( null, 'http://automattic.github.io/wp-desktop/deps/spellchecker-win32-v3.0.2-electron-v0.36.0.zip' )
+	beforeBuild: spellchecker.bind( null, 'http://automattic.github.io/wp-desktop/deps/spellchecker-win32-v3.2.3-electron-v0.36.8.zip' )
 }


### PR DESCRIPTION
Update spellcheck zips for each platform.
Use skip words to avoid contractions being marked as misspelling
Add build instructions instructions for creating spellcheck native

Note: `make distclean` before running to get the latest spellcheck binary.