### PR TITLE
Fix showing error when user is trying to start a new instance of the app

### DIFF
--- a/desktop/lib/app-instance/index.js
+++ b/desktop/lib/app-instance/index.js
@@ -31,7 +31,7 @@ AppInstance.prototype.isSingleInstance = function() {
 
 	if ( shouldQuit ) {
 		debug( 'App is already running, quitting' );
-		app.quit();
+		app.exit();
 		return false;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-desktop/issues/339

### Testing Instructions
- Apply this patch
- `make clean`
- `make run`
- Once the app has booted, type `node_modules/.bin/electron .` in a new terminal
- Ensure no error is displayed in the terminal

### Reviews
- [ ] Code
- [ ] Product
