### PR TITLE
Fix RCE in Electron Windows

### DIFF
--- a/desktop-config/config-base.json
+++ b/desktop-config/config-base.json
@@ -30,7 +30,8 @@
 		"skipTaskbar": true,
 		"title": "Preferences",
 		"useContentSize": true,
-		"width": 480
+		"width": 480,
+		"wpDragAndDropDisabled": true
 	},
 	"aboutWindow": {
 		"acceptFirstMouse": true,
@@ -41,7 +42,8 @@
 		"skipTaskbar": true,
 		"title": "About WordPress.com",
 		"useContentSize": true,
-		"width": 300
+		"width": 300,
+		"wpDragAndDropDisabled": true
 	},
 	"secretWindow": {
 		"acceptFirstMouse": true,
@@ -52,7 +54,11 @@
 		"resizable": false,
 		"skipTaskbar": true,
 		"transparent": true,
-		"width": "full"
+		"width": "full",
+		"webPreferences": {
+			"nodeIntegration": false
+		},
+		"wpDragAndDropDisabled": true
 	},
 	"crash_reporter": false,
 	"updater": false,
@@ -65,6 +71,7 @@
 		"proxy-url": "socks5://localhost",
 		"proxy-port": "8080",
 		"proxy-pac": "",
-		"spellcheck-enabled": false
+		"spellcheck-enabled": false,
+		"wpDragAndDropDisabled": true
 	}
 }

--- a/desktop/lib/window-manager/index.js
+++ b/desktop/lib/window-manager/index.js
@@ -79,6 +79,13 @@ function openWindow( windowName ) {
 			windows[windowName].handle.on( 'closed', function() {
 				windows[windowName].handle = null;
 			} );
+
+			if ( Config[settings.config].wpDragAndDropDisabled ) {
+				windows[windowName].handle.webContents.on( 'will-navigate', function( event ) {
+					event.preventDefault();
+					return false;
+				} );
+			}
 		} else {
 			settings.handle.show();
 		}

--- a/desktop/lib/window-manager/index.js
+++ b/desktop/lib/window-manager/index.js
@@ -80,6 +80,8 @@ function openWindow( windowName ) {
 				windows[windowName].handle = null;
 			} );
 
+			// TODO: add a check to disable navigation events only for drag & drop
+			// https://github.com/Automattic/wp-desktop/pull/464#discussion_r198071749
 			if ( Config[settings.config].wpDragAndDropDisabled ) {
 				windows[windowName].handle.webContents.on( 'will-navigate', function( event ) {
 					event.preventDefault();


### PR DESCRIPTION
Greetings! I come from https://github.com/Automattic/simplenote-electron where I've recently fixed a vulnerability related to dragging and dropping content into electron windows that could execute remote code. This app is also similarly vulnerable, but only for secondary windows (not the main app window).

I've added a new config property that will allow us to disable drag and drop (or any window navigation action at all), and enabled it for the windows in the app that were exposed to this (About, Preferences, Secret and Wapuu). I have also disabled node integration on the `secretWindow`, because as far as I can tell it didn't need it.

**To Test**
1. Start the app, open the preferences window.
2. Drag something into the window (url, image, pdf, etc).
3. Nothing should happen 🤪
4. Verify that drag and drop still works in the post editor to add media or other acceptable content.