### PR TITLE
Add check for browser URL

### DIFF
--- a/desktop/window-handlers/external-links/index.js
+++ b/desktop/window-handlers/external-links/index.js
@@ -34,8 +34,21 @@ const DONT_OPEN_IN_BROWSER = [
 
 const domainAndPathSame = ( first, second ) => first.hostname === second.hostname && ( first.pathname === second.pathname || second.pathname === '/*' );
 
+function isValidBrowserUrl( url ) {
+	const parsedUrl = new URL( url );
+
+	if ( parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:' ) {
+		return url;
+	}
+
+	return false;
+}
+
 function openInBrowser( event, url ) {
-	shell.openExternal( url );
+	if ( isValidBrowserUrl( url ) ) {
+		shell.openExternal( url );
+	}
+
 	event.preventDefault();
 }
 


### PR DESCRIPTION
Extra check to make sure we only open URLs that go to the browser, and not other apps.

Existing external links should continue to work as normal.