### PR TITLE
Builder: Log the correct packager error

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -58,7 +58,7 @@ builder.beforeBuild( __dirname, opts, function( error ) {
 
 	packager( opts, function( err ) {
 		if ( err ) {
-			console.log( error );
+			console.log( err );
 		} else {
 			builder.cleanUp( path.join( __dirname, 'release' ), opts );
 		}


### PR DESCRIPTION
I noticed that while running `make win32` the process would fail without an error message - instead I would see `undefined` in the terminal after `Packaging app for platform win32 ia32 using electron v1.3.5`.

After some head scratching I tracked that `undefined` to `console.log( error );` and noticed that this is referencing `error` from the above scope.

This small PR aims to log the error produced by running `packager`.

When applying the fix I now see error details like so:

```bash
{ Error: Could not find "wine" on your system.

Wine is required to use the app-copyright, app-version, build-version, icon, and
version-string parameters for Windows targets.
...

code: 'ENOENT',
errno: 'ENOENT',
syscall: 'spawn wine',
path: 'wine',
...
```

It might be worth explicitly logging just the error body (`console.log( err.Error );`), but there may be value in logging the rest of the details too.