### PR TITLE
Add instructions for adding oauth_client_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ WordPress.com for Desktop is an [Electron](https://github.com/atom/electron) wra
  - `git submodule init`
  - `git submodule update`
 1. Create a `calypso/config/secrets.json` file and fill it with [secrets](docs/secrets.md)
+1. After obtaining the [secrets](docs/secrets.md), put your `oauth_client_id` in `calypso/config/desktop.json` too,
 1. `make run` to build and run the app
 
 Need more detailed instructions? [We have them.](docs/install.md)

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -4,11 +4,11 @@ Some secrets are needed to build the app. You will need to create the files your
 
 ## Calypso Secrets
 
-We use an OAuth connection to authenticate logins against the WordPress.com API. 
-You can [create an application here](https://developer.wordpress.com/apps/). 
+We use an OAuth connection to authenticate logins against the WordPress.com API.
+You can [create an application here](https://developer.wordpress.com/apps/).
 
 When creating your application, provide a name and a quick description. In the `Javascript Origins` field, you'll
-want to whitelist `http://127.0.0.1:41050`. Leave the application type as `web`. Answer the bot challenge, 
+want to whitelist `http://127.0.0.1:41050`. Leave the application type as `web`. Answer the bot challenge,
 and click on the create button. The other fields may be left blank.
 
 In the end, your application details should look similar to:
@@ -23,3 +23,5 @@ After your application is created, copy your client id and client secret, and ad
 	"desktop_oauth_client_secret": "<YOUR CLIENT SECRET>"
 }
 ```
+
+Add your `oauth_client_id` to `calypso/config/desktop.json` as well.


### PR DESCRIPTION
I was just installing and running the desktop app, followed all the instructions and still got an error about missing `oauth_client_id`. The error/warning is coming from https://github.com/Automattic/wp-calypso/blob/master/client/auth/connect.jsx#L30 which was introduced in https://github.com/Automattic/wp-calypso/pull/4506.

After adding the `oauth_client_id`, the desktop app works as expected.