### PR TITLE
Disable spellchecker for Windows

### DIFF
--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -202,7 +202,7 @@ function setupSpellchecker( locale ) {
 		return;
 	}
 
-	if ( process.platform === 'windows' ) {
+	if ( process.platform === 'win32' ) {
 		debug( 'Disabling spellcheck, Windows support not working' );
 		return;
 	}

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -202,6 +202,11 @@ function setupSpellchecker( locale ) {
 		return;
 	}
 
+	if ( process.platform === 'windows' ) {
+		debug( 'Disabling spellcheck, Windows support not working' );
+		return;
+	}
+
 	try {
 		spellchecker = electron.remote.require( 'spellchecker' );
 

--- a/resource/platform/win32.js
+++ b/resource/platform/win32.js
@@ -34,5 +34,5 @@ function cleanBuild( appPath, buildOpts ) {
 
 module.exports = {
 	cleaner: function() { /* noop */ }, // cleanBuild,
-	beforeBuild: spellchecker.bind( null, 'http://automattic.github.io/wp-desktop/deps/spellchecker-win32-v3.2.3-electron-v0.36.8.zip' )
+	//beforeBuild: spellchecker.bind( null, 'http://automattic.github.io/wp-desktop/deps/spellchecker-win32-v3.2.3-electron-v0.36.8.zip' )
 }


### PR DESCRIPTION
The binary bindings is not working on the latest version with Windows

Spellcheck still works in Visual editor (Tinymce) so the feature is not completely lost, but what is lost is the auto underlining of misspelled words in the editor without having to click the spellcheck button.

This PR will disable so the release can still move forward if we can't fix prior