### PR TITLE
Build: Add calypso's node modules as a cache directory

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,8 @@ checkout:
 
 # pre-test
 dependencies:
+    cache_directories:
+        - "calypso/node_modules"
     pre:
         - npm install -g npm
         - npm install


### PR DESCRIPTION
This should speed up subsequent builds, as `npm install` for calypso will take less time