### PR TITLE
Update calypso to latest, and fix the loaders

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -9,22 +9,20 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				test: /extensions\/index/,
+				test: /extensions[\/\\]index/,
 				exclude: path.join( __dirname, 'calypso', 'node_modules' ),
 				loader: path.join( __dirname, 'calypso', 'server', 'bundler', 'extensions-loader' )
 			},
 			{
-				test: /sections.js$/,
-				exclude: path.join( __dirname, 'calypso', 'node_modules' ),
-				loader: path.join( __dirname, 'calypso', 'server', 'isomorphic-routing', 'loader' )
+				include: path.join( __dirname, 'calypso', 'client/sections.js' ),
+				use: {
+					loader: path.join( __dirname, 'calypso', 'server', 'bundler', 'sections-loader' ),
+					options: { forceRequire: true, onlyIsomorphic: true },
+				},
 			},
 			{
 				test: /\.html$/,
 				loader: 'html-loader'
-			},
-			{
-				test: /\.json$/,
-				loader: 'json-loader'
 			},
 			{
 				test: /\.jsx?$/,
@@ -62,7 +60,6 @@ module.exports = {
 		]
 	},
 	plugins: [
-		// new webpack.optimize.DedupePlugin(),
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]abtest$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]sites-list$/, 'lodash/noop' ), // Depends on BOM


### PR DESCRIPTION
This PR:
1. updates extensions-loader rule to match wp-calypso's
2. removes `json-loader` which isn't needed in the latest versions of webpack
3. updates the isomorphic-routing loader to use the new sections-loader introduced in https://github.com/Automattic/wp-calypso/pull/21349
4. points calypso to to the tip

**to test**
run `npm start`