### PR TITLE
Fix sharing page in new window

### DIFF
--- a/desktop/window-handlers/external-links/index.js
+++ b/desktop/window-handlers/external-links/index.js
@@ -6,6 +6,7 @@
 const shell = require( 'electron' ).shell;
 const debug = require( 'debug' )( 'desktop:external-links' );
 const { URL } = require( 'url' );
+const path = require( 'path' );
 
 /**
  * Internal dependencies
@@ -71,6 +72,10 @@ module.exports = function( webContents ) {
 				options.y = options.y + OFFSET_NEW_WINDOW;
 				options.width = options.width * SCALE_NEW_WINDOW_FACTOR;
 				options.height = options.height * SCALE_NEW_WINDOW_FACTOR;
+
+				const preloadFile = path.resolve( path.join( __dirname, '..', '..', '..', 'public_desktop', 'preload.js' ) );
+				options.webPreferences.preload = preloadFile;
+				console.log(options);
 				return;
 			}
 		}

--- a/desktop/window-handlers/external-links/index.js
+++ b/desktop/window-handlers/external-links/index.js
@@ -28,7 +28,7 @@ const ALWAYS_OPEN_IN_APP = [
 ];
 
 const DONT_OPEN_IN_BROWSER = [
-	Config.server_url,
+	'http://127.0.0.1:41050/*',
 	'https://public-api.wordpress.com/connect/'
 ];
 

--- a/desktop/window-handlers/external-links/index.js
+++ b/desktop/window-handlers/external-links/index.js
@@ -32,6 +32,7 @@ const DONT_OPEN_IN_BROWSER = [
 	'https://public-api.wordpress.com/connect/'
 ];
 
+const samePort = ( first, second ) => second.port ? first.port === second.port : ! first.port;
 const domainAndPathSame = ( first, second ) => first.hostname === second.hostname && ( first.pathname === second.pathname || second.pathname === '/*' );
 
 function openInBrowser( event, url ) {
@@ -46,7 +47,7 @@ module.exports = function( webContents ) {
 		for ( let x = 0; x < ALWAYS_OPEN_IN_APP.length; x++ ) {
 			const alwaysOpenUrl = new URL( ALWAYS_OPEN_IN_APP[ x ] );
 
-			if ( domainAndPathSame( parsedUrl, alwaysOpenUrl ) ) {
+			if ( domainAndPathSame( parsedUrl, alwaysOpenUrl ) && samePort( parsedUrl, alwaysOpenUrl ) ) {
 				return;
 			}
 		}
@@ -61,7 +62,7 @@ module.exports = function( webContents ) {
 		for ( let x = 0; x < DONT_OPEN_IN_BROWSER.length; x++ ) {
 			const dontOpenUrl = new URL( DONT_OPEN_IN_BROWSER[ x ] );
 
-			if ( domainAndPathSame( parsedUrl, dontOpenUrl ) ) {
+			if ( domainAndPathSame( parsedUrl, dontOpenUrl ) && samePort( parsedUrl, dontOpenUrl ) ) {
 				debug( 'Open in new window for ' + url );
 
 				// When we do open another Electron window make it a bit smaller so we know it's there

--- a/desktop/window-handlers/external-links/index.js
+++ b/desktop/window-handlers/external-links/index.js
@@ -75,7 +75,6 @@ module.exports = function( webContents ) {
 
 				const preloadFile = path.resolve( path.join( __dirname, '..', '..', '..', 'public_desktop', 'preload.js' ) );
 				options.webPreferences.preload = preloadFile;
-				console.log(options);
 				return;
 			}
 		}


### PR DESCRIPTION
This allows the sharing popups to open in a new desktop window, instead of pushing them to a browser window. The key change is that the `DONT_OPEN_IN_BROWSER` needs to work for any URL on `http://127.0.0.1:41050/`, not just the root. This then allows the popup sharing connection windows to open.

On top of this we need to add the preload script otherwise the newly opened window doesn't have access to Electron, and will crash.

Additionally I added an extra check that the ports match when checking URLs. I don't think this is necessary, but it seems like a good thing to do.

To test:
- Open the post editor and click the 'add new service' in the sharing panel. A new window inside the desktop app should open and show all the sharing buttons

Note that after doing this PR and thinking further, I don't know if this is the best thing to be doing as you've now got two desktop windows open, and can go and do other things in the newly opened window. This is probably something that needs changing in Calypso to either not show this on desktop or to not open in a new window on desktop. It's a very browser-based action anyway and not really suitable for the desktop app.