### PR TITLE
Webpack: Add alias for "desktop"

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -47,6 +47,9 @@ module.exports = {
 		'devdocs/components-usage-stats.json'
 	],
 	resolve: {
+		alias: {
+			'desktop': path.join( __dirname, 'desktop' ),
+		},
 		extensions: [ '', '.js', '.jsx' ],
 		modulesDirectories: [ 'node_modules', path.join( __dirname, 'calypso', 'server' ), path.join( __dirname, 'calypso', 'client' ), 'desktop' ]
 	},


### PR DESCRIPTION
Hi all!
I'm opening this up early and without actual implementation in the hope that it aids @samouri with #275.

The alias added in this PR allows paths like `lib/config` to be replaced with the more specific `desktop/lib/config`.
This will help avoid conflicting references between `desktop` and Calypso's own 'modules' - `client` and `server`.

#### Testing
Right now theres no usage of `desktop/xx` paths so to test the alias works, you'll have to change some manually before running `make run`.
A good example change would be to update `desktop/lib/app-instance`s internal deps to:
```js
/**
 * Internal dependencies
 */
const config = require( 'desktop/lib/config' );
const platform = require( 'desktop/lib/platform' );
```

#### notes
I plan to add aliases for `server` and `client` eventually but I'll open another PR for these once I've properly tested them.
I also plan on updating a bunch of references to use the `desktop` alias as this will help with my current project of merging `wp-desktop` in to `wp-calypso` - Either as part of this PR or in a separate one. 