### PR TITLE
README: add remote flag to submodule update cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ WordPress.com for Desktop is an [Electron](https://github.com/atom/electron) wra
 1. Clone this repository locally
 1. Update the Calypso submodule with:
  - `git submodule init`
- - `git submodule update`
+ - `git submodule update --remote`
 1. Create a `calypso/config/secrets.json` file and fill it with [secrets](docs/secrets.md)
 1. `make run` to build and run the app
 


### PR DESCRIPTION
Without updating the wp-calypso dependency, all I get is a blank screen with a WordPress logo & this in the console:
```
Uncaught ReferenceError: preloadHub is not defined
desktop-app.js:140 Uncaught TypeError: window.AppBoot is not a function
```