### PR TITLE
Update Calypso version, and Webpack NMR path for analytics

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -51,7 +51,7 @@ module.exports = {
 	plugins: [
 		// new webpack.optimize.DedupePlugin(),
 		new webpack.optimize.OccurenceOrderPlugin(),
-		new webpack.NormalModuleReplacementPlugin( /^analytics$/, 'lodash/noop' ), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^lib\/analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib\/upgrades\/actions$/, 'lodash/noop' ), // Uses Flux dispatcher
 		new webpack.NormalModuleReplacementPlugin( /^lib\/route$/, 'lodash/noop' ) // Depends too much on page.js
 


### PR DESCRIPTION
`analytics` was moved to `lib`. This PR fixes the `NormalModuleReplacementPlugin` line in `webpack.shared.js` accordingly.

Note that to get the desktop app to work again, Automattic/wp-calypso#4767 is also required, so it's probably best to wait for that to be merged and update this PR accordingly.

/cc @gwwar 