### PR TITLE
Separate dependencies between external / internal categories

### DIFF
--- a/desktop/server/server.js
+++ b/desktop/server/server.js
@@ -3,12 +3,14 @@
 /**
  * External Dependencies
  */
-const portscanner = require( 'portscanner' );
 const debug = require( 'debug' )( 'desktop:server' );
+const http = require( 'http' );
+const portscanner = require( 'portscanner' );
 
 /**
  * Internal dependencies
  */
+const boot = require( 'boot' );
 const Config = require( 'lib/config' );
 
 function showFailure( app ) {
@@ -26,9 +28,7 @@ function showFailure( app ) {
 }
 
 function startServer( running_cb ) {
-	var boot = require( 'boot' );
-	var http = require( 'http' );
-	var server = http.createServer( boot() );
+	const server = http.createServer( boot() );
 
 	debug( 'Server created, binding to ' + Config.server_port );
 


### PR DESCRIPTION
Hi All!
I'm currently putting together my first-pass at running the desktop builds from within Calypso itself - A bit of a flip around!

One snag that I had when fiddling with the make file to point at Calypso as a parent directory rather than a child directory was when I hit a `Module not found` error, complaining that it `Cannot resolve module 'boot'`.

Without much context my initial thoughts were something along the lines of - "either this is some core node module that I don't know about, or there's a file called 'boot". I'd seen some files named 'boot' but nothing that looked as though it'd be considered root/boot (sorry, had too!).
I wasted a little time looking for boot in package.json, looking at node docs for some for-free module that I didn't know about etc. before noticing this in the webpack config:
```js
resolve: {
  extensions: [ '', '.js', '.jsx' ],
  modulesDirectories: [ 
    'node_modules', 
    path.join( __dirname, 'calypso', 'server' ), 
    path.join( __dirname, 'calypso', 'client' ), 
    'desktop' 
  ]
},
```

I've moved a couple of dependency `require`s around in this file to help make them a little more clear for future readers but also to ask a few of questions:

- Is there significance to `require`ing these deps within the method blocks as they were?

- Would there be any value in changing the way we reference the calypso directory here?
  If I'm not mistaken, any identically named files/dirs that appear in both `calypso.server` & `calypso.client` would clash?

- I'm 99% sure that such tweaks will be unavoidable when pulling `wp-desktop` in to Calypso, is it worth updating here beforehand?

-----

P.S. the build failed, looks to be due to an issue with `makensis`. I'm really not sure of the details but have noticed that I've been getting this error when building locally and ignoring it for now while I'm still in the playing-around phase... I'll look in to it further down the line :)