### PR TITLE
Ignore SASS/CSS imports when building desktop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "3.3.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4325,7 +4325,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -7178,9 +7178,9 @@
       }
     },
     "event-kit": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-2.5.0.tgz",
-      "integrity": "sha512-tUDxeNC9JzN2Tw/f8mLtksY34v1hHmaR7lV7X4p04XSjaeUhFMfzjF6Nwov9e0EKGEx63BaKcgXKxjpQaPo0wg=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-2.5.1.tgz",
+      "integrity": "sha512-frzENdbgPE8VQwBhMXWC8U7/qs80HpENLp4/QA8dhltAhQUuBJVgRn9HOjTF9BVpqqTvx3pScK9rm3oRBooTFA=="
     },
     "events": {
       "version": "1.1.1",
@@ -9232,6 +9232,12 @@
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
+    "ignore-loader": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ignore-loader/-/ignore-loader-0.1.2.tgz",
+      "integrity": "sha1-2B8kA3bQuk8Nd4lyw60lh0EXpGM=",
+      "dev": true
+    },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
@@ -11151,9 +11157,9 @@
       }
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
     },
     "nanomatch": {
       "version": "1.2.9",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "electron-rebuild": "1.8.2",
     "eslint": "^2.10.2",
     "eslint-plugin-react": "^5.1.1",
+    "ignore-loader": "0.1.2",
     "json-loader": "^0.5.4",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -29,6 +29,10 @@ module.exports = {
 				test: /\.jsx?$/,
 				loader: 'babel-loader',
 				exclude: /node_modules/
+			},
+			{
+				test: /\.(sc|sa|c)ss$/,
+				loader: 'ignore-loader'
 			}
 		]
 	},


### PR DESCRIPTION
Server build doesn't need to process any CSS imports -- that's only for Calypso client build. Fixed build errors in Automattic/wp-calypso#26820.
