### PR TITLE
Makefile: use .m.js file target in package task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ package: build-if-changed
 	@cp $(CALYPSO_DIR)/config/_shared.json $(BUILD_DIR)/calypso/config/
 	@cp $(CALYPSO_DIR)/config/desktop.json $(BUILD_DIR)/calypso/config/
 	@rm $(BUILD_DIR)/calypso/public/style-debug.css*
-	@mv $(BUILD_DIR)/calypso/public/build.min.js $(BUILD_DIR)/calypso/public/build.js
+	@mv $(BUILD_DIR)/calypso/public/build.m.js $(BUILD_DIR)/calypso/public/build.js
 	@rm -rf $(BUILD_DIR)/calypso/server/pages/test $(BUILD_DIR)/calypso/server/pages/Makefile $(BUILD_DIR)/calypso/server/pages/README.md
 	@cd $(BUILD_DIR); $(NPM) install --production --no-optional; $(NPM) prune
 


### PR DESCRIPTION
While working on #322 I noticed that running `make package` or it's related tasks would throw an error while trying to copy a minified file. The file is there but with a `.m.js` extension rather than `.min.js`.
This PR fixes that :)

To test, run `make package` and ensure there are no errors thrown during the process.