### PR TITLE
Build: Compare node & npm versions between wp-desktop & Calypso

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ NPM ?= $(NODE) $(shell which npm)
 NPM_BIN = $(shell npm bin)
 
 RED=`tput setaf 1`
+GREEN=`tput setaf 2`
 RESET=`tput sgr0`
 
 START_APP := @$(NPM_BIN)/electron .
@@ -60,12 +61,14 @@ check-node-and-npm-version-parity:
 	@if [ ! $(CALYPSO_NODE_VERSION) = $(DESKTOP_NODE_VERSION) ] || \
 		[ ! $(CALYPSO_NPM_VERSION) = $(DESKTOP_NPM_VERSION) ]; \
 		then { \
-			echo "Please ensure that wp-desktop and wp-calypso are using the same NPM and Node versions before continuing"; \
+			echo "Please ensure that wp-desktop is using the following versions of NPM and Node to match wp-calypso before continuing"; \
+			printf " - Node: $(CALYPSO_NODE_VERSION)"; \
 			if [ ! $(CALYPSO_NODE_VERSION) = $(DESKTOP_NODE_VERSION) ]; \
-				then echo " - wp-desktop should be using node version: $(CALYPSO_NODE_VERSION)"; \
+				then echo "$(RED) x$(RESET)"; else echo "$(GREEN) ✓$(RESET)"; \
 			fi; \
+			printf " - NPM: $(CALYPSO_NPM_VERSION)"; \
 			if [ ! $(CALYPSO_NPM_VERSION) = $(DESKTOP_NPM_VERSION) ]; \
-				then echo " - wp-desktop should be using NPM version: $(CALYPSO_NPM_VERSION)"; \
+				then echo "$(RED) x$(RESET)"; else echo "$(GREEN) ✓$(RESET)"; \
 			fi; \
 			echo ""; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ check-node-and-npm-version-parity:
 	fi;
 
 # Builds Calypso (desktop)
-build: install
+build: check-node-and-npm-version-parity install
 	@echo "Building Calypso (Desktop on branch $(RED)$(CALYPSO_BRANCH)$(RESET))"
 	@cd calypso && CALYPSO_ENV=desktop npm run build
 	@rm -f $(THIS_DIR)/calypso/public/devmodules.*

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,28 @@ run: config-dev package
 run-release: config-release package
 	$(START_APP)
 
+CALYPSO_NODE_VERSION := $(shell node -p "require('$(CALYPSO_DIR)/package.json').engines.node")
+CALYPSO_NPM_VERSION := $(shell node -p "require('$(CALYPSO_DIR)/package.json').engines.npm")
+DESKTOP_NODE_VERSION := $(shell node -p "require('$(THIS_DIR)/package.json').engines.node")
+DESKTOP_NPM_VERSION := $(shell node -p "require('$(THIS_DIR)/package.json').engines.npm")
+
+# Check that the current node & npm versions are the versions Calypso expects to ensure it is built safely.
+check-node-and-npm-version-parity:
+	@if [ ! $(CALYPSO_NODE_VERSION) = $(DESKTOP_NODE_VERSION) ] || \
+		[ ! $(CALYPSO_NPM_VERSION) = $(DESKTOP_NPM_VERSION) ]; \
+		then { \
+			echo "Please ensure that wp-desktop and wp-calypso are using the same NPM and Node versions before continuing"; \
+			if [ ! $(CALYPSO_NODE_VERSION) = $(DESKTOP_NODE_VERSION) ]; \
+				then echo " - wp-desktop should be using node version: $(CALYPSO_NODE_VERSION)"; \
+			fi; \
+			if [ ! $(CALYPSO_NPM_VERSION) = $(DESKTOP_NPM_VERSION) ]; \
+				then echo " - wp-desktop should be using NPM version: $(CALYPSO_NPM_VERSION)"; \
+			fi; \
+			echo ""; \
+			exit 1; \
+		} \
+	fi;
+
 # Builds Calypso (desktop)
 build: install
 	@echo "Building Calypso (Desktop on branch $(RED)$(CALYPSO_BRANCH)$(RESET))"


### PR DESCRIPTION
### Summary

This PR aims to add an extra check to the desktop build process in order to avoid building Calypso with versions of `node` or `npm` that differ from those which Calypso expects to be built with as doing so could cause issues.

### Current output:

<img width="820" alt="screen shot 2017-10-14 at 22 13 08" src="https://user-images.githubusercontent.com/4335450/31579427-f25ecb3e-b12d-11e7-840b-f645b248d818.png">

### Testing
Make sure you have Calypso set up in the`/calypso` directory (follow `README.md` for this).

- Start by changing the `node` and `npm` versions under `engines` in `wp-desktop`s `package.json`...
- Try setting both to be different from those found in Calypso's `package.json`.
- run `make build` to attempt to start a desktop build.
- The process should bail almost immediately prompting you to update `wp-desktop`s versions - You should see that both `node` and `npm` versions appear with an `x` next to them.

Repeat the above process, but testing cases where 
- only one of the engines are wrong - you should see a green tick next to the matching engine.
- both `node` and `npm` are matching between projects - you should see the build process continue as usual, without errors thrown and without the above messages shown.

### Extra Thoughts

At this point, all we're checking for is that the expected NPM and Node versions are both equal between the two projects. We could further this by checking the developers current working versions by looking at the output of `node -v` & `npm -v`.
We might even consider being strict about one type of check (let's call the two checks 'working version' and 'project parity'). 
For instance, I personally have both `npm` and `node` running at the required versions so Calypso would build as expected even though the 'project parity' check would fail - should I be blocked from building until `wp-desktop`s `package.json` is updated? In that case a warning might suffice.
If, conversely, I've updated `wp-desktop`s versions to pass the 'project parity' check but have not upgraded my working versions this would still pose the risk of building Calypso with an unexpected version of `node`.