### PR TITLE
 Advanced SEO: Fixes preview nudge breaking the app on load.

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -53,6 +53,7 @@ module.exports = {
 	plugins: [
 		// new webpack.optimize.DedupePlugin(),
 		new webpack.optimize.OccurenceOrderPlugin(),
+		new webpack.NormalModuleReplacementPlugin( /^components\/seo\/preview-upgrade-nudge$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib\/analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib\/upgrades\/actions$/, 'lodash/noop' ), // Uses Flux dispatcher
 		new webpack.NormalModuleReplacementPlugin( /^lib\/route$/, 'lodash/noop' ), // Depends too much on page.js


### PR DESCRIPTION
Adds a module replacement entry to the webpack configuration to noop the SeoPreviewNudge component until we can extract the shared functionality.

This should fix this issue: https://github.com/Automattic/wp-calypso/pull/7479#issuecomment-243960156

cc: @sendhil @roundhill 