### PR TITLE
Replace internal calypso url with external url

### DIFF
--- a/desktop-config/config-base.json
+++ b/desktop-config/config-base.json
@@ -4,6 +4,7 @@
 	"server_port": 41050,
 	"server_url": "http://127.0.0.1",
 	"server_host": "127.0.0.1",
+	"wordpress_host": "wordpress.com",
 	"debug": false,
 	"appPathName": "WordPress.com",
 	"mainWindow": {

--- a/desktop/window-handlers/external-links/index.js
+++ b/desktop/window-handlers/external-links/index.js
@@ -61,8 +61,6 @@ function replaceInternalCalypsoUrl( url ) {
 		url.port = '';
 	}
 
-	debug( 'Returning url object', url );
-
 	return url;
 }
 

--- a/desktop/window-handlers/external-links/index.js
+++ b/desktop/window-handlers/external-links/index.js
@@ -5,7 +5,7 @@
  */
 const shell = require( 'electron' ).shell;
 const debug = require( 'debug' )( 'desktop:external-links' );
-const { URL } = require( 'url' );
+const { URL, format } = require( 'url' );
 
 /**
  * Internal dependencies
@@ -53,9 +53,22 @@ function openInBrowser( event, url ) {
 	event.preventDefault();
 }
 
+function replaceInternalCalypsoUrl( url ) {
+	if ( url.hostname === Config.server_host ) {
+		debug( 'Replacing internal url with public url', url.hostname, Config.wordpress_url );
+
+		url.hostname = Config.wordpress_host;
+		url.port = '';
+	}
+
+	debug( 'Returning url object', url );
+
+	return url;
+}
+
 module.exports = function( webContents ) {
 	webContents.on( 'will-navigate', function( event, url ) {
-		const parsedUrl = new URL( url );
+		let parsedUrl = new URL( url );
 
 		for ( let x = 0; x < ALWAYS_OPEN_IN_APP.length; x++ ) {
 			const alwaysOpenUrl = new URL( ALWAYS_OPEN_IN_APP[ x ] );
@@ -70,7 +83,7 @@ module.exports = function( webContents ) {
 	} );
 
 	webContents.on( 'new-window', function( event, url, frameName, disposition, options ) {
-		const parsedUrl = new URL( url );
+		let parsedUrl = new URL( url );
 
 		for ( let x = 0; x < DONT_OPEN_IN_BROWSER.length; x++ ) {
 			const dontOpenUrl = new URL( DONT_OPEN_IN_BROWSER[ x ] );
@@ -88,7 +101,11 @@ module.exports = function( webContents ) {
 			}
 		}
 
-		debug( 'Open in new browser for ' + url );
-		openInBrowser( event, url );
+		parsedUrl = replaceInternalCalypsoUrl( parsedUrl );
+
+		const openUrl = format( parsedUrl );
+
+		debug( 'Open in new browser for ' + openUrl );
+		openInBrowser( event, openUrl );
 	} );
 };

--- a/desktop/window-handlers/external-links/index.js
+++ b/desktop/window-handlers/external-links/index.js
@@ -66,7 +66,7 @@ function replaceInternalCalypsoUrl( url ) {
 
 module.exports = function( webContents ) {
 	webContents.on( 'will-navigate', function( event, url ) {
-		let parsedUrl = new URL( url );
+		const parsedUrl = new URL( url );
 
 		for ( let x = 0; x < ALWAYS_OPEN_IN_APP.length; x++ ) {
 			const alwaysOpenUrl = new URL( ALWAYS_OPEN_IN_APP[ x ] );


### PR DESCRIPTION
### Description
This PR adds a check to replace internal calypso urls like `127.0.0.1:41050` or `calypso.localhost:3000` for external link handling. 

### Motivation and Context
https://github.com/Automattic/wp-calypso/pull/28109

### How to test
- In calypso, checkout https://github.com/Automattic/wp-calypso/pull/28109
- run `make dev-server` and `make dev` ([docs](https://github.com/Automattic/wp-desktop/blob/develop/docs/development.md#dev-mode))
- Open the dev tools <kbd>Cmd</kbd>+<kbd>Alt</kbd>+<kbd>i</kbd> and head to `http://calypso.localhost:3000/start` and opt to use your own domain
- Click on the We're happy to help! link at the bottom
- `wordpress.com/help/contact` will be opened in the browser. 