### PR TITLE
upgrade webpack to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,16 +28,16 @@
   },
   "devDependencies": {
     "asar": "^0.11.0",
-    "babel-core": "^6.9.0",
+    "babel-core": "6.26.0",
     "babel-eslint": "^6.0.4",
-    "babel-loader": "^6.2.2",
+    "babel-loader": "7.1.2",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.3.13",
     "chai": "^3.4.1",
+    "electron": "1.6.11",
     "electron-builder": "2.8.4",
     "electron-mocha": "^2.1.0",
     "electron-packager": "^7.0.2",
-    "electron": "1.6.11",
     "electron-rebuild": "^1.2.1",
     "eslint": "^2.10.2",
     "eslint-plugin-react": "^5.1.1",
@@ -46,7 +46,7 @@
     "mkdirp": "^0.5.1",
     "mv": "^2.1.1",
     "unzip": "^0.1.11",
-    "webpack": "^1.13.1"
+    "webpack": "3.10.0"
   },
   "dependencies": {
     "debug": "2.6.8",

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -7,15 +7,15 @@ var webpack = require( 'webpack' );
 module.exports = {
 	target: 'node',
 	module: {
-		loaders: [
+		rules: [
 			{
 				test: /extensions\/index/,
-				exclude: 'node_modules',
+				exclude: path.join( __dirname, 'calypso', 'node_modules' ),
 				loader: path.join( __dirname, 'calypso', 'server', 'bundler', 'extensions-loader' )
 			},
 			{
 				test: /sections.js$/,
-				exclude: 'node_modules',
+				exclude: path.join( __dirname, 'calypso', 'node_modules' ),
 				loader: path.join( __dirname, 'calypso', 'server', 'isomorphic-routing', 'loader' )
 			},
 			{
@@ -52,12 +52,17 @@ module.exports = {
 		'devdocs/components-usage-stats.json'
 	],
 	resolve: {
-		extensions: [ '', '.js', '.jsx', '.json' ],
-		modulesDirectories: [ 'node_modules', path.join( __dirname, 'calypso', 'server' ), path.join( __dirname, 'calypso', 'client' ), 'desktop' ]
+		extensions: [ '.js', '.jsx', '.json' ],
+		modules: [
+			path.join( __dirname, 'calypso', 'node_modules' ),
+			path.join( __dirname, 'node_modules' ),
+			path.join( __dirname, 'calypso', 'server' ),
+			path.join( __dirname, 'calypso', 'client' ),
+			path.join( __dirname, 'desktop' ),
+		]
 	},
 	plugins: [
 		// new webpack.optimize.DedupePlugin(),
-		new webpack.optimize.OccurenceOrderPlugin(),
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]abtest$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]sites-list$/, 'lodash/noop' ), // Depends on BOM


### PR DESCRIPTION
this updates webpack to be the same version as wp-calypso.

To test:
- whatever your usual desktop testing strategies are! A basic smoketest looked good to me.

Note: i'm seeing a double-build issue where two webpack builds are launched. This was pre-existing