### PR TITLE
Use native calypso login instead of oauth2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ CERT_SPC := $(THIS_DIR)/resource/secrets/automattic-code.spc
 CERT_PVK := $(THIS_DIR)/resource/secrets/automattic-code.pvk
 CALYPSO_DIR := $(THIS_DIR)/calypso
 CALYPSO_JS := $(CALYPSO_DIR)/public/build.js
-CALYPSO_CHANGES_STD := `find "$(CALYPSO_DIR)" -newer "$(CALYPSO_JS)" \( -name "*.js" -o -name "*.jsx" -o -name "*.json" -o -name "*.scss" \) -type f -print -quit | grep -v .m. | wc -l`
+CALYPSO_CHANGES_STD := `find "$(CALYPSO_DIR)" -newer "$(CALYPSO_JS)" \( -name "*.js" -o -name "*.jsx" -o -name "*.json" -o -name "*.scss" \) -type f -print -quit | grep -v .min. | wc -l`
 CALYPSO_BRANCH = $(shell git --git-dir ./calypso/.git branch | sed -n -e 's/^\* \(.*\)/\1/p')
 WEBPACK_BIN := $(NPM_BIN)/webpack
 


### PR DESCRIPTION
This PR updates wp-desktop to use the last version of calypso and switches the login method from oauth2 to the new WpLogin component (which relies on the few endpoints created at `/wp-login.php`). It relies on changes from https://github.com/Automattic/wp-calypso/pull/16187

It also updates the part which detects changes in calypso so you don't need to run `make distclean` anymore each time you changed something on calypso.

### Testing instructions
- Sandbox wordpress.com and apply patch D6385 and D6403
- Checkout this branch `git checkout update/login && git submodule update`
- Boot the app `npm start`
- Ensure that you can log in and log out properly
- Try to navigate to `/oauth-login` with `window.location = '/oauth-login';` to emulate a user who left at that page last time he loaded the app. Ensure you are redirected to `/log-in`

### Reviews 
- [x] Code
- [ ] Product
