### PR TITLE
Implement electron-updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ publish/publish-config.js
 publish/node_modules/
 resource/secrets
 build
+dev-app-update.yml

--- a/desktop-config/config-development.json
+++ b/desktop-config/config-development.json
@@ -5,7 +5,7 @@
 	"server_url": "http://calypso.localhost",
 	"server_host": "calypso.localhost",
 	"updater": {
-		"downloadUrl": "https://github.com/Automattic/wp-desktop/releases",
+		"downloadUrl": "https://apps.wordpress.com/desktop/",
 		"apiUrl": "https://api.github.com/repos/Automattic/wp-desktop/releases",
 		"delay": 2000,
 		"interval": 600000

--- a/desktop-config/config-development.json
+++ b/desktop-config/config-development.json
@@ -4,6 +4,12 @@
 	"server_port": 3000,
 	"server_url": "http://calypso.localhost",
 	"server_host": "calypso.localhost",
+	"updater": {
+		"downloadUrl": "https://github.com/Automattic/wp-desktop/releases",
+		"apiUrl": "https://api.github.com/repos/Automattic/wp-desktop/releases",
+		"delay": 2000,
+		"interval": 600000
+	},
 	"debug": {
 		"enabled_by_default": true,
 		"namespace": "desktop:*",

--- a/desktop-config/config-release.json
+++ b/desktop-config/config-release.json
@@ -1,7 +1,7 @@
 {
 	"build": "release",
 	"updater": {
-		"downloadUrl": "https://github.com/Automattic/wp-desktop/releases",
+		"downloadUrl": "https://apps.wordpress.com/desktop/",
 		"apiUrl": "https://api.github.com/repos/Automattic/wp-desktop/releases",
 		"delay": 2000,
 		"interval": 43200000

--- a/desktop-config/config-release.json
+++ b/desktop-config/config-release.json
@@ -1,7 +1,8 @@
 {
 	"build": "release",
 	"updater": {
-		"url": "https://public-api.wordpress.com/rest/v1.1/desktop/",
+		"downloadUrl": "https://github.com/Automattic/wp-desktop/releases",
+		"apiUrl": "https://api.github.com/repos/Automattic/wp-desktop/releases",
 		"delay": 2000,
 		"interval": 43200000
 	}

--- a/desktop-config/config-updater.json
+++ b/desktop-config/config-updater.json
@@ -7,7 +7,8 @@
 		"colors": true
 	},
 	"updater": {
-		"url": "https://public-api.wordpress.com/rest/v1.1/desktop/",
+		"downloadUrl": "https://github.com/Automattic/wp-desktop/releases",
+		"apiUrl": "https://api.github.com/repos/Automattic/wp-desktop/releases",
 		"delay": 2000,
 		"interval": 600000
 	}

--- a/desktop/app-handlers/updater/auto-updater/index.js
+++ b/desktop/app-handlers/updater/auto-updater/index.js
@@ -76,6 +76,18 @@ class AutoUpdater extends Updater {
 	onConfirm() {
 		AppQuit.allowQuit();
 		autoUpdater.quitAndInstall();
+
+		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-confirm-update` );
+	}
+
+	onCancel() {
+		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-update-cancelled` );
+	}
+
+	onError( event ) {
+		debug( 'Update error', event );
+
+		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-update-error` );
 	}
 }
 

--- a/desktop/app-handlers/updater/auto-updater/index.js
+++ b/desktop/app-handlers/updater/auto-updater/index.js
@@ -36,6 +36,8 @@ class AutoUpdater extends Updater {
 		autoUpdater.on( 'update-not-available', this.onNotAvailable.bind( this ) );
 		autoUpdater.on( 'update-downloaded', this.onDownloaded.bind( this ) );
 
+		autoUpdater.autoInstallOnAppQuit = false;
+
 		if ( this.beta ) {
 			autoUpdater.allowPrerelease = true;
 		}

--- a/desktop/app-handlers/updater/auto-updater/index.js
+++ b/desktop/app-handlers/updater/auto-updater/index.js
@@ -79,17 +79,17 @@ class AutoUpdater extends Updater {
 		AppQuit.allowQuit();
 		autoUpdater.quitAndInstall();
 
-		bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-confirm` );
+		bumpStat( 'wpcom-desktop-update', `${getStatsString( this.beta )}-confirm` );
 	}
 
 	onCancel() {
-		bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-update-cancel` );
+		bumpStat( 'wpcom-desktop-update', `${getStatsString( this.beta )}-update-cancel` );
 	}
 
 	onError( event ) {
 		debug( 'Update error', event );
 
-		bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-update-error` );
+		bumpStat( 'wpcom-desktop-update', `${getStatsString( this.beta )}-update-error` );
 	}
 }
 

--- a/desktop/app-handlers/updater/auto-updater/index.js
+++ b/desktop/app-handlers/updater/auto-updater/index.js
@@ -19,6 +19,8 @@ const Updater = require( 'lib/updater' );
 const statsPlatform = getPlatform( process.platform )
 const sanitizedVersion = sanitizeVersion( app.getVersion() );
 
+const getStatsString = ( isBeta ) => `${statsPlatform}${isBeta ? '-b' : ''}-${sanitizedVersion}`;
+
 function dialogDebug( message ) {
 	debug( message );
 
@@ -50,12 +52,12 @@ class AutoUpdater extends Updater {
 
 	onAvailable( info ) {
 		debug( 'New update is available', info.version )
-		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-needs-update` );
+		bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-needs-update` );
 	}
 
 	onNotAvailable() {
 		debug( 'No update is available' )
-		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-no-update` );
+		bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-no-update` );
 	}
 
 	onDownloaded( info ) {
@@ -77,17 +79,17 @@ class AutoUpdater extends Updater {
 		AppQuit.allowQuit();
 		autoUpdater.quitAndInstall();
 
-		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-confirm-update` );
+		bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-confirm` );
 	}
 
 	onCancel() {
-		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-update-cancelled` );
+		bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-update-cancel` );
 	}
 
 	onError( event ) {
 		debug( 'Update error', event );
 
-		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-update-error` );
+		bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-update-error` );
 	}
 }
 

--- a/desktop/app-handlers/updater/auto-updater/index.js
+++ b/desktop/app-handlers/updater/auto-updater/index.js
@@ -3,9 +3,8 @@
 /**
  * External Dependencies
  */
-const electron = require( 'electron' );
-const autoUpdater = electron.autoUpdater;
-const dialog = electron.dialog;
+const { app } = require( 'electron' );
+const { autoUpdater } = require( 'electron-updater' )
 const debug = require( 'debug' )( 'desktop:updater:auto' );
 
 /**
@@ -14,6 +13,11 @@ const debug = require( 'debug' )( 'desktop:updater:auto' );
 const AppQuit = require( 'lib/app-quit' );
 const Config = require( 'lib/config' );
 const debugTools = require( 'lib/debug-tools' );
+const { bumpStat, sanitizeVersion, getPlatform } = require( 'lib/desktop-analytics' );
+const Updater = require( 'lib/updater' );
+
+const statsPlatform = getPlatform( process.platform )
+const sanitizedVersion = sanitizeVersion( app.getVersion() );
 
 function dialogDebug( message ) {
 	debug( message );
@@ -23,59 +27,54 @@ function dialogDebug( message ) {
 	}
 }
 
-function AutoUpdater( url ) {
-	debug( 'Starting auto-updater' );
+class AutoUpdater extends Updater {
+	constructor( options = {} ) {
+		super( options );
 
-	this.hasPrompted = false;
-	this.url = url;
+		autoUpdater.on( 'error', this.onError.bind( this ) );
+		autoUpdater.on( 'update-available', this.onAvailable.bind( this ) );
+		autoUpdater.on( 'update-not-available', this.onNotAvailable.bind( this ) );
+		autoUpdater.on( 'update-downloaded', this.onDownloaded.bind( this ) );
 
-	autoUpdater.setFeedURL( url );
-	autoUpdater.on( 'error', this.onError.bind( this ) );
-	autoUpdater.on( 'update-available', this.onAvailable.bind( this ) );
-	autoUpdater.on( 'update-not-available', this.onNotAvailable.bind( this ) );
-	autoUpdater.on( 'update-downloaded', this.onDownloaded.bind( this ) );
-}
-
-AutoUpdater.prototype.ping = function() {
-	dialogDebug( 'Pinging update URL ' + this.url );
-	autoUpdater.checkForUpdates();
-};
-
-AutoUpdater.prototype.onError = function( error ) {
-	dialogDebug( 'Auto-updater failed: ' + error );
-};
-
-AutoUpdater.prototype.onAvailable = function() {
-	dialogDebug( 'Update detected' );
-};
-
-AutoUpdater.prototype.onNotAvailable = function() {
-	dialogDebug( 'No update detected' );
-};
-
-AutoUpdater.prototype.onDownloaded = function( event, releaseNotes, releaseName, releaseDate, updateUrl, quitAndUpdate ) {
-	const updateDialogOptions = {
-		buttons: [ 'Update & Restart', 'Cancel' ],
-		title: 'Update Available',
-		message: releaseName,
-		detail: releaseNotes
-	};
-
-	debug( 'Updated download: ' + releaseName + ' ' + releaseNotes );
-
-	if ( this.hasPrompted === false ) {
-		this.hasPrompted = true;
-
-		dialog.showMessageBox( updateDialogOptions, function( i ) {
-			this.hasPrompted = false;
-
-			if ( i === 0 ) {
-				debug( 'Update and restart' );
-				AppQuit.allowQuit();
-				quitAndUpdate();
-			}
-		} );
+		if ( this.beta ) {
+			autoUpdater.allowPrerelease = true;
+		}
 	}
-};
+
+	ping() {
+		dialogDebug( 'Checking for update' );
+		autoUpdater.checkForUpdates();
+	}
+
+	onAvailable( info ) {
+		debug( 'New update is available', info.version )
+		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-needs-update` );
+	}
+
+	onNotAvailable() {
+		debug( 'No update is available' )
+		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-no-update` );
+	}
+
+	onDownloaded( info ) {
+		debug( 'Update downloaded', info.version );
+
+		this.setVersion( info.version );
+		this.notify();
+
+		const stats = {
+			'wpcom-desktop-download': `${statsPlatform}-app`,
+			'wpcom-desktop-download-by-ver': `${statsPlatform}-app-${sanitizedVersion}`,
+			'wpcom-desktop-download-ref': `update-${statsPlatform}-app`,
+			'wpcom-desktop-download-ref-only': 'update',
+		}
+		bumpStat( stats );
+	}
+
+	onConfirm() {
+		AppQuit.allowQuit();
+		autoUpdater.quitAndInstall();
+	}
+}
 
 module.exports = AutoUpdater;

--- a/desktop/app-handlers/updater/index.js
+++ b/desktop/app-handlers/updater/index.js
@@ -37,8 +37,8 @@ module.exports = function() {
 						dialogMessage:
 							'{name} {newVersion} is now available — you have {currentVersion}. Would you like to download it now?',
 						confirmLabel: 'Download',
+						beta,
 					},
-					beta,
 				} );
 			}
 

--- a/desktop/app-handlers/updater/index.js
+++ b/desktop/app-handlers/updater/index.js
@@ -3,50 +3,50 @@
 /**
  * External Dependencies
  */
-const electron = require( 'electron' );
-const app = electron.app;
+const { app } = require( 'electron' );
+const debug = require( 'debug' )( 'desktop:updater' );
 
 /**
  * Internal dependencies
  */
 const platform = require( 'lib/platform' );
 const Config = require( 'lib/config' );
+const settings = require( 'lib/settings' );
 const AutoUpdater = require( './auto-updater' );
 const ManualUpdater = require( './manual-updater' );
-const settings = require( 'lib/settings' );
 
 let updater = false;
 
-function urlBuilder( version, channel ) {
-	let platformString = 'osx';
-
-	if ( platform.isWindows() ) {
-		platformString = 'windows';
-	} else if ( platform.isLinux() ) {
-		platformString = 'linux';
-	}
-
-	if ( Config.isUpdater() ) {
-		version = '0.1.0';  // This forces an update so we can check the updater still works
-	}
-
-	return Config.updater.url + platformString + '/version?compare=' + version + '&channel=' + channel;
-}
-
 module.exports = function() {
+	debug( 'Updater config is', Config.updater )
 	if ( Config.updater ) {
 		app.on( 'will-finish-launching', function() {
-			let url = urlBuilder( app.getVersion(), settings.getSetting( 'release-channel' ) );
-
-			if ( platform.isOSX() ) {
-				updater = new AutoUpdater( url );
+			const beta = settings.getSetting( 'release-channel' ) === 'beta';
+			debug( 'Update channel', settings.getSetting( 'release-channel' ), beta )
+			if ( platform.isOSX() || platform.isWindows() || process.env.APPIMAGE ) {
+				debug( 'Auto Update' )
+				updater = new AutoUpdater( {
+					beta,
+				} );
 			} else {
-				updater = new ManualUpdater( url );
+				debug( 'Manual Update' )
+				updater = new ManualUpdater( {
+					downloadUrl: Config.updater.downloadUrl,
+					apiUrl: Config.updater.apiUrl,
+					options: {
+						dialogMessage:
+							'{name} {newVersion} is now available — you have {currentVersion}. Would you like to download it now?',
+						confirmLabel: 'Download',
+					},
+					beta,
+				} );
 			}
 
 			// Start one straight away
 			setTimeout( updater.ping.bind( updater ), Config.updater.delay );
 			setInterval( updater.ping.bind( updater ), Config.updater.interval );
 		} );
+	} else {
+		debug( 'Skipping Update – no configuration' )
 	}
 };

--- a/desktop/app-handlers/updater/manual-updater/index.js
+++ b/desktop/app-handlers/updater/manual-updater/index.js
@@ -18,6 +18,8 @@ const { bumpStat, sanitizeVersion, getPlatform } = require( 'lib/desktop-analyti
 const statsPlatform = getPlatform( process.platform )
 const sanitizedVersion = sanitizeVersion( app.getVersion() );
 
+const getStatsString = ( isBeta ) => `${statsPlatform}${isBeta ? '-b' : ''}-${sanitizedVersion}`;
+
 class ManualUpdater extends Updater {
 	constructor( { apiUrl, downloadUrl, options = {} } ) {
 		super( options );
@@ -75,31 +77,31 @@ class ManualUpdater extends Updater {
 						releaseConfig.version
 					);
 
-					bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-needs-update` );
+					bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-needs-update` );
 
 					this.setVersion( releaseConfig.version );
 					this.notify();
 				} else {
 					debug( 'Update is not available' );
 
-					bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-no-update` );
+					bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-no-update` );
 					return;
 				}
 			}
 		} catch ( err ) {
 			debug( err.message );
-			bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-update-check-error` );
+			bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-check-failed` );
 		}
 	}
 
 	onConfirm() {
 		shell.openExternal( `${this.downloadUrl}${this.beta ? '?beta=1' : ''}` );
 
-		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-confirm-update` );
+		bumpStat( 'wpcom-desktop-update', `${getStatsString( this.beta )}-dl-update` );
 	}
 
 	onCancel() {
-		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-update-cancelled` );
+		bumpStat( 'wpcom-desktop-update', `${getStatsString( this.beta )}-update-cancel` );
 	}
 }
 

--- a/desktop/app-handlers/updater/manual-updater/index.js
+++ b/desktop/app-handlers/updater/manual-updater/index.js
@@ -24,7 +24,6 @@ class ManualUpdater extends Updater {
 
 		this.apiUrl = apiUrl;
 		this.downloadUrl = downloadUrl;
-		this.latestReleaseTag = null;
 	}
 
 	async ping() {
@@ -75,7 +74,6 @@ class ManualUpdater extends Updater {
 						'New update is available, prompting user to update to',
 						releaseConfig.version
 					);
-					this.latestReleaseTag = releaseBody.tag_name;
 
 					bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-needs-update` );
 
@@ -95,7 +93,8 @@ class ManualUpdater extends Updater {
 	}
 
 	onConfirm() {
-		shell.openExternal( `${this.downloadUrl}${this.latestReleaseTag ? `/tag/${this.latestReleaseTag}` : ''}` );
+		shell.openExternal( `${this.downloadUrl}${this.beta ? '?beta=1' : ''}` );
+
 		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-confirm-update` );
 	}
 

--- a/desktop/app-handlers/updater/manual-updater/index.js
+++ b/desktop/app-handlers/updater/manual-updater/index.js
@@ -35,9 +35,9 @@ class ManualUpdater extends Updater {
 		};
 
 		try {
-			debug( 'is beta', this.beta )
 			const url = `${this.apiUrl}${!this.beta ? '/latest' : ''}`;
 			debug( 'Checking for update. Fetching:', url );
+			debug( 'Checking for beta release:', this.beta )
 
 			const releaseResp = await fetch( url, options );
 

--- a/desktop/app-handlers/updater/manual-updater/index.js
+++ b/desktop/app-handlers/updater/manual-updater/index.js
@@ -90,11 +90,17 @@ class ManualUpdater extends Updater {
 			}
 		} catch ( err ) {
 			debug( err.message );
+			bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-update-check-error` );
 		}
 	}
 
 	onConfirm() {
 		shell.openExternal( `${this.downloadUrl}${this.latestReleaseTag ? `/tag/${this.latestReleaseTag}` : ''}` );
+		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-confirm-update` );
+	}
+
+	onCancel() {
+		bumpStat( 'wpcom-desktop-update-check', `${statsPlatform}${this.beta ? '-beta' : ''}-${sanitizedVersion}-update-cancelled` );
 	}
 }
 

--- a/desktop/lib/desktop-analytics/README.md
+++ b/desktop/lib/desktop-analytics/README.md
@@ -1,0 +1,47 @@
+Desktop Analytics
+=========
+
+Automatticians may refer to internal documentation for more information about MC.
+
+## Usage
+
+### `analytics.bumpStat( group, name )`
+
+Bump a single WP.com stat:
+
+```js
+analytics.mc.bumpStat( 'newdash_visits', 'sites' );
+```
+
+### `analytics.bumpStat( obj )`
+
+Bump multiple WP.com stats:
+
+```js
+analytics.mc.bumpStat( {
+	'stat_name1': 'stat_value1',
+	'statname2': 'stat_value2'
+} );
+```
+
+### `analytics.sanitizeVersion( version )`
+
+Sanitizes version string for analytics. To be used for e.g. bumpStat
+
+```js
+analytics.sanitizeVersion( '3.5.0-beta.1' ); // 3-5-0-beta-1
+```
+
+### `analytics.getPlatform( platform )`
+
+Returns the analytics conform platform string for electrons `process.platform`
+
+- `darwin`: osx
+- `win32`: windows
+- `linux`: linux
+
+```js
+const platform = process.platform; // darwin
+analytics.getPlatform( platform ); // osx
+```
+

--- a/desktop/lib/desktop-analytics/index.js
+++ b/desktop/lib/desktop-analytics/index.js
@@ -1,0 +1,51 @@
+const debug = require( 'debug' )( 'desktop:analytics' );
+const fetch = require( 'electron-fetch' ).default
+
+function buildQuerystring( group, name ) {
+	let uriComponent = '';
+
+	if ( 'object' === typeof group ) {
+		for ( const key in group ) {
+			uriComponent += '&x_' + encodeURIComponent( key ) + '=' + encodeURIComponent( group[key] );
+		}
+	} else {
+		uriComponent = '&x_' + encodeURIComponent( group ) + '=' + encodeURIComponent( name );
+	}
+
+	return uriComponent;
+}
+
+export async function bumpStat( group, name ) {
+	if ( 'object' === typeof group ) {
+		debug( 'Bumping stats %o', group );
+	} else {
+		debug( 'Bumping stat %s:%s', group, name );
+	}
+
+	const uriComponent = buildQuerystring( group, name );
+	const url = `https://pixel.wp.com/g.gif?v=wpcom-no-pv${uriComponent}&t=${Math.random()}`;
+
+	const resp = await fetch( url );
+	if ( resp.status === 200 ) {
+		debug( 'Sent analytics ping' );
+	} else {
+		debug( 'Analytics ping failed', resp.status, resp.statusText );
+	}
+};
+
+// Cet analytics conform version string
+// version string needs to be formatted without `.`
+export function sanitizeVersion( version ) {
+	return version.replace( /\./g, '-' );
+}
+
+const PLATFORMS = {
+	darwin: 'osx',
+	win32: 'windows',
+	linux: 'linux',
+}
+
+// Get analytics conform platform string
+export function getPlatform( platform ) {
+	return PLATFORMS[platform];
+}

--- a/desktop/lib/desktop-analytics/index.js
+++ b/desktop/lib/desktop-analytics/index.js
@@ -6,9 +6,11 @@ function buildQuerystring( group, name ) {
 
 	if ( 'object' === typeof group ) {
 		for ( const key in group ) {
+			checkLength( key, group[key] )
 			uriComponent += '&x_' + encodeURIComponent( key ) + '=' + encodeURIComponent( group[key] );
 		}
 	} else {
+		checkLength( group, name )
 		uriComponent = '&x_' + encodeURIComponent( group ) + '=' + encodeURIComponent( name );
 	}
 
@@ -33,10 +35,11 @@ export async function bumpStat( group, name ) {
 	}
 };
 
-// Cet analytics conform version string
+// Get analytics conform version string
 // version string needs to be formatted without `.`
+// Replaces `beta` with `b` as stats key and value is limited to 32 chars
 export function sanitizeVersion( version ) {
-	return version.replace( /\./g, '-' );
+	return version.replace( /\./g, '-' ).replace( 'beta', 'b' );
 }
 
 const PLATFORMS = {
@@ -48,4 +51,14 @@ const PLATFORMS = {
 // Get analytics conform platform string
 export function getPlatform( platform ) {
 	return PLATFORMS[platform];
+}
+
+// Stats key and value is limited to 32 chars
+function checkLength( key, val ) {
+	if ( key.length > 32 ) {
+		debug( `WARNING: bumpStat() key '${key}' is longer than 32 chars` );
+	}
+	if ( val.length > 32 ) {
+		debug( `WARNING: bumpStat() value '${val}' is longer than 32 chars` );
+	}
 }

--- a/desktop/lib/updater/README.md
+++ b/desktop/lib/updater/README.md
@@ -1,0 +1,87 @@
+Updater
+=========
+
+Base class for Auto- and Manual updater. 
+
+## Options
+- **`confirmLabel`** = `Update & Restart` - Label for the confirm button of the "Update is available" dialog
+- **`dialogMessage`** = `{name} {newVersion} is now available — you have {currentVersion}. Would you like to update now?` - Message for the dialog
+- **`dialogTitle`** = `A new version of {name} is available!` - Title for the dialog
+- **`beta`** = `false` - Check for beta versions
+
+## Methods
+### `Updater.ping()`
+Checks for updates.
+
+```js
+updater.ping();
+```
+
+### `Updater.setVersion()`
+Sets the new version for the updater dialog.
+
+```js
+updater.setVersion('1.0.1');
+```
+
+### `Updater.notify()`
+
+Prompts the user with the update dialog.
+`this.onConfirm` and `this.onCancel` will be executed based on the users confirmation or cancellation.
+
+```js
+class MyUpdater extends Updater {
+  constructor( { options } ) {
+    super( options );
+  }
+
+  async ping() {
+    // check for update
+    if (true) {
+      this.setVersion('1.0.0');
+      this.notify();
+    }
+  }
+}
+```
+
+### `Updater.expandMacros( text )`
+Expands macros.
+
+Available macros are
+
+- **`name`** = `app.getName()`
+- **`currentVersion`** = `app.getVersion()`
+- **`newVersion`** = `this._version` (defined by `this.setVersion()`)
+
+
+```js
+updater.expandMacros('{name} {newVersion} is now available'); // WordPress.com 1.0.1 is now available
+```
+
+### `Updater.onConfirm()`
+
+Function that will be triggered when the user click the confirm button.
+
+```js
+class MyUpdater extends Updater {
+  onConfirm() {
+    // Download Update
+    autoUpdater.quitAndInstall();
+    // or for e.g. manual updater
+    shell.openExternal('http://...');
+  }
+}
+```
+
+### `Updater.onCancel()`
+
+Function that will be triggered when the user clicks the cancel button.
+
+```js
+class MyUpdater extends Updater {
+  onCancel() {
+    // The user has cancelled the updater
+  }
+}
+```

--- a/desktop/lib/updater/index.js
+++ b/desktop/lib/updater/index.js
@@ -1,6 +1,14 @@
-const EventEmitter = require( 'events' ).EventEmitter;
+/**
+ * External Dependencies
+ */
 const { app, dialog } = require( 'electron' );
+const { EventEmitter } = require( 'events' );
 const debug = require( 'debug' )( 'desktop:updater' );
+
+/**
+ * Internal dependencies
+ */
+const platform = require( 'lib/platform' );
 
 class Updater extends EventEmitter {
 	constructor( options ) {
@@ -42,7 +50,7 @@ class Updater extends EventEmitter {
 
 	notify() {
 		const updateDialogOptions = {
-			buttons: [this.confirmLabel, 'Cancel'],
+			buttons: [this.sanitizeButtonLabel( this.confirmLabel ), 'Cancel'],
 			title: 'Update Available',
 			message: this.expandMacros( this.dialogTitle ),
 			detail: this.expandMacros( this.dialogMessage ),
@@ -86,6 +94,14 @@ class Updater extends EventEmitter {
 		}
 
 		return text;
+	}
+
+	sanitizeButtonLabel( value ) {
+		if ( platform.isWindows() ) {
+			return value.replace( '&', '&&' );
+		}
+
+		return value;
 	}
 }
 

--- a/desktop/lib/updater/index.js
+++ b/desktop/lib/updater/index.js
@@ -1,0 +1,92 @@
+const EventEmitter = require( 'events' ).EventEmitter;
+const { app, dialog } = require( 'electron' );
+const debug = require( 'debug' )( 'desktop:updater' );
+
+class Updater extends EventEmitter {
+	constructor( options ) {
+		super();
+
+		this.confirmLabel = options.confirmLabel || 'Update & Restart';
+		this.dialogTitle =
+		options.dialogTitle || 'A new version of {name} is available!';
+		this.dialogMessage =
+		options.dialogMessage ||
+		'{name} {newVersion} is now available — you have {currentVersion}. Would you like to update now?';
+		this.beta = options.beta || false;
+
+		this._version = '';
+		this._hasPrompted = false;
+	}
+
+	ping() {}
+
+	onDownloaded( info ) {
+		debug( 'Update downloaded', info );
+	}
+
+	onAvailable( info ) {
+		debug( 'Update is available', info );
+	}
+
+	onNotAvailable( info ) {
+		debug( 'Update is not available', info );
+	}
+
+	onError( event ) {
+		debug( 'Update error', event );
+	}
+
+	onConfirm() {}
+
+	onCancel() {}
+
+	notify() {
+		const updateDialogOptions = {
+			buttons: [this.confirmLabel, 'Cancel'],
+			title: 'Update Available',
+			message: this.expandMacros( this.dialogTitle ),
+			detail: this.expandMacros( this.dialogMessage ),
+		};
+
+		if ( !this._hasPrompted ) {
+			this._hasPrompted = true;
+
+			dialog.showMessageBox( updateDialogOptions, button => {
+				this._hasPrompted = false;
+
+				if ( button === 0 ) {
+					// Confirm
+					this.onConfirm();
+				} else {
+					this.onCancel();
+				}
+
+				this.emit( 'end' );
+			} );
+		}
+	}
+
+	setVersion( version ) {
+		this._version = version;
+	}
+
+	expandMacros( originalText ) {
+		const macros = {
+			name: app.getName(),
+			currentVersion: app.getVersion(),
+			newVersion: this._version,
+		};
+
+		let text = originalText;
+
+		for ( const key in macros ) {
+			if ( macros.hasOwnProperty( key ) ) {
+				text = text.replace( new RegExp( `{${key}}`, 'ig' ), macros[key] );
+			}
+		}
+
+		return text;
+	}
+}
+
+module.exports = Updater;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "3.6.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3067,7 +3067,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -4359,14 +4358,12 @@
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "bluebird-lst": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.5.tgz",
       "integrity": "sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==",
-      "dev": true,
       "requires": {
         "bluebird": "^3.5.1"
       }
@@ -4587,8 +4584,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -6476,6 +6472,19 @@
         }
       }
     },
+    "electron-fetch": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.2.1.tgz",
+      "integrity": "sha512-pQy0el/vxu30sL9JjXss8yZL+ztRnmioffPQsLL4UYnfSUFTuGBlgCPCxxKYJV7y52WfaIEZQ9tlbac1YHrH0w==",
+      "requires": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "electron-is-dev": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-0.3.0.tgz",
+      "integrity": "sha1-FOb9pcaOnk7L7/nM8DfL18BcWv4="
+    },
     "electron-mocha": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-2.3.1.tgz",
@@ -6794,6 +6803,76 @@
       "integrity": "sha1-0tnxJwuko7lnuDHEDvcftNmrXOA=",
       "dev": true
     },
+    "electron-updater": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-3.1.2.tgz",
+      "integrity": "sha512-y3n37O01pdynMJHhJbOd2UVhVrmDW6zLvR2SOZ+gk3S6r16872+0nNbC48GXWwc26lTeus/Zja/XUpiqrvdw4A==",
+      "requires": {
+        "bluebird-lst": "^1.0.5",
+        "builder-util-runtime": "~4.4.1",
+        "electron-is-dev": "^0.3.0",
+        "fs-extra-p": "^4.6.1",
+        "js-yaml": "^3.12.0",
+        "lazy-val": "^1.0.3",
+        "lodash.isequal": "^4.5.0",
+        "semver": "^5.5.1",
+        "source-map-support": "^0.5.9"
+      },
+      "dependencies": {
+        "builder-util-runtime": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-4.4.1.tgz",
+          "integrity": "sha512-8L2pbL6D3VdI1f8OMknlZJpw0c7KK15BRz3cY77AOUElc4XlCv2UhVV01jJM7+6Lx7henaQh80ALULp64eFYAQ==",
+          "requires": {
+            "bluebird-lst": "^1.0.5",
+            "debug": "^3.1.0",
+            "fs-extra-p": "^4.6.1",
+            "sax": "^1.2.4"
+          }
+        },
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "semver": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-support": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "electron-window": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/electron-window/-/electron-window-0.8.1.tgz",
@@ -6834,6 +6913,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -7137,8 +7224,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "esrecurse": {
       "version": "4.2.0",
@@ -7964,7 +8050,6 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.6.1.tgz",
       "integrity": "sha512-IsTMbUS0svZKZTvqF4vDS9c/L7Mw9n8nZQWWeSzAGacOSe+8CzowhUN0tdZEZFIJNP5HC7L9j3MMikz/G4hDeQ==",
-      "dev": true,
       "requires": {
         "bluebird-lst": "^1.0.5",
         "fs-extra": "^6.0.1"
@@ -7974,7 +8059,6 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
           "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -7985,7 +8069,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -8924,8 +9007,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -9209,7 +9291,6 @@
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -9890,10 +9971,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true,
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -10105,8 +10185,7 @@
     "lazy-val": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.3.tgz",
-      "integrity": "sha512-pjCf3BYk+uv3ZcPzEVM0BFvO9Uw58TmlrU0oG5tTrr9Kcid3+kdKxapH8CjdYmVa2nO5wOoZn2rdvZx2PKj/xg==",
-      "dev": true
+      "integrity": "sha512-pjCf3BYk+uv3ZcPzEVM0BFvO9Uw58TmlrU0oG5tTrr9Kcid3+kdKxapH8CjdYmVa2nO5wOoZn2rdvZx2PKj/xg=="
     },
     "lcid": {
       "version": "1.0.0",
@@ -10441,6 +10520,11 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "log-symbols": {
       "version": "1.0.2",
@@ -13152,8 +13236,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-filename": {
       "version": "1.6.1",
@@ -13167,8 +13250,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "schema-utils": {
       "version": "0.4.5",
@@ -13219,9 +13301,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -13681,8 +13763,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.13.1",
@@ -14649,8 +14730,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "3.0.0",
+  "version": "3.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "3.6.0",
+  "version": "3.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "3.6.0",
+  "version": "3.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"

--- a/package.json
+++ b/package.json
@@ -59,12 +59,16 @@
   },
   "dependencies": {
     "debug": "2.6.8",
+    "electron-fetch": "1.2.1",
     "electron-spellchecker": "github:ssbc/electron-spellchecker-prebuilt",
+    "electron-updater": "3.1.2",
     "express": "4.15.3",
+    "js-yaml": "3.12.0",
     "lodash.clonedeep": "4.5.0",
     "lodash.debounce": "4.0.8",
     "portscanner": "1.2.0",
     "pug": "2.0.0-rc.4",
+    "semver": "5.6.0",
     "superagent": "1.8.5"
   },
   "build": {


### PR DESCRIPTION
### Description
This PR replaces the built in auto updater with `electron-updater`. 

### Motivation and Context
- Enable auto update for Windows
- Simplify release process (using Github Releases for release management)
- Update manual updater to use Github Releases as well

### How to test (dev env)
1. Create `dev-app-update.yml` in your project root with the following content: 
    ```yml
    owner: automattic
    repo: wp-desktop
    provider: github
    ```
1. In `package.json` Set version to `3.5.0`
1. Execute `make dev-server` and `make dev` to launch the app
1. Wait for the updater to prompt. 
    - on confirm: macOS & Windows performs auto update
    - Linux opens Github Release page in browser. 

### How to test (production)
1. Get installer binaries from here: https://circleci.com/gh/Automattic/wp-desktop/26710#artifacts/containers/0
1. Wait for the updater to prompt. 
    - on confirm: macOS & Windows performs auto update
    - Linux opens Github Release page in browser. 

### Todos
- [ ] Testing