### PR TITLE
Assert expectation of loc being string

### DIFF
--- a/desktop/server/index.js
+++ b/desktop/server/index.js
@@ -113,6 +113,10 @@ function isValidLastLocation( loc ) {
 		'/start'         // Don't attempt to resume the signup flow
 	];
 
+	if ( typeof loc !== 'string' ) {
+		return false;
+	}
+
 	for ( let s of invalids ) {
 		if ( loc.startsWith( s ) ) {
 			return false;


### PR DESCRIPTION
When I started the application for the first time after installation, I've got that:

![screen shot 2017-07-12 at 10 01 08](https://user-images.githubusercontent.com/326402/28106162-63c7b0f2-66eb-11e7-9f91-b3cb006384a3.png)

I'm not really sure how I landed there, since the stack seems to be from the `close` [event](https://github.com/Automattic/wp-desktop/blob/master/desktop/server/index.js#L87).
