### PR TITLE
Add .eslintrc extension

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
 	"parser": "babel-eslint",
 	"env": {
 		"browser": true,


### PR DESCRIPTION
### Description:
Add .js extension to .eslintrc file, changing content to a js export module, given it has comments, which are not allowed in JSON format.

### Motivation and Context:
.eslintrc without extension is deprecated (https://eslint.org/docs/user-guide/configuring#configuration-file-formats).

### How Has This Been Tested:
Testing not deemed necessary

### Screenshots (if appropriate):
None

### Todos:
None
