### PR TITLE
Bring webpack plugins section in sync with wp-calypso

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2343,6 +2343,11 @@
       "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
       "dev": true
     },
+    "buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -11060,23 +11065,15 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
       "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       },
       "dependencies": {
-        "buffer-from": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-          "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "lodash.debounce": "4.0.8",
     "portscanner": "1.2.0",
     "pug": "2.0.0-rc.4",
+    "source-map-support": "0.5.6",
     "spellchecker": "3.4.3",
     "superagent": "1.8.5"
   },

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -1,12 +1,16 @@
 /**
  * External Dependencies
  */
-var path = require( 'path' );
-var webpack = require( 'webpack' );
-var fs = require('fs');
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+
+const config = require( 'config' );
+const bundleEnv = config( 'env' );
+
+const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
 
 module.exports = {
-	target: 'node',
+	target: 'electron-main',
 	module: {
 		rules: [
 			{
@@ -61,16 +65,21 @@ module.exports = {
 		]
 	},
 	plugins: [
+		new webpack.BannerPlugin( {
+			banner: 'require( "source-map-support" ).install();',
+			raw: true,
+			entryOnly: false,
+		} ),
+		new webpack.DefinePlugin( {
+			PROJECT_NAME: JSON.stringify( config( 'project' ) ),
+			COMMIT_SHA: JSON.stringify( commitSha ),
+			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
+		} ),
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]abtest$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]analytics$/, 'lodash/noop' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]sites-list$/, 'lodash/noop' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]olark$/, 'lodash/noop' ), // Depends on DOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]user$/, 'lodash/noop' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]post-normalizer[\/\\]rule-create-better-excerpt$/, 'lodash/noop' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^components[\/\\]seo[\/\\]reader-preview$/, 'components/empty-component' ), // Conflicts with component-closest module
 		new webpack.NormalModuleReplacementPlugin( /^components[\/\\]popover$/, 'components/null-component' ), // Depends on BOM and interactions don't work without JS
 		new webpack.NormalModuleReplacementPlugin( /^my-sites[\/\\]themes[\/\\]theme-upload$/, 'components/empty-component' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^client[\/\\]layout[\/\\]guided-tours[\/\\]config$/, 'components/empty-component' ), // should never be required server side
-		new webpack.NormalModuleReplacementPlugin( /^components[\/\\]site-selector$/, 'components/null-component' ), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^matches-selector$/, 'component-matches-selector' ), // Required as this module is not compiled for browser target
 	],
 };


### PR DESCRIPTION
### Description

Webpack plugins in `webpack.shared.js` should be in sync with the calypso webpack config.

### Additional Note

As webpack is using the `browser` key from the package.json of dependencies for the `web` target, we run into the issue that the module `matches-selector` can't be found as it's actually `component-matches-selector` for non-web targets.

We can work around that issue by adding the following line but it might be a common trap to fall into in the future.
```js
new webpack.NormalModuleReplacementPlugin( /^matches-selector$/, 'component-matches-selector' ), // Required as this module is not compiled for browser target

```
