### PR TITLE
Add stalebot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,44 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 365 # 1 year
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: -1 # Close the issue almost immediately. See: https://github.com/probot/stale/issues/131
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - "[Pri] High"
+  - "[Pri] BLOCKER"
+  - "OSS Citizen"
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Label to use when marking as stale
+staleLabel: "[Status] Stale"
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  <p>This issue has been marked as stale and will be automatically closed. 
+  This happened because:</p>
+  
+  <ul>
+    <li>It has been inactive for the past year.</li>
+    <li>It isn't in a project or a milestone.</li>
+    <li>It hasn’t been labeled `[Pri] BLOCKER`, `[Pri] High`, or `OSS Citizen`.</li>
+  </ul>
+  
+  <p>However, discussion is still welcome! If the issue is still valid, 
+  please leave a comment with a brief explanation so the issue can
+  be reopened.</p>
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 2
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
This PR adds a config so we can start using the [Stale Probot](https://github.com/probot/stale) to help manage issues in the repo.

This config:
- Marks an issue (only issues, not PRs at this point) as stale if it hasn’t had any activity in the past year (365 days) and closes the issue within about an hour.
- Adds the label `[Status] Stale`.
- Leaves a comment explaining what that means and how to proceed if the issue is still valid.
- Ignores these issues (they won’t be marked stale or closed):
 - High priority/blocking issues (labels `[Pri] High` and `[Pri] BLOCKER`)
 - Issues opened by OSS Citizens (label `OSS Citizen`)
 - Issues in a milestone or project