### PR TITLE
Ignore WP-Calypso's components usage stats

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -42,7 +42,8 @@ module.exports = {
 		// These are Calypso server modules we don't need, so let's not bundle them
 		'webpack.config',
 		'bundler/hot-reloader',
-		'devdocs/search-index'
+		'devdocs/search-index',
+		'devdocs/components-usage-stats.json'
 	],
 	resolve: {
 		extensions: [ '', '.js', '.jsx' ],


### PR DESCRIPTION
WP-Calypso master now builds a json file containing the ui components usage stats from `client/components`. However this file is not generated for WP-Desktop.

When building the desktop app @gwwar noticed the following error:

<img width="785" alt="stats" src="https://cloud.githubusercontent.com/assets/711311/15618073/80b5f1ac-244c-11e6-80c9-2ce4e49128fe.png">

What happened:
Webpack tried to pick up that file but since we don't build it for the desktop app it couldn't find it.

The fix is pretty straightforward:
I am adding the file `devdocs/components-usage-stats.json` to the webpack's `externas` object so that it doesn't get bundled.