### PR TITLE
Cache calypso

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ references:
       paths:
         - ~/.npm
   calypso_cache_paths: &calypso_cache_paths
-    - calypso-cached-hash
+    - calypso-hash
     - build
     - resource/certificates
     - calypso/public
@@ -59,7 +59,6 @@ references:
     run:
       name: Prepare calypso cache
       command: |
-              # touch calypso-cached-hash
               git rev-parse @:./calypso > calypso-current-hash
   calypso_restore_cache: &calypso_restore_cache
     restore_cache:
@@ -70,8 +69,8 @@ references:
     run:
       name: Finalize calypso cache
       command: |
-              if [ "$(cat calypso-current-hash)" != "$(cat calypso-cached-hash)" ]; then
-                cp calypso-current-hash calypso-cached-hash
+              if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
+                cp calypso-current-hash calypso-hash
               fi
   calypso_save_cache: &calypso_save_cache
     save_cache:
@@ -106,7 +105,7 @@ jobs:
       - run:
           name: Decrypt assets
           command: |
-                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-cached-hash)" ]; then
+                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
                     openssl aes-256-cbc -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
                     openssl aes-256-cbc -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
                     openssl aes-256-cbc -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
@@ -115,7 +114,7 @@ jobs:
       - run:
           name: Npm install
           command: |
-                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-cached-hash)" ]; then
+                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
                     source $HOME/.nvm/nvm.sh
                     nvm use
                     npm ci
@@ -127,7 +126,7 @@ jobs:
           name: Build sources
           command: |
                   # only build calypso when there is no calypso-hash file
-                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-cached-hash)" ]; then
+                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
                     set +e
                     source $HOME/.nvm/nvm.sh
                     nvm use

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,12 @@ references:
     run:
       name: Prepare calypso cache
       command: |
-              git rev-parse @:./calypso > calypso-current-hash
+              if [ -n "${CALYPSO_HASH}" ]; then
+                # cache bust e2e tests
+                uuidgen > calypso-current-hash
+              else 
+                git rev-parse @:./calypso > calypso-current-hash
+              fi
   calypso_restore_cache: &calypso_restore_cache
     restore_cache:
       name: Restore calypso cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,13 +45,8 @@ references:
       key: v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
       paths:
         - ~/.npm
-  calypso_restore_cache: &calypso_restore_cache
-    restore_cache:
-      name: Restore calypso cache
-      keys:
-        - v1-calypso-{{ arch }}-{{ checksum "calypso-hash" }}
   calypso_cache_paths: &calypso_cache_paths
-    - calypso-hash
+    - calypso-cached-hash
     - build
     - resource/certificates
     - calypso/public
@@ -64,11 +59,24 @@ references:
     run:
       name: Prepare calypso cache
       command: |
-              git rev-parse @:./calypso > calypso-hash
+              # touch calypso-cached-hash
+              git rev-parse @:./calypso > calypso-current-hash
+  calypso_restore_cache: &calypso_restore_cache
+    restore_cache:
+      name: Restore calypso cache
+      keys:
+        - v1-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
+  calypso_finalize_cache: &calypso_finalize_cache
+    run:
+      name: Finalize calypso cache
+      command: |
+              if [ "$(cat calypso-current-hash)" != "$(cat calypso-cached-hash)" ]; then
+                cp calypso-current-hash calypso-cached-hash
+              fi
   calypso_save_cache: &calypso_save_cache
     save_cache:
       name: Save calypso cache
-      key: v1-calypso-{{ arch }}-{{ checksum "calypso-hash" }}
+      key: v1-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
       paths: *calypso_cache_paths
 
 jobs:
@@ -79,27 +87,26 @@ jobs:
     working_directory: /Users/distiller/wp-desktop
     steps:
       - checkout
-      - *calypso_restore_cache
       - run:
           name: Setup calypso
           command: |
-                  if [ ! -f ./calypso-hash ]; then
-                    git submodule init
-                    git submodule update
+                  git submodule init
+                  git submodule update
 
-                    if [ -n "${CALYPSO_HASH}" ]; then
-                      cd calypso;
-                      git fetch;
-                      git checkout ${CALYPSO_HASH};
-                    fi
+                  if [ -n "${CALYPSO_HASH}" ]; then
+                    cd calypso;
+                    git fetch;
+                    git checkout ${CALYPSO_HASH};
                   fi
+      - *calypso_prepare_cache
+      - *calypso_restore_cache
       - *restore_nvm
       - *setup_nvm
       - *save_nvm
       - run:
           name: Decrypt assets
           command: |
-                  if [ ! -f ./calypso-hash ]; then
+                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-cached-hash)" ]; then
                     openssl aes-256-cbc -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
                     openssl aes-256-cbc -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
                     openssl aes-256-cbc -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
@@ -108,7 +115,7 @@ jobs:
       - run:
           name: Npm install
           command: |
-                  if [ ! -f ./calypso-hash ]; then
+                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-cached-hash)" ]; then
                     source $HOME/.nvm/nvm.sh
                     nvm use
                     npm ci
@@ -120,7 +127,7 @@ jobs:
           name: Build sources
           command: |
                   # only build calypso when there is no calypso-hash file
-                  if [ ! -f ./calypso-hash ]; then
+                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-cached-hash)" ]; then
                     set +e
                     source $HOME/.nvm/nvm.sh
                     nvm use
@@ -151,7 +158,7 @@ jobs:
                     nvm use
                     make test
                   fi
-      - *calypso_prepare_cache
+      - *calypso_finalize_cache
       - *calypso_save_cache
       - persist_to_workspace:
           root: /Users/distiller/wp-desktop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ jobs:
       - run:
           name: Build sources
           command: |
+                  # only build calypso when there is no calypso-hash file
                   if [ ! -f ./calypso-hash ]; then
                     set +e
                     source $HOME/.nvm/nvm.sh
@@ -130,7 +131,6 @@ jobs:
                     #   CONFIG_ENV=release
                     # fi
 
-                    # only build calypso when there is no calypso-hash file
                     CONFIG_ENV=release # TODO: update accordingly when code from above changes
 
                     if [ -n "${CALYPSO_HASH}" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ references:
       key: v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
       paths:
         - ~/.npm
-  calypso_cache_paths: &calypso_cache_paths
+  app_cache_paths: &app_cache_paths
     - calypso-hash
     - build
     - resource/certificates
@@ -81,7 +81,7 @@ references:
     save_cache:
       name: Save calypso cache
       key: v1-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
-      paths: *calypso_cache_paths
+      paths: *app_cache_paths
 
 jobs:
   build:
@@ -119,10 +119,11 @@ jobs:
       - run:
           name: Npm install
           command: |
+                  source $HOME/.nvm/nvm.sh
+                  nvm use
+                  npm ci
+                  
                   if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
-                    source $HOME/.nvm/nvm.sh
-                    nvm use
-                    npm ci
                     cd calypso
                     npm ci
                   fi
@@ -130,25 +131,30 @@ jobs:
       - run:
           name: Build sources
           command: |
-                  # only build calypso when there is no calypso-hash file
+                  # only use the updater when we are building from master or a release branch
+                  # if [[ $CIRCLE_BRANCH =~ ^release(.*)|(^master$) ]]
+                  # then
+                  #   CONFIG_ENV=release
+                  # fi
+
+                  # TODO: update accordingly when code from above changes
+                  CONFIG_ENV=release
+
+                  # only build the whole bundle when there is no calypso-hash file
                   if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
                     set +e
                     source $HOME/.nvm/nvm.sh
                     nvm use
 
-                    # only use the updater when we are building from master or a release branch
-                    # if [[ $CIRCLE_BRANCH =~ ^release(.*)|(^master$) ]]
-                    # then
-                    #   CONFIG_ENV=release
-                    # fi
-
-                    CONFIG_ENV=release # TODO: update accordingly when code from above changes
 
                     if [ -n "${CALYPSO_HASH}" ]; then
                       CONFIG_ENV=test
                     fi
 
                     make build-source CONFIG_ENV=$CONFIG_ENV
+                  else
+                    make build-config CONFIG_ENV=$CONFIG_ENV
+                    make build-desktop
                   fi
       - run:
           name: Test
@@ -166,7 +172,7 @@ jobs:
       - *calypso_save_cache
       - persist_to_workspace:
           root: /Users/distiller/wp-desktop
-          paths: *calypso_cache_paths
+          paths: *app_cache_paths
 
   win-and-linux:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,16 +79,19 @@ jobs:
     working_directory: /Users/distiller/wp-desktop
     steps:
       - checkout
+      - *calypso_restore_cache
       - run:
           name: Setup calypso
           command: |
-                  git submodule init
-                  git submodule update
+                  if [ ! -f ./calypso-hash ]; then
+                    git submodule init
+                    git submodule update
 
-                  if [ -n "${CALYPSO_HASH}" ]; then
-                    cd calypso;
-                    git fetch;
-                    git checkout ${CALYPSO_HASH};
+                    if [ -n "${CALYPSO_HASH}" ]; then
+                      cd calypso;
+                      git fetch;
+                      git checkout ${CALYPSO_HASH};
+                    fi
                   fi
       - *restore_nvm
       - *setup_nvm
@@ -96,34 +99,38 @@ jobs:
       - run:
           name: Decrypt assets
           command: |
-                  openssl aes-256-cbc -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                  openssl aes-256-cbc -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                  openssl aes-256-cbc -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                  if [ ! -f ./calypso-hash ]; then
+                    openssl aes-256-cbc -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                    openssl aes-256-cbc -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                    openssl aes-256-cbc -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                  fi
       - *npm_restore_cache
       - run:
           name: Npm install
           command: |
-            source $HOME/.nvm/nvm.sh
-            nvm use
-            npm ci
-            cd calypso
-            npm ci
+                  if [ ! -f ./calypso-hash ]; then
+                    source $HOME/.nvm/nvm.sh
+                    nvm use
+                    npm ci
+                    cd calypso
+                    npm ci
+                  fi
       - *npm_save_cache
       - run:
           name: Build sources
           command: |
-                  set +e
-                  source $HOME/.nvm/nvm.sh
-                  nvm use
-
-                  # only use the updater when we are building from master or a release branch
-                  # if [[ $CIRCLE_BRANCH =~ ^release(.*)|(^master$) ]]
-                  # then
-                  #   CONFIG_ENV=release
-                  # fi
-
-                  # only build calypso when there is no calypso-hash file
                   if [ ! -f ./calypso-hash ]; then
+                    set +e
+                    source $HOME/.nvm/nvm.sh
+                    nvm use
+
+                    # only use the updater when we are building from master or a release branch
+                    # if [[ $CIRCLE_BRANCH =~ ^release(.*)|(^master$) ]]
+                    # then
+                    #   CONFIG_ENV=release
+                    # fi
+
+                    # only build calypso when there is no calypso-hash file
                     CONFIG_ENV=release # TODO: update accordingly when code from above changes
 
                     if [ -n "${CALYPSO_HASH}" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,31 @@ references:
       key: v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
       paths:
         - ~/.npm
+  calypso_restore_cache: &calypso_restore_cache
+    restore_cache:
+      name: Restore calypso cache
+      keys:
+        - v1-calypso-{{ arch }}-{{ checksum "calypso-hash" }}
+  calypso_cache_paths: &calypso_cache_paths
+    - calypso-hash
+    - build
+    - resource/certificates
+    - calypso/public
+    - calypso/server
+    - calypso/config
+    - calypso/package.json
+    - calypso/npm-shrinkwrap.json
+    - calypso/.nvmrc
+  calypso_prepare_cache: &calypso_prepare_cache
+    run:
+      name: Prepare calypso cache
+      command: |
+              git rev-parse @:./calypso > calypso-hash
+  calypso_save_cache: &calypso_save_cache
+    save_cache:
+      name: Save calypso cache
+      key: v1-calypso-{{ arch }}-{{ checksum "calypso-hash" }}
+      paths: *calypso_cache_paths
 
 jobs:
   build:
@@ -97,13 +122,16 @@ jobs:
                   #   CONFIG_ENV=release
                   # fi
 
-                  CONFIG_ENV=release # TODO: update accordingly when code from above changes
+                  # only build calypso when there is no calypso-hash file
+                  if [ ! -f ./calypso-hash ]; then
+                    CONFIG_ENV=release # TODO: update accordingly when code from above changes
 
-                  if [ -n "${CALYPSO_HASH}" ]; then
-                    CONFIG_ENV=test
+                    if [ -n "${CALYPSO_HASH}" ]; then
+                      CONFIG_ENV=test
+                    fi
+
+                    make build-source CONFIG_ENV=$CONFIG_ENV
                   fi
-
-                  make build-source CONFIG_ENV=$CONFIG_ENV
       - run:
           name: Test
           command: |
@@ -116,17 +144,11 @@ jobs:
                     nvm use
                     make test
                   fi
+      - *calypso_prepare_cache
+      - *calypso_save_cache
       - persist_to_workspace:
           root: /Users/distiller/wp-desktop
-          paths:
-            - build
-            - resource/certificates
-            - calypso/public
-            - calypso/server
-            - calypso/config
-            - calypso/package.json
-            - calypso/npm-shrinkwrap.json
-            - calypso/.nvmrc
+          paths: *calypso_cache_paths
 
   win-and-linux:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,11 +122,8 @@ jobs:
                   source $HOME/.nvm/nvm.sh
                   nvm use
                   npm ci
-                  
-                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
-                    cd calypso
-                    npm ci
-                  fi
+                  cd calypso
+                  npm ci
       - *npm_save_cache
       - run:
           name: Build sources


### PR DESCRIPTION
### Description:
Introduce a caching strategy for calypso bundles as they can be shared between wp-desktop builds.

### Motivation and Context:
Every time we make changes with the desktop app, we do a complete calypso rebuild that takes 5+ minutes even though calypso did not change at all for at least 95% of all builds. (Not counting e2e)
