### PR TITLE
Try bashrc file for shared setup

### DIFF
--- a/.circleci/bashrc
+++ b/.circleci/bashrc
@@ -1,5 +1,5 @@
 export NVM_DIR="${HOME}/.nvm"
 [ -s "${NVM_DIR}/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-[ type "nvm" ] && nvm use
+type nvm > /dev/null && nvm use
 
 set -o errexit

--- a/.circleci/bashrc
+++ b/.circleci/bashrc
@@ -1,0 +1,5 @@
+export NVM_DIR="${HOME}/.nvm"
+[ -s "${NVM_DIR}/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ type "nvm" ] && nvm use
+
+set -o errexit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,7 @@ jobs:
           name: Release cleanup
           command: |
                   rm -rf release/github
+                  exit 1;
                   rm -rf release/mac
       - persist_to_workspace:
           root: /Users/distiller/wp-desktop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,7 @@ jobs:
           command: |
                   rm -rf release/github
                   rm -rf release/win-unpacked
+                  exit 1;
                   rm -rf release/win-ia32-unpacked/
                   rm -rf release/linux-unpacked
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,6 @@ jobs:
           name: Release cleanup
           command: |
                   rm -rf release/github
-                  exit 1;
                   rm -rf release/mac
       - persist_to_workspace:
           root: /Users/distiller/wp-desktop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,6 @@ jobs:
                   git submodule init
                   git submodule update
 
-                  exit 1;
-
                   if [ -n "${CALYPSO_HASH}" ]; then
                     cd calypso;
                     git fetch;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,6 @@ jobs:
           command: |
                   rm -rf release/github
                   rm -rf release/win-unpacked
-                  exit 1;
                   rm -rf release/win-ia32-unpacked/
                   rm -rf release/linux-unpacked
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,8 @@ references:
     run:
       name: Install nvm and calypso node version
       command: |
-        set +e
-        set +u
-        set +x
+        set -o nounset
         NODE_VERSION=$(cat calypso/.nvmrc)
-        export NVM_DIR="${HOME}/.nvm"
         mkdir -p "$NVM_DIR"
 
         if [ ! -f "${NVM_DIR}/nvm.sh" ]; then
@@ -48,6 +45,8 @@ references:
 
 jobs:
   build:
+    environment:
+      BASH_ENV: ".circleci/bashrc"
     macos:
       xcode: "9.0"
     shell: /bin/bash --login
@@ -78,8 +77,6 @@ jobs:
       - run:
           name: Npm install
           command: |
-            source $HOME/.nvm/nvm.sh
-            nvm use
             npm ci
             cd calypso
             npm ci
@@ -87,10 +84,6 @@ jobs:
       - run:
           name: Build sources
           command: |
-                  set +e
-                  source $HOME/.nvm/nvm.sh
-                  nvm use
-
                   # only use the updater when we are building from master or a release branch
                   # if [[ $CIRCLE_BRANCH =~ ^release(.*)|(^master$) ]]
                   # then
@@ -107,13 +100,9 @@ jobs:
       - run:
           name: Test
           command: |
-                  set +e
-
                   # At this stage, we can only do canary tests when CONFIG_ENV=test as the electron binary is not signed
                   # TODO: We might be able to ignore this once we switched to electron-builders auto-update
                   if [ -n "${CALYPSO_HASH}" ]; then
-                    source $HOME/.nvm/nvm.sh
-                    nvm use
                     make test
                   fi
       - persist_to_workspace:
@@ -131,6 +120,8 @@ jobs:
   win-and-linux:
     docker:
       - image: electronuserland/builder:wine-mono
+    environment:
+      BASH_ENV: ".circleci/bashrc"
     working_directory: /wp-desktop
     steps:
       - checkout
@@ -142,23 +133,16 @@ jobs:
       - *npm_restore_cache
       - run:
           name: Npm install
-          command: |
-            source $HOME/.nvm/nvm.sh
-            nvm use
-            npm ci
+          command: npm ci
       - *npm_save_cache
       - run:
           name: Build Windows & Linux
           environment:
             CSC_LINK: resource/certificates/win.p12
-          command: |
-                  source $HOME/.nvm/nvm.sh
-                  nvm use
-                  make package BUILD_PLATFORM=wl
+          command: make package BUILD_PLATFORM=wl
       - run:
           name: Release cleanup
           command: |
-                  set +e
                   rm -rf release/github
                   rm -rf release/win-unpacked
                   rm -rf release/win-ia32-unpacked/
@@ -171,6 +155,8 @@ jobs:
   mac:
     macos:
       xcode: "9.0"
+    environment:
+      BASH_ENV: ".circleci/bashrc"
     shell: /bin/bash --login
     working_directory: /Users/distiller/wp-desktop
     steps:
@@ -183,31 +169,20 @@ jobs:
       - *npm_restore_cache
       - run:
           name: Npm install
-          command: |
-            source $HOME/.nvm/nvm.sh
-            nvm use
-            npm ci
+          command: npm ci
       - *npm_save_cache
       - run:
           name: Build Mac
           environment:
             CSC_LINK: resource/certificates/mac.p12
             CSC_FOR_PULL_REQUEST: true # don't do this in production
-          command: |
-                  set +e
-                  source $HOME/.nvm/nvm.sh
-                  nvm use
-                  make package BUILD_PLATFORM=m
+          command: make package BUILD_PLATFORM=m
       - run:
           name: Test
-          command: |
-                  source $HOME/.nvm/nvm.sh
-                  nvm use
-                  make test TEST_PRODUCTION_BINARY=true
+          command: make test TEST_PRODUCTION_BINARY=true
       - run:
           name: Release cleanup
           command: |
-                  set +e
                   rm -rf release/github
                   rm -rf release/mac
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,6 @@ references:
     run:
       name: Install nvm and calypso node version
       command: |
-        set -o nounset
-        NODE_VERSION=$(cat calypso/.nvmrc)
         mkdir -p "$NVM_DIR"
 
         if [ ! -f "${NVM_DIR}/nvm.sh" ]; then
@@ -20,6 +18,8 @@ references:
         fi
 
         [ -s "${NVM_DIR}/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+        NODE_VERSION=$(cat calypso/.nvmrc)
         nvm install "$NODE_VERSION"
         nvm alias default "$NODE_VERSION"
         nvm use "$NODE_VERSION"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,8 @@ jobs:
                   git submodule init
                   git submodule update
 
+                  exit 1;
+
                   if [ -n "${CALYPSO_HASH}" ]; then
                     cd calypso;
                     git fetch;


### PR DESCRIPTION
We can clean up CI a bit by setting up the environment in a consistent way from a shared file. `.circleci/bashrc` will be executed by the shells on startup.

- Set errexit (ensure multi-line commands don't swallow errors)
- Setup and export `$NVM_DIR`
- Source `${NVM_DIR}/nvm.sh`
- nvm use (if nvm exists)

Provide desired setup for all steps via shared file. See https://discuss.circleci.com/t/sourcing-bash-file-before-every-run-command/13467

cc: @adlk 