### PR TITLE
Makefile: Fix typo in build-sources .PHONY target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,4 +162,4 @@ clean:
 	@rm -rf .$/release
 	@rm -rf .$/build
 
-.PHONY: test build-sources
+.PHONY: test build-source


### PR DESCRIPTION
The target is named `build-source` (singular, not plural)
