### PR TITLE
Fix: Extensions loader in webpack

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -9,6 +9,11 @@ module.exports = {
 	module: {
 		loaders: [
 			{
+				test: /extensions\/index/,
+				exclude: 'node_modules',
+				loader: path.join( __dirname, 'calypso', 'server', 'bundler', 'extensions-loader' )
+			},
+			{
 				test: /sections.js$/,
 				exclude: 'node_modules',
 				loader: path.join( __dirname, 'calypso', 'server', 'isomorphic-routing', 'loader' )

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -58,16 +58,14 @@ module.exports = {
 	plugins: [
 		// new webpack.optimize.DedupePlugin(),
 		new webpack.optimize.OccurenceOrderPlugin(),
-		new webpack.NormalModuleReplacementPlugin( /^lib\/olark$/, 'lodash/noop' ), // Too many dependencies, e.g. sites-list
-		new webpack.NormalModuleReplacementPlugin( /^components\/seo\/preview-upgrade-nudge$/, 'components/empty-component' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^components\/popover$/, 'components/empty-component' ), // Depends on BOM and interactions don't work without JS
 		new webpack.NormalModuleReplacementPlugin( /^lib\/analytics$/, 'lodash/noop' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^lib\/upgrades\/actions$/, 'lodash/noop' ), // Uses Flux dispatcher
-		new webpack.NormalModuleReplacementPlugin( /^lib\/route$/, 'lodash/noop' ), // Depends too much on page.js
-		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/themes-site-selector-modal$/, 'components/empty-component' ), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^lib\/sites-list$/, 'lodash/noop' ), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^lib\/olark$/, 'lodash/noop' ), // Depends on DOM
+		new webpack.NormalModuleReplacementPlugin( /^lib\/user$/, 'lodash/noop' ), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^lib\/post-normalizer\/rule-create-better-excerpt$/, 'lodash/noop' ), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^components\/seo\/reader-preview$/, 'components/empty-component' ), // Conflicts with component-closest module
+		new webpack.NormalModuleReplacementPlugin( /^components\/popover$/, 'components/null-component' ), // Depends on BOM and interactions don't work without JS
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/theme-upload$/, 'components/empty-component' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/single-site$/, 'components/empty-component' ), // Depends on DOM
-		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/multi-site$/, 'components/empty-component' ), // Depends on DOM
+		new webpack.NormalModuleReplacementPlugin( /^client\/layout\/guided-tours\/config$/, 'components/empty-component' ) // should never be required server side
 	],
 };


### PR DESCRIPTION
Note: Feel free to merge this if it's good to go, or you can just take the code from `webpack.shared.js` and apply it to another PR. Whichever works best.

This fixes the error that comes up when using a newer version of
wp-calypso. It requires a custom webpack loader to translate the
extensions reducers into a js module.

This also pulls up the calypso submodule to the point that the
extensions loader PR was merged there.

See: https://github.com/Automattic/wp-calypso/pull/11728