### PR TITLE
Electron: first mouse click on disabled window shouldn't trigger action

### DIFF
--- a/desktop-config/config-base.json
+++ b/desktop-config/config-base.json
@@ -4,7 +4,7 @@
 	"server_host": "127.0.0.1",
 	"debug": false,
 	"mainWindow": {
-		"acceptFirstMouse": true,
+		"acceptFirstMouse": false,
 		"frame": true,
 		"height": 800,
 		"minHeight": 450,


### PR DESCRIPTION
**Can we disable in Electron the triggering of clicks when a window gets focus?**

Note when you switch to an inactive Chrome window: you can click anywhere, even links and active elements, and that doesn't trigger on the first click: the first click always focuses the window _first_. Then one can click.

Instead our app instantly triggers the action underlying. Which means that trying to switch to a partially covered window is an exercise in finding the blank spot (or going to the window top bar).

Electron has a setting for that: `accept-first-mouse`. This PR turns that off on the main window. Just on the main window, since the others are accessory ones, with less controls on screen and more blank space. We can change these too if we feel like standardizing, but just the main window is enough.

#### How to test?

1. Open the main window
2. Put it below another window (not in focus)
3. Try to click on a button or any element that does an action
4. (It shouldn't trigger the action on the first click that puts the window in focus)

/cc @jasmussen 