### PR TITLE
Add ADDRESS_UNREACHABLE to ignored error codes

### DIFF
--- a/desktop/window-handlers/failed-to-load/index.js
+++ b/desktop/window-handlers/failed-to-load/index.js
@@ -24,6 +24,7 @@ const FAILED_FILE = 'file://' + assets.getPath( FAIL_TO_LOAD_FILE );
 const ERRORS_TO_IGNORE = [
 	-3,     // ABORTED
 	-102,   // CONNECTION_REFUSED
+	-109,   // ADDRESS_UNREACHABLE
 	-502,   // NO_PRIVATE_KEY_FOR_CERT
 	-501,   // INSECURE_RESPONSE
 ];
@@ -65,6 +66,8 @@ function failedToLoadError( mainWindow ) {
 	}
 }
 
+// TODO: evaluate if this is still the way to go to handle requests.
+// @adlk: Keep in mind that every request, even the ones we do not control (e.g. atomic- or self hosted sites), might cause the app to "soft-crash" even though the user experience might not be affected directly by some requests that fail.
 module.exports = function( mainWindow ) {
 	// This attempts to catch some network errors and display an error screen in order to avoid a blank white page
 	mainWindow.webContents.on( 'did-fail-load', function( event, errorCode, errorDescription ) {


### PR DESCRIPTION
### Description
This PR is adds the `109` error code for `ADDRESS_UNREACHABLE` to the list ignored errors. 

### Motivation and Context
closes #493 

### How Has This Been Tested:
- Easiest way to test this is with an atomic site that runs on a custom domain. Let's go with `foo.blog` for now
- Block every request to `foo.blog` with e.g. little snitch
- Launch the app in dev mode
- Select `foo.blog` in "My Sites"
- Go to "View Site"
- Pre PR: you will be redirected to the _Uh oh!_-error site
- This PR: calypso you won't be redirected to the _Uh oh!_-error site

### General note
I doubt that we should have such a strict request handling, especially since we hardly can differentiate between requests that fail that we care about and the ones we don't care about. Plus, a request that fails doesn't necessarily break the whole app. Anyhow, I need to do more research on this one.