### PR TITLE
Bump up to node 8.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "wordpress.com"
   ],
   "engines": {
-    "node": "8.9.4",
+    "node": "8.11.0",
     "npm": "5.6.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Partner to https://github.com/Automattic/wp-calypso/pull/23744, moving us to node 8.11.0, the latest in the Carbon line.