### PR TITLE
Updater: replace name from package.json with actual app name.

### DIFF
--- a/desktop-config/config-base.json
+++ b/desktop-config/config-base.json
@@ -6,6 +6,7 @@
 	"server_host": "127.0.0.1",
 	"wordpress_host": "wordpress.com",
 	"debug": false,
+	"appName": "WordPress.com",
 	"appPathName": "WordPress.com",
 	"mainWindow": {
 		"acceptFirstMouse": false,

--- a/desktop/lib/updater/index.js
+++ b/desktop/lib/updater/index.js
@@ -9,6 +9,7 @@ const debug = require( 'debug' )( 'desktop:updater' );
  * Internal dependencies
  */
 const platform = require( 'lib/platform' );
+const config = require( 'lib/config' );
 
 class Updater extends EventEmitter {
 	constructor( options ) {
@@ -80,7 +81,7 @@ class Updater extends EventEmitter {
 
 	expandMacros( originalText ) {
 		const macros = {
-			name: 'WordPress.com',
+			name: config.appName,
 			currentVersion: app.getVersion(),
 			newVersion: this._version,
 		};

--- a/desktop/lib/updater/index.js
+++ b/desktop/lib/updater/index.js
@@ -80,7 +80,7 @@ class Updater extends EventEmitter {
 
 	expandMacros( originalText ) {
 		const macros = {
-			name: app.getName(),
+			name: 'WordPress.com',
 			currentVersion: app.getVersion(),
 			newVersion: this._version,
 		};


### PR DESCRIPTION
Electron pulls the app name from package.jsons `name` field. In our case however. The app is not called `WordPressDesktop` but `WordPress.com`.

There is now an `appName` field in the desktop config (`./desktop-config/config-base.json`) for this.