### PR TITLE
CircleCI: Cache nvm usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,9 @@ jobs:
                     git fetch;
                     git checkout ${CALYPSO_HASH};
                   fi
-      - <<: *nvm
+      - <<: *restore_nvm
+      - <<: *setup_nvm
+      - <<: *save_nvm
       - run:
           name: Decrypt assets
           command: |
@@ -119,7 +121,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: /wp-desktop
-      - <<: *nvm
+      - <<: *restore_nvm
+      - <<: *setup_nvm
+      - <<: *save_nvm
       - restore_cache:
           key: v1-win-linux-dependencies-cache-{{ checksum "package.json" }}
       - run:
@@ -162,7 +166,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: /Users/distiller/wp-desktop
-      - <<: *nvm
+      - <<: *restore_nvm
+      - <<: *setup_nvm
+      - <<: *save_nvm
       - restore_cache:
           key: v1-mac-dependencies-cache-{{ checksum "package.json" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,11 @@
 version: 2
 
 references:
-  restore_nvm: &restore_nvm
+  nvm: &nvm
     restore_cache:
       name: Restoring NVM cache
       key: v1-nvm-0.33.11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
       key: v1-nvm-0.33.11-{{ arch }}
-  setup_nvm: &setup_nvm
     run:
       name: Install nvm and calypso node version
       command: |
@@ -24,7 +23,6 @@ references:
         nvm install "$NODE_VERSION"
         nvm alias default "$NODE_VERSION"
         nvm use "$NODE_VERSION"
-  save_nvm: &save_nvm
     save_cache:
       name: Saving NVM cache
       key: v1-nvm-0.33.11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
@@ -50,9 +48,7 @@ jobs:
                     git fetch;
                     git checkout ${CALYPSO_HASH};
                   fi
-      - <<: *restore_nvm
-      - <<: *setup_nvm
-      - <<: *save_nvm
+      <<: *nvm
       - run:
           name: Decrypt assets
           command: |
@@ -121,9 +117,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: /wp-desktop
-      - <<: *restore_nvm
-      - <<: *setup_nvm
-      - <<: *save_nvm
+      <<: *nvm
       - restore_cache:
           key: v1-win-linux-dependencies-cache-{{ checksum "package.json" }}
       - run:
@@ -166,9 +160,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: /Users/distiller/wp-desktop
-      - <<: *restore_nvm
-      - <<: *setup_nvm
-      - <<: *save_nvm
+      <<: *nvm
       - restore_cache:
           key: v1-mac-dependencies-cache-{{ checksum "package.json" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,14 @@ references:
         set +u
         set +x
         NODE_VERSION=$(cat calypso/.nvmrc)
-        export NVM_DIR="$HOME/.nvm"
+        export NVM_DIR="${HOME}/.nvm"
+        mkdir -p "$NVM_DIR"
 
         if [ ! -f "${NVM_DIR}/nvm.sh" ]; then
           curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
         fi
 
-        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+        [ -s "${NVM_DIR}/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
         nvm install "$NODE_VERSION"
         nvm alias default "$NODE_VERSION"
         nvm use "$NODE_VERSION"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,9 @@ references:
   restore_nvm: &restore_nvm
     restore_cache:
       name: Restoring NVM cache
-      key: v1-nvm-0.33.11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
-      key: v1-nvm-0.33.11-{{ arch }}
+      keys:
+        - nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+        - nvm-0-33-11-{{ arch }}
   setup_nvm: &setup_nvm
     run:
       name: Install nvm and calypso node version
@@ -27,7 +28,7 @@ references:
   save_nvm: &save_nvm
     save_cache:
       name: Saving NVM cache
-      key: v1-nvm-0.33.11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+      key: nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
       paths:
         - ~/.nvm
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ setup_nvm: &nvm
 
       [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
       nvm install "$NODE_VERSION"
+      nvm alias default "$NODE_VERSION"
       nvm use "$NODE_VERSION"
   save_cache:
     name: Saving NVM cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,30 @@
 # YAML merge tags
-nvm: &nvm
+setup_nvm: &nvm
+  restore_cache:
+    name: Restoring NVM cache
+    key: v1-nvm-0.33.11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+    key: v1-nvm-0.33.11-{{ arch }}
   run:
     name: Install nvm and calypso node version
     command: |
-            set +e
-            NODE_VERSION=$(cat calypso/.nvmrc)
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
+      set +e
+      set +u
+      set +x
+      NODE_VERSION=$(cat calypso/.nvmrc)
+      export NVM_DIR="$HOME/.nvm"
 
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+      if [ ! -f "${NVM_DIR}/nvm.sh" ]; then
+        curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+      fi
 
-            nvm install $(cat calypso/.nvmrc)
+      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+      nvm install "$NODE_VERSION"
+      nvm use "$NODE_VERSION"
+  save_cache:
+    name: Saving NVM cache
+    key: v1-nvm-0.33.11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+    paths:
+      - ~/.nvm
 
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,12 @@
 version: 2
 
 references:
-  nvm: &nvm
+  restore_nvm: &restore_nvm
     restore_cache:
       name: Restoring NVM cache
       key: v1-nvm-0.33.11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
       key: v1-nvm-0.33.11-{{ arch }}
+  setup_nvm: &setup_nvm
     run:
       name: Install nvm and calypso node version
       command: |
@@ -23,6 +24,7 @@ references:
         nvm install "$NODE_VERSION"
         nvm alias default "$NODE_VERSION"
         nvm use "$NODE_VERSION"
+  save_nvm: &save_nvm
     save_cache:
       name: Saving NVM cache
       key: v1-nvm-0.33.11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
@@ -48,7 +50,9 @@ jobs:
                     git fetch;
                     git checkout ${CALYPSO_HASH};
                   fi
-      <<: *nvm
+      - *restore_nvm
+      - *setup_nvm
+      - *save_nvm
       - run:
           name: Decrypt assets
           command: |
@@ -117,7 +121,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: /wp-desktop
-      <<: *nvm
+      - *restore_nvm
+      - *setup_nvm
+      - *save_nvm
       - restore_cache:
           key: v1-win-linux-dependencies-cache-{{ checksum "package.json" }}
       - run:
@@ -160,7 +166,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: /Users/distiller/wp-desktop
-      <<: *nvm
+      - *restore_nvm
+      - *setup_nvm
+      - *save_nvm
       - restore_cache:
           key: v1-mac-dependencies-cache-{{ checksum "package.json" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,36 @@
-# YAML merge tags
-setup_nvm: &nvm
-  restore_cache:
-    name: Restoring NVM cache
-    key: v1-nvm-0.33.11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
-    key: v1-nvm-0.33.11-{{ arch }}
-  run:
-    name: Install nvm and calypso node version
-    command: |
-      set +e
-      set +u
-      set +x
-      NODE_VERSION=$(cat calypso/.nvmrc)
-      export NVM_DIR="$HOME/.nvm"
-
-      if [ ! -f "${NVM_DIR}/nvm.sh" ]; then
-        curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
-      fi
-
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm install "$NODE_VERSION"
-      nvm alias default "$NODE_VERSION"
-      nvm use "$NODE_VERSION"
-  save_cache:
-    name: Saving NVM cache
-    key: v1-nvm-0.33.11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
-    paths:
-      - ~/.nvm
-
 version: 2
+
+references:
+  restore_nvm: &restore_nvm
+    restore_cache:
+      name: Restoring NVM cache
+      key: v1-nvm-0.33.11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+      key: v1-nvm-0.33.11-{{ arch }}
+  setup_nvm: &setup_nvm
+    run:
+      name: Install nvm and calypso node version
+      command: |
+        set +e
+        set +u
+        set +x
+        NODE_VERSION=$(cat calypso/.nvmrc)
+        export NVM_DIR="$HOME/.nvm"
+
+        if [ ! -f "${NVM_DIR}/nvm.sh" ]; then
+          curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+        fi
+
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+        nvm install "$NODE_VERSION"
+        nvm alias default "$NODE_VERSION"
+        nvm use "$NODE_VERSION"
+  save_nvm: &save_nvm
+    save_cache:
+      name: Saving NVM cache
+      key: v1-nvm-0.33.11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+      paths:
+        - ~/.nvm
+
 jobs:
   build:
     macos:


### PR DESCRIPTION
Cache nvm and node install on CircleCI

Should speed things up!

(Observation, not part of this PR) It would be nice to avoid the source and `nvm use` for every command:
- https://discuss.circleci.com/t/how-to-add-a-path-to-path-in-circle-2-0/11554/3
- https://discuss.circleci.com/t/sourcing-bash-file-before-every-run-command/13467