### PR TITLE
Fix: Make dev-server doesn't use `CONFIG_ENV`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,15 @@ start:
 dev-server: CONFIG_ENV = development
 dev-server: CALYPSO_ENV = desktop-development
 dev-server: NODE_ENV = development
-dev-server: checks desktop$/config.json
+dev-server: checks
 	@echo "\n\n$(GREEN)+------------------------------------------------+"
 	@echo "|                                                |"
 	@echo "|    Wait for calypso to start the dev server    |"
 	@echo "|       and start the app with \`make dev\`        |"
 	@echo "|                                                |"
 	@echo "+------------------------------------------------+$(RESET)\n\n"
+
+	$(MAKE) desktop$/config.json CONFIG_ENV=$(CONFIG_ENV)
 
 	@npx concurrently -k \
 	-n "Calypso,Desktop" \


### PR DESCRIPTION
### Description:
The make `dev-server` target isn't correctly passing `CONFIG_ENV` to the `desktop/config.json` target. When running `make dev` this results in the app rendering just a white screen as it's looking for `http://127.0.0.1:41050` instead of `http://calypso.localhost:3000`.

### Motivation and Context:
This PR closes #484