### PR TITLE
Try: Dynamically use calypso's node version on CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,8 +16,8 @@ checkout:
                 git checkout ${CALYPSO_HASH};
             fi
         - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
-        - nvm install v6.11.5
-        - nvm use v6.11.5
+        - nvm install $(cat calypso/.nvmrc)
+        - nvm use $(cat calypso/.nvmrc)
 
 deployment:
     beta-release:
@@ -33,7 +33,7 @@ deployment:
             - brew cask install xquartz
             - brew install wine makensis mono gnu-tar
             - gem install fpm
-            - nvm use v6.11.5
+            - nvm use $(cat calypso/.nvmrc)
             - make distclean
             - make package-osx
             - make package-win32


### PR DESCRIPTION
Dynamically detect the desired Node (nvm) version based on what's defined in `calypso/.nvmrc`.

This appears to work correctly based on [CI results for this branch](https://circleci.com/gh/Automattic/wp-desktop/11048):

---

```sh
$ nvm install $(cat calypso/.nvmrc)
# Exit code: 0
nvm install $(cat calypso/.nvmrc)
Downloading and installing node v6.11.2...
Downloading https://nodejs.org/dist/v6.11.2/node-v6.11.2-darwin-x64.tar.gz...

# …

$ nvm use $(cat calypso/.nvmrc)
# Exit code: 0
nvm use $(cat calypso/.nvmrc)
Now using node v6.11.2 (npm v3.10.10)
```