### PR TITLE
Enable google social login

### DIFF
--- a/desktop/window-handlers/external-links/index.js
+++ b/desktop/window-handlers/external-links/index.js
@@ -3,7 +3,7 @@
 /**
  * External Dependencies
  */
-const shell = require( 'electron' ).shell;
+const { shell } = require( 'electron' );
 const debug = require( 'debug' )( 'desktop:external-links' );
 const { URL } = require( 'url' );
 
@@ -30,7 +30,8 @@ const ALWAYS_OPEN_IN_APP = [
 
 const DONT_OPEN_IN_BROWSER = [
 	Config.server_url,
-	'https://public-api.wordpress.com/connect/'
+	'https://public-api.wordpress.com/connect/',
+	'https://accounts.google.com/*',
 ];
 
 const domainAndPathSame = ( first, second ) => first.hostname === second.hostname && ( first.pathname === second.pathname || second.pathname === '/*' );


### PR DESCRIPTION
This PR enables users to login with their connected google account and depends on https://github.com/Automattic/wp-calypso/pull/27685

### How to test:
* Run `git submodule init` and `git submodule update` 
* Follow the [wp-desktop development instructions](https://github.com/Automattic/wp-desktop/blob/develop/docs/development.md#starting-the-app) (`make dev-server` and `make-dev`)
* Login with your connected google account

Closes #506