### PR TITLE
Webpack: Resolve json modules correctly

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -52,7 +52,7 @@ module.exports = {
 		'devdocs/components-usage-stats.json'
 	],
 	resolve: {
-		extensions: [ '', '.js', '.jsx' ],
+		extensions: [ '', '.js', '.jsx', '.json' ],
 		modulesDirectories: [ 'node_modules', path.join( __dirname, 'calypso', 'server' ), path.join( __dirname, 'calypso', 'client' ), 'desktop' ]
 	},
 	plugins: [


### PR DESCRIPTION
Include json extension in the webpack resolve extensions so the same rules as js and jsx are obeyed and modules can be found.

see p1508183849000336-slack-wordpress-desktop
cc/ @astralbodies 