### PR TITLE
Fix: check for valid secret only when creating a release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,10 @@ checks: check-node-version-parity secret
 # Check for secret and confirm proper clientid for production release
 secret:
 ifneq (,$(wildcard $(CALYPSO_DIR)$/config$/secrets.json))
+ifeq (release,$(CONFIG_ENV))
 ifneq (43452,$(shell node -p "require('$(CALYPSO_DIR)$/config$/secrets.json').desktop_oauth_client_id"))
 	$(error "desktop_oauth_client_id" must be "43452" in $(CALYPSO_DIR)$/config$/secrets.json)
+endif
 endif
 else 
 	$(error $(CALYPSO_DIR)$/config$/secrets.json does not exist)


### PR DESCRIPTION
### Description:
In #467 the secrets check has been simplified which leads to an error when not using the official wp.com client id.

This PR is changing the secrets check to fail only when `CONFIG_ENV` is `release` and the secret is not the official wp.com  client id.

### How to test:
- In `calypso/config/secrets.json` change `desktop_oauth_client_id` to eg. `12345`.
- Run `make build CONFIG_ENV=release` and the build should fail.
- Change `desktop_oauth_client_id` to `43452`.
- Run `make build CONFIG_ENV=release` and the build should succeed.

### Motivation and Context:
This PR closes #483