### PR TITLE
Update electron to 1.7.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2579,9 +2579,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "7.0.66",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.66.tgz",
-      "integrity": "sha512-W11u5kUNSX2+N6bJ7rPyLW4N98/xzrZg8apRoTwC0zbFjIie//oxgKAvqkQNQ97KVchB49ost74kgzoeDiE+Uw==",
+      "version": "7.0.70",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.70.tgz",
+      "integrity": "sha512-bAcW/1aM8/s5iFKhRpu/YJiQf/b1ZwnMRqqsWRCmAqEDQF2zY8Ez3Iu9AcZKFKc3vCJc8KJVpJ6Pn54sJ1BvXQ==",
       "dev": true
     },
     "abbrev": {
@@ -4325,7 +4325,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6079,9 +6079,9 @@
       "dev": true
     },
     "electron": {
-      "version": "1.7.15",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.15.tgz",
-      "integrity": "sha512-2NCG4sgrZOtQ6/Uvy94Pig7d+JOxpLdfeD42HODtPFaoJS8PMtnPSBvOqFn/fDlG3/IzvuvsCIIuzP5FgojhPg==",
+      "version": "1.7.16",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.16.tgz",
+      "integrity": "sha512-k17+2K3hny6g1etWMkWvzEL06yapZGpqG66O3e5vxfzeHT3FgqrNa3xRF7znjaqvWQmmEdGFdSktQADjUZ0gog==",
       "dev": true,
       "requires": {
         "@types/node": "^7.0.18",
@@ -6930,9 +6930,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
       "dev": true
     },
     "es6-set": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chalk": "2.3.1",
     "check-node-version": "3.2.0",
     "concurrently": "3.5.1",
-    "electron": "1.7.15",
+    "electron": "1.7.16",
     "electron-builder": "20.16.3",
     "electron-mocha": "2.3.1",
     "electron-packager": "^7.0.2",


### PR DESCRIPTION
Maintenance PR to update electron to 1.7.16 to fix a critical issue.

New in 1.7.16:
> Fixed webPreferences inheritance issue. CVE-2018-15685