### PR TITLE
Preview: Ignore x-frame-options for iframes

### DIFF
--- a/desktop/server/index.js
+++ b/desktop/server/index.js
@@ -60,6 +60,24 @@ function showAppWindow() {
 		}
 	} );
 
+	mainWindow.webContents.session.webRequest.onHeadersReceived( function( details, callback ) {
+		// always allow previews to be loaded in iframes
+		if ( details.resourceType === 'subFrame' ) {
+			const headers = Object.assign( {}, details.responseHeaders );
+			Object.keys( headers ).forEach( function ( name ) {
+				if ( name.toLowerCase() === 'x-frame-options' ) {
+					delete headers[ name ];
+				}
+			} );
+			callback( {
+				cancel: false,
+				responseHeaders: headers
+			} );
+			return;
+		}
+		callback( { cancel: false } );
+	} );
+
 	mainWindow.loadURL( appUrl );
 	//mainWindow.openDevTools();
 


### PR DESCRIPTION
This PR allows us to show preview even for sites that send `x-frame-options: sameorigin` or even `deny`. 

This header can be present on some Jetpack sites with plugins like this (https://wordpress.org/plugins/http-headers/) or the header can also be set in the code of some themes. Previously, loading of such site lead to the error with error code `NaN` and you had to restart the app in order to use Calypso again.

The header is not stripped on the server but rather on the network level inside of the Electron app thus we are not lowering the security of the site on the internet.

To test:
- have a jetpack site with plugin above mentioned
- in wp-admin, go to settings and enable `x-frame-options` to sameorigin
- test "Preview" functionality in the app