### PR TITLE
Update exception handlers

### DIFF
--- a/desktop/app-handlers/exceptions/index.js
+++ b/desktop/app-handlers/exceptions/index.js
@@ -11,6 +11,7 @@ const dialog = electron.dialog;
  * Internal dependencies
  */
 const crashTracker = require( 'lib/crash-tracker' );
+const system = require( 'lib/system' );
 
 /**
  * Module variables
@@ -42,7 +43,9 @@ function showErrorAndExit( error ) {
 		'\n\n' +
 		'If you continue to have issues, please contact us at help@wordpress.com and mention the error details below:' +
 		'\n\n' +
-		error.stack
+		error.stack +
+		'\n\n' +
+		'System info: ' + JSON.stringify( system.getVersionData() )
 	);
 
 	exit();

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -14,7 +14,6 @@ module.exports = function( finished_cb ) {
 	debug( 'Starting app handlers' );
 
 	// Stuff that can run before the main window
-	require( './app-handlers/exceptions' )();
 	require( './app-handlers/crash-reporting' )();
 	require( './app-handlers/updater' )();
 	require( './app-handlers/preferences' )();

--- a/desktop/env.js
+++ b/desktop/env.js
@@ -14,27 +14,16 @@ const dialog = require( 'electron' ).dialog;
 const config = require( './lib/config' );
 const Settings = require( './lib/settings' );
 
+// Catch-all error handler
+// We hook in very early to catch issues during the startup process
+require( './app-handlers/exceptions' )();
+
 /**
  * Module variables
  */
 process.chdir( app.getAppPath() );
 
 process.env.CALYPSO_ENV = config.calypso_config;
-
-// Catch-all error handler
-process.on( 'uncaughtException', function( error ) {
-	console.log( 'uncaughtException', error, error.stack, typeof error );
-	dialog.showErrorBox(
-		'WordPress.com ran into an error',
-		'Please restart the app and try again.' +
-		'\n\n' +
-		'If you continue to have issues, please contact us at help@wordpress.com and mention the error details below:' +
-		'\n\n' +
-		error.stack
-	);
-
-	process.exit( 1 );
-} );
 
 // If debug is enabled then setup the debug target
 if ( Settings.isDebug() ) {

--- a/desktop/lib/crash-tracker/index.js
+++ b/desktop/lib/crash-tracker/index.js
@@ -43,6 +43,10 @@ function gatherData( errorType, errorData ) {
 }
 
 module.exports = {
+	isEnabled: function() {
+		return config.crash_reporter.tracker;
+	},
+
 	track: function( errorType, errorData, cb ) {
 		if ( config.crash_reporter.tracker ) {
 			// Send to crash tracker

--- a/desktop/lib/crash-tracker/index.js
+++ b/desktop/lib/crash-tracker/index.js
@@ -5,7 +5,6 @@
  */
 const electron = require( 'electron' );
 const app = electron.app;
-const os = require( 'os' );
 const request = require( 'superagent' );
 const path = require( 'path' );
 const debug = require( 'debug' )( 'desktop:crash-tracker' );
@@ -14,6 +13,7 @@ const debug = require( 'debug' )( 'desktop:crash-tracker' );
  * Internal dependencies
  */
 const config = require( 'lib/config' );
+const system = require( 'lib/system' );
 
 function finished( error, response, cb ) {
 	if ( error ) {
@@ -29,17 +29,11 @@ function finished( error, response, cb ) {
 
 function gatherData( errorType, errorData ) {
 	// Gather basic data
-	const data = {
-		platform: process.platform,
-		release: os.release(),
-		version: config.version,
-		build: config.build,
+	return Object.assign( {}, system.getVersionData(), {
 		time: parseInt( new Date().getTime() / 1000, 10 ),
 		type: errorType,
 		data: errorData
-	};
-
-	return data;
+	} );
 }
 
 module.exports = {

--- a/desktop/lib/system/index.js
+++ b/desktop/lib/system/index.js
@@ -7,11 +7,12 @@
 const Platform = require( 'lib/platform' );
 const exec = require( 'child_process' ).execSync;
 const debug = require( 'debug' )( 'desktop:system' );
+const os = require( 'os' );
 
 /**
  * Internal dependencies
  */
-
+const config = require( 'lib/config' );
 const SettingsFile = require( 'lib/settings/settings-file' );
 const APPS_DIRECTORY = '/Applications';
 
@@ -53,5 +54,13 @@ module.exports = {
 
 		debug( 'System details: ', details );
 		return details;
+	},
+	getVersionData: function() {
+		return {
+			platform: process.platform,
+			release: os.release(),
+			version: config.version,
+			build: config.build,
+		};
 	}
 };


### PR DESCRIPTION
Two changes:

1) Consolidate multiple exception handlers into one

An exception handler added early in development was more lenient with network errors, which can sometimes happen with updater. A handler added later overrode the existing one and failed on everything.

This combines the two so we handle network errors accordingly and properly fail on others.

We still run the exception handler super early to catch any issues during the bootup process.

2) Include system data in exception error message.

@mkaz can you take a look?