### PR TITLE
Electron: Use 1.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "electron-builder": "2.8.4",
     "electron-mocha": "^2.1.0",
     "electron-packager": "^7.0.2",
-    "electron": "1.3.5",
+    "electron": "1.6.11",
     "electron-rebuild": "^1.2.1",
     "eslint": "^2.10.2",
     "eslint-plugin-react": "^5.1.1",


### PR DESCRIPTION
### * Blocked *
By https://github.com/Automattic/wp-desktop/pull/323 & https://github.com/Automattic/wp-desktop/pull/325, both are very minor changes that are needed to be able to run the make processes necessary for testing this PR on a new set up. You might not see the makensis issue if you've built previously and already have one of the checked-for versions installed.

Also, I'm unable to test the linux build at the moment, it builds successfully and I would assume it runs as the other 2 platforms do but I'd ❤️  if somebody else could test and confirm that for me 😃 

### Summary

This PR brings the version of Electron used in the project up to `v1.6.11`.

The motivation for doing so comes from the need to use node `v6.9.0` or above to remove a potential vulnerability. Ping me privately if you're not already aware of the details.
Electron `v1.6.11` uses node version `7.4.0`, so this issue will be solved.

### Test Plan
I have yet to test all that I'd like to as I'm having issues with certain builds. I'm on a relatively new machine and I think the issues that I'm seeing are more likely to be down to the machine rather the updated Electron version.
I'll keep working on successfully creating builds but I'd appreciate it if somebody else can beat me to it :)

- [x] Ensure App is built to use node `v7.4.0` in the main process
    - An easy way to check is to `console.log( process.versions[ 'node' ] )` in `desktop/env.js` or similar.

- [x] Successfully run `make run`
- [x] Successfully build and test `make package`
- [x] Successfully build and test `make package-linux`
    - [x] build
    - [x] test
- [x] Successfully build and test `make package-osx`
    - [x] build
    - [x] test
- [x] Successfully build and test `make package-win32`
    - [x] build
    - [x] test

### Notes

I was expecting to need to update other Electron related dependancies (`electron-builder`, `electron-packager` etc.) but so far that doesn't seem to be the case.
I'll aim to do some research around these dependancies to make sure they are not using an older node version themselves, or to see if there are other benefits to updating them all at once.
