### PR TITLE
Update webhooks URL for wp-calyspo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -44,4 +44,4 @@ deployment:
 
 notify:
   webhooks:
-    - url: https://a8cghdesktopcirclebridge.herokuapp.com/circleciwebhook
+    - url: https://a8c-gh-desktop-bridge.go-vip.co/circleciwebhook


### PR DESCRIPTION
These have moved to VIP Go