### PR TITLE
Build: Update Node version to 8.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "wordpress.com"
   ],
   "engines": {
-    "node": "8.11.0",
+    "node": "8.11.2",
     "npm": "5.6.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This PR updates Calypso to node v8.11.2. This brings us to the [latest of the Carbon LTS line](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.11.2). This pairs with https://github.com/Automattic/wp-calypso/pull/25004