### PR TITLE
Enhancement: Add Command+Ctrl+F keyboard shortcut for Toggle Full Screen on OS X

### DIFF
--- a/desktop/lib/menu/view-menu.js
+++ b/desktop/lib/menu/view-menu.js
@@ -7,6 +7,7 @@ const BrowserWindow = require( 'electron' ).BrowserWindow;
  */
 const Config = require( 'lib/config' );
 const debugMenu = require( './debug-menu' );
+const platform = require( 'lib/platform' );
 
 /**
  * Module variables
@@ -20,6 +21,7 @@ if ( Config.debug ) {
 menuItems.push(
 	{
 		label: 'Toggle Full Screen',
+		accelerator: platform.isOSX() ? 'Command+Ctrl+F' : undefined,
 		fullscreen: true,
 		click: function() {
 			const focusedWindow = BrowserWindow.getFocusedWindow();


### PR DESCRIPTION
On the Mac the established shortcut convention for toggling a window into full screen mode is Command+Control+F. This is evidenced in the following Apple applications, amongst others:

* Finder
* Safari
* iTunes

This pull request adds this expected shortcut to the View menu's "Toggle Full Screen" item when the platform is OS X. (I am not adequately familiar with other platforms to make any determinations on what, if any, shortcuts should be used elsewhere.)