### PR TITLE
Match 10.5.0 and v10.5.0 node versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,10 @@ secret-clientid:
 	fi;
 
 
-CALYPSO_NODE_VERSION := $(shell cat calypso/.nvmrc)
-CURRENT_NODE_VERSION := $(shell node -v)
+# Sed to strip leading v to ensure 'v1.2.3' and '1.2.3' can match.
+# The .nvmrc file may contain either, `node --version` prints with 'v' prefix.
+CALYPSO_NODE_VERSION := $(shell cat calypso/.nvmrc | sed -n 's/v\{0,1\}\(.*\)/\1/p')
+CURRENT_NODE_VERSION := $(shell node --version | sed -n 's/v\{0,1\}\(.*\)/\1/p')
 
 # Check that the current node & npm versions are the versions Calypso expects to ensure it is built safely.
 check-node-version-parity:


### PR DESCRIPTION
The `.nvmrc` file in Calypso _may_ be any version-ish string that nvm understands (lts/*, v10.5.0, v10…).

It happens that the Renovate bot, handling deps updates, uses `10.5.0` rather than `v10.5.0`, which is what `node --version` prints.

See p1531231208000023-slack-wordpress-desktop and https://github.com/Automattic/wp-calypso/pull/25951/commits/70f5862718e2a04784137650364718fd8fa96c97

This mismatch is incompatible with the existing logic.

Add small, portable (🤞) `sed` to smooth over the `v`/no-`v` divergance.

## Testing
1. Checkout this branch
1. Check your local node version `node --version`
1. `git submodule update --init`
1. Look at calypso .nvmrc `cat calypso/.nvmrc`
1. Use `make check-node-version-parity` and ensure it report correct pass/fail.
1. Adjust the string in `calypso/.nvmrc` and repeat `make check-node-version-parity`, ensuring different strings pass/fail as expected. Here are some suggestions:
   - `10.5.0`
   - `10.6.0`
   - `gibberish`
   - `v10.5.0`
   - `v10.6.0`
   - empty
   - `vgibberish`
   