### PR TITLE
Upgrade Babel to 7.0.0 beta 53

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	presets: [
+		[ '@babel/env', { targets: { electron: '1.8.4' } } ],
+		'@babel/react'
+	],
+	plugins: [
+		'@babel/plugin-proposal-class-properties'
+	]
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,28 +46,131 @@
       }
     },
     "@babel/core": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.44.tgz",
-      "integrity": "sha512-E16ps55Av+GAO6qVTZeVR5FMVppraUPjiJEHuH0sANsbmkEjqQ70XQiv0KXPYbPzHBd+gijx6uLakSacjvtwIA==",
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.53.tgz",
+      "integrity": "sha1-q2R8+7JyQf0i7DyhNC161Oa1T58=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/generator": "7.0.0-beta.44",
-        "@babel/helpers": "7.0.0-beta.44",
-        "@babel/template": "7.0.0-beta.44",
-        "@babel/traverse": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
+        "@babel/code-frame": "7.0.0-beta.53",
+        "@babel/generator": "7.0.0-beta.53",
+        "@babel/helpers": "7.0.0-beta.53",
+        "@babel/parser": "7.0.0-beta.53",
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53",
         "convert-source-map": "^1.1.0",
         "debug": "^3.1.0",
         "json5": "^0.5.0",
-        "lodash": "^4.2.0",
+        "lodash": "^4.17.5",
         "micromatch": "^2.3.11",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+          "integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.5",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+          "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.53",
+            "@babel/template": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+          "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+          "integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+          "integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/generator": "7.0.0-beta.53",
+            "@babel/helper-function-name": "7.0.0-beta.53",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -76,6 +179,24 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -112,6 +233,471 @@
         }
       }
     },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.53.tgz",
+      "integrity": "sha1-WZYGKDdcvu+WoH7f4co4t1bwGqg=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.53.tgz",
+      "integrity": "sha1-RFZwliPX2vqivulPglUD9MDs6Fs=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-builder-react-jsx": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.53.tgz",
+      "integrity": "sha1-e9fn419EOf03NfAC5hIyGGv5zs8=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.53",
+        "esutils": "^2.0.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.53.tgz",
+      "integrity": "sha1-ld6Lq9A/nmz08rVkoDhwjBOP/jE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0-beta.53",
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+          "integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.5",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+          "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.53",
+            "@babel/template": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+          "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+          "integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+          "integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/generator": "7.0.0-beta.53",
+            "@babel/helper-function-name": "7.0.0-beta.53",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.53.tgz",
+      "integrity": "sha1-SOniJlRTeHl1BD76qx7a0jnqlpU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53",
+        "lodash": "^4.17.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+          "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.53",
+            "@babel/template": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+          "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.53.tgz",
+      "integrity": "sha1-1bytK2tH9ATAruillk3/2TEkc6g=",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+          "integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.5",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+          "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.53",
+            "@babel/template": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+          "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+          "integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+          "integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/generator": "7.0.0-beta.53",
+            "@babel/helper-function-name": "7.0.0-beta.53",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
     "@babel/helper-function-name": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
@@ -132,6 +718,579 @@
         "@babel/types": "7.0.0-beta.44"
       }
     },
+    "@babel/helper-hoist-variables": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.53.tgz",
+      "integrity": "sha1-TCfjuHP6CcWtbpPrQHBMIA+EE3w=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.53.tgz",
+      "integrity": "sha1-D7Dviy07kD0cO/Qm2kp0V14BnOQ=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.53.tgz",
+      "integrity": "sha1-5zXmqjClBLD52Fw4ptRwqfSqgdk=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.53",
+        "lodash": "^4.17.5"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.53.tgz",
+      "integrity": "sha1-e6IUzcyPhiPy0Xl96v8f80mqzhM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.53",
+        "@babel/helper-simple-access": "7.0.0-beta.53",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53",
+        "lodash": "^4.17.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+          "integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.53.tgz",
+      "integrity": "sha1-j8eO9MD2n4uzu980zSMsIBIEFMg=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.53.tgz",
+      "integrity": "sha1-1kRYY2/8JYtCcUqd2Trrb4uM8+0=",
+      "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.53.tgz",
+      "integrity": "sha1-bp0hl7Vid54iVWWUaumoXCFbIl4=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.53.tgz",
+      "integrity": "sha1-uDSnVy3sF2OJ/6x+djV5WGSQySI=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.53",
+        "@babel/helper-wrap-function": "7.0.0-beta.53",
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+          "integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.5",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+          "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.53",
+            "@babel/template": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+          "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+          "integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+          "integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/generator": "7.0.0-beta.53",
+            "@babel/helper-function-name": "7.0.0-beta.53",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.53.tgz",
+      "integrity": "sha1-M5tb3BAilElbGifFWBMjBuG3vKc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "7.0.0-beta.53",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.53",
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+          "integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.5",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+          "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.53",
+            "@babel/template": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+          "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+          "integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+          "integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/generator": "7.0.0-beta.53",
+            "@babel/helper-function-name": "7.0.0-beta.53",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.53.tgz",
+      "integrity": "sha1-cvbbmr5C+GgfpvAo79WdgVRHUrM=",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53",
+        "lodash": "^4.17.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
     "@babel/helper-split-export-declaration": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
@@ -141,15 +1300,303 @@
         "@babel/types": "7.0.0-beta.44"
       }
     },
-    "@babel/helpers": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.44.tgz",
-      "integrity": "sha512-7qXsqiaMZzVuI0dobFGa9dQhCd6Y19lGeu4HrFHJo13/y9NKngepg/CYMzBi79TacKeaWfJNj3TeVCyRtfZqUg==",
+    "@babel/helper-wrap-function": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.53.tgz",
+      "integrity": "sha1-q/sr+pQBBCurJXwBkPWtbbjfFdU=",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.44",
-        "@babel/traverse": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44"
+        "@babel/helper-function-name": "7.0.0-beta.53",
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+          "integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.5",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+          "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.53",
+            "@babel/template": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+          "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+          "integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+          "integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/generator": "7.0.0-beta.53",
+            "@babel/helper-function-name": "7.0.0-beta.53",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.53.tgz",
+      "integrity": "sha1-xDb/uOCTAU2olba7d5f/RuPRzM8=",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.0.0-beta.53",
+        "@babel/traverse": "7.0.0-beta.53",
+        "@babel/types": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+          "integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.5",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+          "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.53",
+            "@babel/template": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+          "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+          "integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+          "integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/generator": "7.0.0-beta.53",
+            "@babel/helper-function-name": "7.0.0-beta.53",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "@babel/highlight": {
@@ -161,6 +1608,887 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+      "integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+      "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.53.tgz",
+      "integrity": "sha1-XFnvZm0Xwn3LVoa3XsMr622MUNY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.53",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.53.tgz",
+      "integrity": "sha1-Jou4wNUKjqkeXIHgOtDNPMnNyVc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.53",
+        "@babel/helper-member-expression-to-functions": "7.0.0-beta.53",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-replace-supers": "7.0.0-beta.53",
+        "@babel/plugin-syntax-class-properties": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+          "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.53",
+            "@babel/template": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+          "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.53.tgz",
+      "integrity": "sha1-5rXwusUBg48W6PPG00sAs+pANdk=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.53.tgz",
+      "integrity": "sha1-i6DVywtncv66DwxY5u1+oj/S8gI=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.53.tgz",
+      "integrity": "sha1-YAlUHdmG6OsKkKJRFSMAEQLn3EM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-regex": "7.0.0-beta.53",
+        "regexpu-core": "^4.2.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regenerate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+          "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+          "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^7.0.0",
+            "regjsgen": "^0.4.0",
+            "regjsparser": "^0.3.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.0.2"
+          }
+        },
+        "regjsgen": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+          "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+          "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.53.tgz",
+      "integrity": "sha1-gpvvbxUBeentC7lDM58qMSM6qSE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.53.tgz",
+      "integrity": "sha1-DGc/Om5RkvyAJ7ws9Nv69w37/3I=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.53.tgz",
+      "integrity": "sha1-IjzIl3IzOcsiCqghbGVQhv60U5g=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.53.tgz",
+      "integrity": "sha1-nb12jD8QnwKyT7oXNllp+iXrRYw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.53.tgz",
+      "integrity": "sha1-pc9szGqrNp/CyleuH0pjs9w4Jes=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.53.tgz",
+      "integrity": "sha1-p19fqEl6rBcp0DO/QcJQQWudHgQ=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.53.tgz",
+      "integrity": "sha1-REx2HMQhXJeptVb/WMp7p99dQVM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.53.tgz",
+      "integrity": "sha1-CkMiGhsMkM1NCfG0a5Wd0khlf3M=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.53.tgz",
+      "integrity": "sha1-nv1uUMofo5jcqnEZYh2j8fu4IbY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "lodash": "^4.17.5"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.53.tgz",
+      "integrity": "sha1-XcLsMb8emAZqzfDEiHt3RMFL7G4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.53",
+        "@babel/helper-define-map": "7.0.0-beta.53",
+        "@babel/helper-function-name": "7.0.0-beta.53",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-replace-supers": "7.0.0-beta.53",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+          "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.53",
+            "@babel/template": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+          "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+          "integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.53.tgz",
+      "integrity": "sha1-l0fiYIKulO2lMPmNLCBZ6NLbwAU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.53.tgz",
+      "integrity": "sha1-DwrbDhptzTWjZkEBYJ7AYv8SenY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.53.tgz",
+      "integrity": "sha1-TEZHMaRf8Fm36TOsdswFzHBlGkA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-regex": "7.0.0-beta.53",
+        "regexpu-core": "^4.1.3"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regenerate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+          "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+          "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^7.0.0",
+            "regjsgen": "^0.4.0",
+            "regjsparser": "^0.3.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.0.2"
+          }
+        },
+        "regjsgen": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+          "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+          "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.53.tgz",
+      "integrity": "sha1-D1WZE6v6GCOcpOCPc+7DbF5XuB8=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.53.tgz",
+      "integrity": "sha1-PiZxeSBMd1GdhBepsZnyUiIejZU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.53.tgz",
+      "integrity": "sha1-+gZSFeGFacj3TdUktXIeEdzKlzs=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.53.tgz",
+      "integrity": "sha1-Kzpbs2TB4cV+zL/iXGv1XygEET4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+          "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+          "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.53",
+            "@babel/template": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+          "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+          "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+          "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.53",
+            "@babel/parser": "7.0.0-beta.53",
+            "@babel/types": "7.0.0-beta.53",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.53.tgz",
+      "integrity": "sha1-vsTxROmpbvUSHRQwx+vl/QiGV8k=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.53.tgz",
+      "integrity": "sha1-WFTXOeZ5IzqId8C0GCaca+t6Miw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.53.tgz",
+      "integrity": "sha1-68P7ocWmyHQ7kJQD7NPn42gcr6U=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-simple-access": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.53.tgz",
+      "integrity": "sha1-uA/NnBWXLcaCMhT1JIUnhgu/BY4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.53.tgz",
+      "integrity": "sha1-Kjar5AodpnbkOhwwcVeOJ70tZ50=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.53.tgz",
+      "integrity": "sha1-m3Sz1TtOhUzw42DwLCpEAwccagE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.53.tgz",
+      "integrity": "sha1-4sTwbts0s9eksnV7oYgp0N8gKcs=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-replace-supers": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.53.tgz",
+      "integrity": "sha1-7+YM7IzsoNGdXG+hrnm8TjMnnVY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "7.0.0-beta.53",
+        "@babel/helper-get-function-arity": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      },
+      "dependencies": {
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+          "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.53"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+          "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.53.tgz",
+      "integrity": "sha1-HOBO/1fsC/atM+9obPUStj2TxL4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.53.tgz",
+      "integrity": "sha1-ZYC3v2Zl8UyFgrn8JmygHwDgoEc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-react-jsx": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.53.tgz",
+      "integrity": "sha1-bKmIVSa0ETbr/H8HlJ4Qiz7e+LY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.53.tgz",
+      "integrity": "sha1-1XYFUD3AcVTnuj5pPYr/ry1P8DY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/plugin-syntax-jsx": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.53.tgz",
+      "integrity": "sha1-T+u/YISvoMHJ7ISX3mjAaV/p2gs=",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.13.3"
+      },
+      "dependencies": {
+        "regenerator-transform": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+          "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+          "dev": true,
+          "requires": {
+            "private": "^0.1.6"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.53.tgz",
+      "integrity": "sha1-38SIG2vXZYoAMew7gWPliPCJjUs=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.53.tgz",
+      "integrity": "sha1-g+j2Rsok8cmCKPnxREz2DL1JOLw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.53.tgz",
+      "integrity": "sha1-D888mUq92Lq1m6l4L+TZ+KVF1uc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-regex": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.53.tgz",
+      "integrity": "sha1-+msLQXEA0j4tsUwd9HorGzl48dk=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.53.tgz",
+      "integrity": "sha1-ZarocamqQPYRSDZlcxIJrr1cKis=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.53.tgz",
+      "integrity": "sha1-CvdOyAGefVnji+ZNt/YikZQv7SU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/helper-regex": "7.0.0-beta.53",
+        "regexpu-core": "^4.1.3"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regenerate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+          "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+          "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^7.0.0",
+            "regjsgen": "^0.4.0",
+            "regjsparser": "^0.3.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.0.2"
+          }
+        },
+        "regjsgen": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+          "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+          "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.53.tgz",
+      "integrity": "sha1-KyBL9CZ14WbdpaJ1bEHrvyKbs34=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.53",
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.53",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.53",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.53",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.53",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.53",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.53",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.53",
+        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.53",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.53",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.53",
+        "@babel/plugin-transform-block-scoping": "7.0.0-beta.53",
+        "@babel/plugin-transform-classes": "7.0.0-beta.53",
+        "@babel/plugin-transform-computed-properties": "7.0.0-beta.53",
+        "@babel/plugin-transform-destructuring": "7.0.0-beta.53",
+        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.53",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.53",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.53",
+        "@babel/plugin-transform-for-of": "7.0.0-beta.53",
+        "@babel/plugin-transform-function-name": "7.0.0-beta.53",
+        "@babel/plugin-transform-literals": "7.0.0-beta.53",
+        "@babel/plugin-transform-modules-amd": "7.0.0-beta.53",
+        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.53",
+        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.53",
+        "@babel/plugin-transform-modules-umd": "7.0.0-beta.53",
+        "@babel/plugin-transform-new-target": "7.0.0-beta.53",
+        "@babel/plugin-transform-object-super": "7.0.0-beta.53",
+        "@babel/plugin-transform-parameters": "7.0.0-beta.53",
+        "@babel/plugin-transform-regenerator": "7.0.0-beta.53",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.53",
+        "@babel/plugin-transform-spread": "7.0.0-beta.53",
+        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.53",
+        "@babel/plugin-transform-template-literals": "7.0.0-beta.53",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.53",
+        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.53",
+        "browserslist": "^3.0.0",
+        "invariant": "^2.2.2",
+        "js-levenshtein": "^1.1.3",
+        "semver": "^5.3.0"
+      }
+    },
+    "@babel/preset-react": {
+      "version": "7.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-beta.53.tgz",
+      "integrity": "sha1-OSBoKDClyu9cAZeAKCV4UliXCJw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+        "@babel/plugin-transform-react-display-name": "7.0.0-beta.53",
+        "@babel/plugin-transform-react-jsx": "7.0.0-beta.53",
+        "@babel/plugin-transform-react-jsx-self": "7.0.0-beta.53",
+        "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.53"
       }
     },
     "@babel/template": {
@@ -2296,6 +4624,16 @@
         "pako": "~1.0.5"
       }
     },
+    "browserslist": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
+      }
+    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -2584,6 +4922,12 @@
           "dev": true
         }
       }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000865",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz",
+      "integrity": "sha512-vs79o1mOSKRGv/1pSkp4EXgl4ZviWeYReXw60XfacPU64uQWZwJT6vZNmxRF9O+6zu71sJwMxLK5JXxbzuVrLw==",
+      "dev": true
     },
     "capture-stack-trace": {
       "version": "1.0.0",
@@ -4564,6 +6908,12 @@
           "dev": true
         }
       }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.52",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz",
+      "integrity": "sha1-0tnxJwuko7lnuDHEDvcftNmrXOA=",
+      "dev": true
     },
     "electron-window": {
       "version": "0.8.1",
@@ -7619,6 +9969,12 @@
         "topo": "2.x.x"
       }
     },
+    "js-levenshtein": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.3.tgz",
+      "integrity": "sha512-/812MXr9RBtMObviZ8gQBhHO8MOrGj8HlEE+4ccMTElNA/6I3u39u+bhny55Lk921yn44nSZFy9naNLElL5wgQ==",
+      "dev": true
+    },
     "js-stringify": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
@@ -10221,6 +12577,23 @@
       "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
       "dev": true
     },
+    "regenerate-unicode-properties": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+      "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      },
+      "dependencies": {
+        "regenerate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+          "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+          "dev": true
+        }
+      }
+    },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -12028,6 +14401,34 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+      "dev": true
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "wordpress.com"
   ],
   "devDependencies": {
-    "@babel/core": "7.0.0-beta.44",
+    "@babel/core": "7.0.0-beta.53",
+    "@babel/plugin-proposal-class-properties": "7.0.0-beta.53",
+    "@babel/preset-env": "7.0.0-beta.53",
+    "@babel/preset-react": "7.0.0-beta.53",
     "asar": "^0.11.0",
     "babel-eslint": "8.2.2",
     "babel-loader": "8.0.0-beta.2",


### PR DESCRIPTION
This patch upgrades Babel to 7.0.0 beta 53 and adds a `babel.config.js` file.

The config file uses Babel Env Preset to specify a compilation target (Electron) and is used to compile the `wp-desktop` files and also the `calypso/server` ones that are included by `desktop/server/server.js`.

With `babel.config.js`, Babel will no longer load `calypso/.babelrc.js`, so the desired config needs to be specified by the parent project.

This patch is a prerequisite to upgrading Babel in Calypso, too (Automattic/wp-calypso#26020)

**How to test:**
The risk is that after the upgrade the build process will output some JS syntax or use some JS builtins that are not yet supported by Electron. Therefore, almost anything can break.
