### PR TITLE
Add snap install instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -22,6 +22,14 @@ To be able to clone the repo and run the application you need:
 
 ## Installing and Running
 
+### Ubuntu and [snap supported distros](https://snapcraft.io/docs/core/install) 
+
+Install the snap on [snap supported](https://snapcraft.io/docs/core/install) systems from the store.
+
+    snap install wordpress-desktop --beta
+
+### From source
+
 Clone this git repo to your machine via the terminal using the `git clone` command and then run `make run` from the root app directory:
 
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,6 +28,8 @@ Install the snap on [snap supported](https://snapcraft.io/docs/core/install) sys
 
     snap install wordpress-desktop --beta
 
+Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released.
+
 ### From source
 
 Clone this git repo to your machine via the terminal using the `git clone` command and then run `make run` from the root app directory:


### PR DESCRIPTION
Wordpress Desktop is now published in the Snap store, this pull request add instructions for installing the snap. Wordpress Desktop is currently in the beta channel but when it's promoted to stable I will file a another pull request to update the documentation.