### PR TITLE
Summer clean up party ☀️🗑

### DIFF
--- a/desktop/lib/cookie-auth/index.js
+++ b/desktop/lib/cookie-auth/index.js
@@ -103,7 +103,7 @@ function setSessionCookies( window, onComplete ) {
 	};
 }
 
-function auth( window, onAuthorized ) {
+function auth( window ) {
 	var userData, currentRequest;
 
 	ipc.on( 'user-auth', function( event, user, token ) {
@@ -113,7 +113,7 @@ function auth( window, onAuthorized ) {
 				// already authing
 				return;
 			}
-			currentRequest = authorize( userData.username, token ).on( 'response', setSessionCookies( window, onAuthorized ) );
+			currentRequest = authorize( userData.username, token ).on( 'response', setSessionCookies( window ) );
 		} else {
 			// retrieve all cookies
 			window.webContents.session.cookies.get( {}, function( e, cookies ) {

--- a/desktop/server/index.js
+++ b/desktop/server/index.js
@@ -43,9 +43,7 @@ function showAppWindow() {
 
 	mainWindow = new BrowserWindow( config );
 
-	cookieAuth( mainWindow, function() {
-		mainWindow.webContents.send( 'cookie-auth-complete' );
-	} );
+	cookieAuth( mainWindow );
 
 	mainWindow.webContents.on( 'did-finish-load', function() {
 		mainWindow.webContents.send( 'app-config', Config, Settings.isDebug(), System.getDetails() );
@@ -53,8 +51,7 @@ function showAppWindow() {
 		const ipc = electron.ipcMain;
 		ipc.on( 'mce-contextmenu', function( ev ) {
 			mainWindow.send( 'mce-contextmenu', ev );
-		});
-
+		} );
 	} );
 
 	mainWindow.webContents.session.webRequest.onBeforeRequest( function( details, callback ) {
@@ -70,7 +67,7 @@ function showAppWindow() {
 		// always allow previews to be loaded in iframes
 		if ( details.resourceType === 'subFrame' ) {
 			const headers = Object.assign( {}, details.responseHeaders );
-			Object.keys( headers ).forEach( function ( name ) {
+			Object.keys( headers ).forEach( function( name ) {
 				if ( name.toLowerCase() === 'x-frame-options' ) {
 					delete headers[ name ];
 				}

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -120,21 +120,22 @@ try {
 	});
 	
 	electron.ipcRenderer.on( 'app-config', function( event, config, debug, details ) {
+	electron.ipcRenderer.on( 'app-config', function( event, config, isDebug, details ) {
 		// if this is the first run, and on the login page, show Windows and Mac users a pin app reminder
-		if ( details.firstRun && document.querySelectorAll( '.logged-out-auth' ).length > 0 ) {
+		if ( details.firstRun && document.querySelectorAll( '.is-section-auth' ).length > 0 ) {
 			if ( details.platform === 'windows' || details.platform === 'darwin' ) {
-				var container = document.querySelector( '#wpcom' );
-				var pinApp = container.querySelector( '.pin-app' );
+				const container = document.querySelector( '#wpcom' );
+				let pinApp = container.querySelector( '.pin-app' );
 
 				if ( ! pinApp ) {
-					var node = document.createElement( 'div' );
+					const node = document.createElement( 'div' );
 					node.className = 'pin-app';
 					container.appendChild( node );
 					pinApp = container.querySelector( '.pin-app' );
 				}
 
-				var closeButton = '<a href="#" class="pin-app-close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M17.705,7.705l-1.41-1.41L12,10.59L7.705,6.295l-1.41,1.41L10.59,12l-4.295,4.295l1.41,1.41L12,13.41 l4.295,4.295l1.41-1.41L13.41,12L17.705,7.705z"/></svg></a>';
-				var pinAppMsg = '';
+				const closeButton = '<a href="#" class="pin-app-close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M17.705,7.705l-1.41-1.41L12,10.59L7.705,6.295l-1.41,1.41L10.59,12l-4.295,4.295l1.41,1.41L12,13.41 l4.295,4.295l1.41-1.41L13.41,12L17.705,7.705z"/></svg></a>';
+				let pinAppMsg = '';
 
 				if ( details.platform === 'windows' ) {
 					pinAppMsg = '<h2>Keep WordPress.com in your taskbar</h2>' +
@@ -149,7 +150,7 @@ try {
 				pinApp.innerHTML = closeButton + pinAppMsg;
 
 				// close button
-				var pinAppClose = container.querySelector( '.pin-app-close' );
+				const pinAppClose = container.querySelector( '.pin-app-close' );
 				pinAppClose.onclick = function() {
 					pinApp.style.display = 'none';
 				};

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -37,18 +37,6 @@ function startDesktopApp() {
 		showWarning( 'Unable to connect to WordPress.com. <button onclick="document.location.reload()">Try again?</button>' );
 	}
 
-	function postCalypso() {
-		// Ensure the dock notification badge is cleared immediatley when notification icon is clicked
-		// The iframe postMessage can be delayed
-		var notIcon = document.querySelector( '#header li.notifications a' );
-
-		if ( notIcon ) {
-			notIcon.addEventListener( 'click', function() {
-				electron.ipcRenderer.send( 'unread-notices-count', 0 );
-			} );
-		}
-	}
-
 	function calysoHasLoaded() {
 		return document.getElementById( 'content' );
 	}
@@ -58,8 +46,6 @@ function startDesktopApp() {
 			if ( ! calysoHasLoaded() ) {
 				showNoCalypso();
 				checkForCalypso();
-			} else {
-				postCalypso();
 			}
 		}, 5000 );
 	}
@@ -117,9 +103,7 @@ function startDesktopApp() {
 		if ( navigator.onLine ) {
 			startCalypso();
 
-			if ( calysoHasLoaded() ) {
-				postCalypso();
-			} else {
+			if ( !calysoHasLoaded() ) {
 				checkForCalypso();
 			}
 		} else {

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -115,11 +115,10 @@ function startDesktopApp() {
 // Wrap this in an exception handler. If it fails then it means Electron is not present, and we are in a browser
 // This will then cause the browser to redirect to hey.html
 try {
-	electron.ipcRenderer.on('is-calypso', function () {
-		electron.ipcRenderer.send('is-calypso-response', document.getElementById('wpcom') !== null);
-	});
-	
-	electron.ipcRenderer.on( 'app-config', function( event, config, debug, details ) {
+	electron.ipcRenderer.on( 'is-calypso', function() {
+		electron.ipcRenderer.send( 'is-calypso-response', document.getElementById( 'wpcom' ) !== null );
+	} );
+
 	electron.ipcRenderer.on( 'app-config', function( event, config, isDebug, details ) {
 		// if this is the first run, and on the login page, show Windows and Mac users a pin app reminder
 		if ( details.firstRun && document.querySelectorAll( '.is-section-auth' ).length > 0 ) {


### PR DESCRIPTION
### Description
The main purpose of this PR is to remove not longer used code and fix features that technically exist but aren't called any longer due to changes in calypso. 

### Motivation and Context
Make wp-desktop easierererer to maintain.

### Todos:
- [x] Remove deprecated click handler for clearing dock badge ([fixed and handled in calypso](https://github.com/Automattic/wp-calypso/pull/26697))
- [x] Remove not longer used `cookieAuth` callback. – This actually caused an error in calypsos `lib/desktop/index.js` when booting the app.
- [x] Fix ~~or Remove~~ "Add to Dock/Taskbar" notification bubble on first run
- tbc (feel free to add your own)