### PR TITLE
add flatpak support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,10 @@ package-osx: osx
 package-linux: linux
 	@node $(THIS_DIR)/resource/build-scripts/package-linux.js
 
+package-flatpak: config-release-flatpak package
+	@node $(BUILDER) linux
+	@node $(THIS_DIR)/resource/build-scripts/package-flatpak.js
+
 distclean: clean
 	@cd calypso; make distclean
 	@rm -rf ./node_modules
@@ -142,6 +146,9 @@ config-test: install secret
 
 config-updater: install secret
 	@node $(BUILD_CONFIG) $(DESKTOP_CONFIG)/config-updater.json > $(CONFIG)
+
+config-release-flatpak: install secret secret-clientid
+	@node $(BUILD_CONFIG) $(DESKTOP_CONFIG)/config-release.json linux flatpak > $(CONFIG)
 
 # NPM
 install: node_modules

--- a/desktop-config/README.md
+++ b/desktop-config/README.md
@@ -19,6 +19,8 @@ The build process is:
 
 `debug` - `false` to disable, or a set of debug config
 
+`disable_updates` - `true` to disable updates
+
 `mainWindow` - main app window config
 
 `preferencesWindow` - preference window config

--- a/desktop-config/config-base.json
+++ b/desktop-config/config-base.json
@@ -3,6 +3,7 @@
 	"server_url": "http://127.0.0.1",
 	"server_host": "127.0.0.1",
 	"debug": false,
+	"disable_updates": false,
 	"mainWindow": {
 		"acceptFirstMouse": false,
 		"frame": true,

--- a/desktop/app-handlers/updater/index.js
+++ b/desktop/app-handlers/updater/index.js
@@ -34,7 +34,7 @@ function urlBuilder( version, channel ) {
 }
 
 module.exports = function() {
-	if ( Config.updater ) {
+	if ( Config.updater && !Config.disable_updates ) {
 		app.on( 'will-finish-launching', function() {
 			let url = urlBuilder( app.getVersion(), settings.getSetting( 'release-channel' ) );
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -5,6 +5,7 @@ Some builds require further packaging before they can be released:
 * `make package-win32` - Produces a signed `Setup.exe` install wizard
 * `make package-osx` - Produces a `DMG` file
 * `make package-linux` - Produces a `.deb` file
+* `make package-flatpak` - Produces a `.flatpak` file
 
 ## Requirements
 
@@ -18,3 +19,4 @@ The Linux package is build using [FPM][1] which is a tool that makes it easy to 
 
 [1]: https://github.com/jordansissel/fpm
 [2]: https://mkaz.tech/code-signing-a-windows-application.html
+

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-preset-react": "^6.3.13",
     "chai": "^3.4.1",
     "electron-builder": "2.8.4",
+    "electron-installer-flatpak": "^0.5.0",
     "electron-mocha": "^2.1.0",
     "electron-packager": "^7.0.2",
     "electron": "1.3.5",

--- a/resource/build-scripts/build-config-file.js
+++ b/resource/build-scripts/build-config-file.js
@@ -8,6 +8,11 @@ var config = require( process.argv[2] );
 // if linux, add icon to mainWindow
 if ( ( process.argv.length > 2 ) && ( process.argv[3] == 'linux' ) ) {
 	Object.assign( base.mainWindow, { "icon": "/usr/share/pixmaps/wpcom.png" } );
+
+	// if flatpak, disable updates
+	if ( ( process.argv.length >= 4 ) && ( process.argv[4] == 'flatpak' ) ) {
+		Object.assign( base, { "disable_updates": true } );
+	}
 }
 
 Object.assign( base, config );

--- a/resource/build-scripts/package-flatpak.js
+++ b/resource/build-scripts/package-flatpak.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * Internal dependencies
+ */
+var cp = require('child_process');
+
+/**
+ * Module variables
+ */
+console.log('Building Flatpak package...');
+
+var onErrorBail = function( error ) {
+	if (error) {
+		console.log("Error: " + error);
+		process.exit(1);
+	}
+};
+
+var cmd = [
+	'electron-installer-flatpak' +
+	' --src release/WordPress.com-linux-x64' +
+	' --dest release/flatpak/' +
+	' --arch x86_64' +
+	' --bin WordPress.com' +
+	' --icon release/WordPress.com-linux-x64/WordPress.png'
+];
+
+cp.execSync( cmd.join(' '), onErrorBail );


### PR DESCRIPTION
This PR adds support for building [flatpak](http://flatpak.org/) for WordPress desktop, which should be runnable on any Linux distro.

This PR also introduces a `disable_updates` option, which is set by default to false, but due to Flatpaks nature we can't do updates that way. Let me know if you have other ideas how to handle this, will be happy to make adjustments to it. Thanks!

### Build and run:

For all requirements have a look at [electron-installer-flatpak.](https://github.com/endlessm/electron-installer-flatpak#requirements)

To build this locally call:

```
make package-flatpak
```
This gives you with a .flatpak file, which you can then install:

```
flatpak install --user --bundle release/flatpak/io.atom.electron.WordPressDesktop_master_x86_64.flatpak
flatpak run io.atom.electron.WordPressDesktop 
```

p.s. Your documentation is really great!