### PR TITLE
makensis: Allow use of v25-Jul-2017

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,12 @@ updater: config-updater package
 verify-makensis:
 ifneq "$(MAKENSIS_VERSION)" "v08-Feb-2016.cvs"
 ifneq "$(MAKENSIS_VERSION)" "v12-Dec-2016.cvs"
+ifneq "$(MAKENSIS_VERSION)" "v25-Jul-2017.cvs"
 	echo "$(RED)Please upgrade NSIS installer requires >= v2.5.0.";
 	echo "> If new version installed, Makefile needs updating (verify-makensis)";
 	echo "> brew update; brew upgrade makensis$(RESET)";
 	exit 1;
+endif
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,10 @@ verify-makensis:
 ifneq "$(MAKENSIS_VERSION)" "v08-Feb-2016.cvs"
 ifneq "$(MAKENSIS_VERSION)" "v12-Dec-2016.cvs"
 ifneq "$(MAKENSIS_VERSION)" "v25-Jul-2017.cvs"
-	echo "$(RED)Please upgrade NSIS installer requires >= v2.5.0.";
-	echo "> If new version installed, Makefile needs updating (verify-makensis)";
-	echo "> brew update; brew upgrade makensis$(RESET)";
-	exit 1;
+	@echo "$(RED)Please upgrade NSIS installer requires >= v2.5.0.";
+	@echo "> If new version installed, Makefile needs updating (verify-makensis)";
+	@echo "> brew update; brew upgrade makensis$(RESET)";
+	@exit 1;
 endif
 endif
 endif


### PR DESCRIPTION
### Summary

While working on #322 and testing the win32 build I noticed that I was seeing the message laid out in the makefile, instructing me to update `makensis` with brew.
I tried this and noticed the message again. Using `makensis -VERSION` I noticed that the version was in fact more recent than those that we were already checking for.

~~I've yet to test that `make package-win32` as I need to find and install the correct certificate first.
I'll mark as 'Needs Review' once I've successfully built the package but wanted to get this PR up sooner rather than later incase there was some other issues.~~

### Testing

- make sure `makensis` is up to date
    - `brew update; brew upgrade makensis`
    - check `makensis -VERSION` is 'v25-Jul-2017.cvs'
- run `make verify-makensis` and note that there is no error message
- run `make package-win32` to test that 'v25-Jul-2017.cvs' is compatible

### Extra

I also updated the way the message is printed when `makensis` is not up to date, the below screenshot first shows the message before and then after the `@`s were added.
This should really have been done in another PR - I'm happy to pull it over to a new changeset if that's preferred :)

<img width="546" alt="screen shot 2017-08-01 at 04 41 30" src="https://user-images.githubusercontent.com/4335450/28808412-b9f42a40-7673-11e7-98ac-e7811c9e455d.png">

This is a pretty naive approach and could be improved upon to check only for a minimum version. Over time the approach used here could get a little out of hand otherwise.

