### PR TITLE
Revert "Move to Node 10.4.0 and npm 6.1.0"

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict = true
 save-exact = true
+package-lock = false

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "wordpress.com"
   ],
   "engines": {
-    "node": "10.4.0",
-    "npm": "6.1.0"
+    "node": "8.11.2",
+    "npm": "5.6.0"
   },
   "optionalDependencies": {
     "appdmg": "^0.4.5"


### PR DESCRIPTION
Reverts Automattic/wp-desktop#453

