### PR TITLE
Build process: environments

### DIFF
--- a/desktop-config/config-base.json
+++ b/desktop-config/config-base.json
@@ -1,4 +1,6 @@
 {
+	"build": "local",
+	"calypso_config": "desktop",
 	"server_port": 41050,
 	"server_url": "http://127.0.0.1",
 	"server_host": "127.0.0.1",

--- a/desktop-config/config-development.json
+++ b/desktop-config/config-development.json
@@ -1,6 +1,5 @@
 {
 	"build": "development",
-	"calypso_config": "desktop",
 	"server_port": 3000,
 	"server_url": "http://calypso.localhost",
 	"server_host": "calypso.localhost",

--- a/desktop-config/config-local.json
+++ b/desktop-config/config-local.json
@@ -1,4 +1,0 @@
-{
-	"build": "release",
-	"calypso_config": "desktop"
-}

--- a/desktop-config/config-release.json
+++ b/desktop-config/config-release.json
@@ -1,6 +1,5 @@
 {
 	"build": "release",
-	"calypso_config": "desktop",
 	"updater": {
 		"url": "https://public-api.wordpress.com/rest/v1.1/desktop/",
 		"delay": 2000,

--- a/desktop-config/config-test.json
+++ b/desktop-config/config-test.json
@@ -1,4 +1,3 @@
 {
-	"build": "test",
-	"calypso_config": "desktop"
+	"build": "test"
 }

--- a/desktop-config/config-updater.json
+++ b/desktop-config/config-updater.json
@@ -1,6 +1,5 @@
 {
 	"build": "updater",
-	"calypso_config": "desktop",
 	"debug": {
 		"enabled_by_default": false,
 		"namespace": "desktop:*",

--- a/resource/build-scripts/build-config-file.js
+++ b/resource/build-scripts/build-config-file.js
@@ -1,21 +1,23 @@
 // TODO: evaluate if there is a more straightforward way to create config files e.g. how does calypso solve this?
-const CONFIG_SRC_DIR = '../../desktop-config/';
-const CONFIG_DEST = './desktop/config.json';
-
 const path = require( 'path' );
 const fs = require( 'fs' );
 const chalk = require( 'chalk' );
 
+const CONFIG_SRC_DIR = path.join( __dirname, '..', '..', 'desktop-config' );
+const CONFIG_DEST = path.join( __dirname, '..', '..', 'desktop', 'config.json' );
+
 const baseConfig = require( path.join( CONFIG_SRC_DIR, 'config-base.json' ) );
 
-const { NODE_ENV } = process.env;
+const environment = process.argv[2];
 let envConfig = {};
 
-try {
-	envConfig = require( path.join( CONFIG_SRC_DIR, `config-${NODE_ENV}.json` ) );
-	console.log( chalk.cyan( `Using "config-${NODE_ENV}.json" to extend config` ) );
-} catch ( err ) {
-	console.log( chalk.yellow( `Config file for environment "${NODE_ENV}" does not exist. Ignoring Environment.` ) );
+if ( environment ) {
+	try {
+		envConfig = require( path.join( CONFIG_SRC_DIR, `config-${environment}.json` ) );
+		console.log( chalk.cyan( `Using "config-${environment}.json" to extend config` ) );
+	} catch ( err ) {
+		console.log( chalk.yellow( `Config file for environment "${environment}" does not exist. Ignoring Environment.` ) );
+	}
 }
 
 // if linux, add icon to mainWindow


### PR DESCRIPTION
### Description:
This PR adds the keys `build` and `calypso_env` to base-config.json. This allows us to create working builds without having the need to specify an environment. E.g. when running it locally. 

In an initial test I've used NODE_ENV for specifying the configuration environment. This is now replaced by using parameters like
```bash
$ npm run build:config release
``` 

**Available environments are:**
- development
- release
- test
- updater

### Motivation and Context:
This PR is part of #421. 