### PR TITLE
Replace legacy flux stores with noop

### DIFF
--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 var path = require( 'path' );
+var webpack = require( 'webpack' );
 
 /**
  * Internal dependencies
@@ -16,5 +17,11 @@ var options = {
 		libraryTarget: 'commonjs2'
 	}
 };
+
+shared.plugins = ( shared.plugins || [] ).concat( [ 
+	new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]user-settings$/, 'lodash/noop' ), // Depends on BOM
+	new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]application-passwords-data$/, 'lodash/noop' ), // Depends on BOM
+	new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]connected-applications-data$/, 'lodash/noop' ), // Depends on BOM
+] );
 
 module.exports = Object.assign( shared, options );


### PR DESCRIPTION
### Description:
Mock flux stores to `noop` for tests
because they depend on `store/store` which depends on `createElement`, a DOM method

### Motivation and Context:
It fixes the failing tests for https://github.com/Automattic/wp-calypso/pull/23300

### How Has This Been Tested:
```
git clone git@github.com:Automattic/wp-desktop.git   
git submodule init
git submodule update
cd calypso
git checkout de01ee8646f9bad189b53a7d90b4aa81cc073068  
cd ..
cp ~/Automattic/wp-calypso/config/secrets.json ./calypso/config/empty-secrets.json
npm test
```
