### PR TITLE
Fixes build.min.js kerfluffle and gets current on Calypso

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ package: build-if-changed
 	@cp $(CALYPSO_DIR)/config/_shared.json $(BUILD_DIR)/calypso/config/
 	@cp $(CALYPSO_DIR)/config/desktop.json $(BUILD_DIR)/calypso/config/
 	@rm $(BUILD_DIR)/calypso/public/style-debug.css*
-	@mv $(BUILD_DIR)/calypso/public/build.m.js $(BUILD_DIR)/calypso/public/build.js
+	@mv $(BUILD_DIR)/calypso/public/build.min.js $(BUILD_DIR)/calypso/public/build.js
 	@rm -rf $(BUILD_DIR)/calypso/server/pages/test $(BUILD_DIR)/calypso/server/pages/Makefile $(BUILD_DIR)/calypso/server/pages/README.md
 	@cd $(BUILD_DIR); $(NPM) install --production --no-optional; $(NPM) prune
 


### PR DESCRIPTION
`build.min.js` is the most current and correct build file post-Webpack 3. This resolves the confusion that I may have caused in my PR merges and also gets current on wp-calypso.