### PR TITLE
Set webpack directory context

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -32,6 +32,7 @@ module.exports = {
 		__filename: true,
 		__dirname: true
 	},
+	context: __dirname,
 	externals: [
 		'express',
 		'webpack',


### PR DESCRIPTION
On my machine `__dirname` is set to a full path which prevents the packaged builds from running.

On a machine where packaged builds work, `__dirname` is set to a path relative to the build directory.