### PR TITLE
Use webhook script instead of CircleCI notify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ references:
       when: on_success
       command: |
           set +o errexit
-          if [[ $CIRCLE_BRANCH != "/tests/"* ]]; then
+          if [[ $CIRCLE_BRANCH != "tests/"* ]]; then
             exit
           fi
           curl -X POST "https://a8c-gh-desktop-bridge.go-vip.co/circleciwebhook" \
@@ -111,10 +111,10 @@ references:
   webhook_notify_failed: &webhook_notify_failed
     run:
       name: Notify webhook of test results
-      when: on_success
+      when: on_fail
       command: |
         set +o errexit
-        if [[ $CIRCLE_BRANCH != "/tests/"* ]]; then
+        if [[ $BRANCHNAME != "tests/"* ]]; then
           exit
         fi
         curl -X POST "https://a8c-gh-desktop-bridge.go-vip.co/circleciwebhook" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,8 +134,8 @@ references:
   				}
   			  }'
   webhook_notify: &webhook_notify
-	- *webhook_notify_failed
-	- *webhook_notify_success
+	<<: *webhook_notify_failed
+	<<: *webhook_notify_success
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,9 @@ references:
       paths: *app_cache_paths
   webhook_notify_success: &webhook_notify_success
     run:
-    name: Notify webhook of test results
-    when: on_success
-    command: |
+      name: Notify webhook of test results
+      when: on_success
+      command: |
           set +o errexit
           if [[ $CIRCLE_BRANCH != "/tests/"* ]]; then
             exit
@@ -110,9 +110,9 @@ references:
           }'
   webhook_notify_failed: &webhook_notify_failed
     run:
-    name: Notify webhook of test results
-    when: on_success
-    command: |
+      name: Notify webhook of test results
+      when: on_success
+      command: |
         set +o errexit
         if [[ $CIRCLE_BRANCH != "/tests/"* ]]; then
           exit
@@ -133,9 +133,6 @@ references:
             }
           }
         }'
-  webhook_notify: &webhook_notify
-    <<: *webhook_notify_failed
-    <<: *webhook_notify_success
 
 jobs:
   build:
@@ -222,7 +219,8 @@ jobs:
       - persist_to_workspace:
           root: /Users/distiller/wp-desktop
           paths: *app_cache_paths
-      - *webhook_notify
+      - *webhook_notify_success
+      - *webhook_notify_failed
 
   linux:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,59 @@ references:
       name: Save calypso cache
       key: v2-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
       paths: *app_cache_paths
+  webhook_notify_success: &webhook_notify_success
+	run:
+	  name: Notify webhook of test results
+	  when: on_success
+	  command: |
+			  set +o errexit
+			  if [[ $CIRCLE_BRANCH != "/tests/"* ]]; then
+				exit
+			  fi
+			  curl -X POST "https://a8c-gh-desktop-bridge.go-vip.co/circleciwebhook" \
+			  -H 'Cache-Control: no-cache'	\
+			  -H 'Content-Type: application/json'	\
+			  -d '{
+			  	"payload": {
+			  	  "outcome": "'"success"'",
+			  	  "status": "'"success"'",
+				  "branch": "'"$BRANCHNAME"'",
+			  	  "build_url": "'"$CIRCLE_BUILD_URL"'",
+			  	  "build_parameters": {
+					  "build_num": '"$CIRCLE_BUILD_NUM"',
+					  "sha": "'"$sha"'",
+					  "calypsoProject": "'"$calypsoProject"'"
+			  	  }
+				}
+			  }'
+  webhook_notify_failed: &webhook_notify_failed
+  	run:
+    	name: Notify webhook of test results
+    	when: on_fail
+    	command: |
+    		  set +o errexit
+	  		  if [[ $CIRCLE_BRANCH != "/tests/"* ]]; then
+	  			exit
+	  		  fi
+    		  curl -X POST "https://a8c-gh-desktop-bridge.go-vip.co/circleciwebhook" \
+    		  -H 'Cache-Control: no-cache'	\
+		  	  -H 'Content-Type: application/json'	\
+  			  -d '{
+  			  	"payload": {
+				  "outcome": "'"success"'",
+				  "status": "'"success"'",
+				  "branch": "'"$BRANCHNAME"'",
+				  "build_url": "'"$CIRCLE_BUILD_URL"'",
+				  "build_parameters": {
+	  			  	"build_num": '"$CIRCLE_BUILD_NUM"',
+	  				"sha": "'"$sha"'",
+	  				"calypsoProject": "'"$calypsoProject"'"
+				  }
+  				}
+  			  }'
+  webhook_notify: &webhook_notify
+	- *webhook_notify_failed
+	- *webhook_notify_success
 
 jobs:
   build:
@@ -169,6 +222,7 @@ jobs:
       - persist_to_workspace:
           root: /Users/distiller/wp-desktop
           paths: *app_cache_paths
+	  - *webhook_notify
 
   linux:
     docker:
@@ -367,15 +421,3 @@ workflows:
               ignore: /tests.*/
             tags:
               only: /.*/
-
-
-experimental:
-  notify:
-    branches:
-      only:
-        - /tests.*/
-
-
-notify:
-  webhooks:
-    - url: https://a8c-gh-desktop-bridge.go-vip.co/circleciwebhook

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ references:
       paths: *app_cache_paths
   webhook_notify_success: &webhook_notify_success
     run:
-      name: Notify webhook of test results
+      name: Notify webhook of successful build
       when: on_success
       command: |
           set +o errexit
@@ -110,7 +110,7 @@ references:
           }'
   webhook_notify_failed: &webhook_notify_failed
     run:
-      name: Notify webhook of test results
+      name: Notify webhook of failed build
       when: on_fail
       command: |
         set +o errexit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,58 +84,58 @@ references:
       key: v2-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
       paths: *app_cache_paths
   webhook_notify_success: &webhook_notify_success
-	run:
-	  name: Notify webhook of test results
-	  when: on_success
-	  command: |
-			  set +o errexit
-			  if [[ $CIRCLE_BRANCH != "/tests/"* ]]; then
-				exit
-			  fi
-			  curl -X POST "https://a8c-gh-desktop-bridge.go-vip.co/circleciwebhook" \
-			  -H 'Cache-Control: no-cache'	\
-			  -H 'Content-Type: application/json'	\
-			  -d '{
-			  	"payload": {
-			  	  "outcome": "'"success"'",
-			  	  "status": "'"success"'",
-				  "branch": "'"$BRANCHNAME"'",
-			  	  "build_url": "'"$CIRCLE_BUILD_URL"'",
-			  	  "build_parameters": {
-					  "build_num": '"$CIRCLE_BUILD_NUM"',
-					  "sha": "'"$sha"'",
-					  "calypsoProject": "'"$calypsoProject"'"
-			  	  }
-				}
-			  }'
+    run:
+    name: Notify webhook of test results
+    when: on_success
+    command: |
+          set +o errexit
+          if [[ $CIRCLE_BRANCH != "/tests/"* ]]; then
+            exit
+          fi
+          curl -X POST "https://a8c-gh-desktop-bridge.go-vip.co/circleciwebhook" \
+          -H 'Cache-Control: no-cache'	\
+          -H 'Content-Type: application/json'	\
+          -d '{
+              "payload": {
+                "outcome": "'"success"'",
+                "status": "'"success"'",
+                "branch": "'"$BRANCHNAME"'",
+                "build_url": "'"$CIRCLE_BUILD_URL"'",
+                "build_parameters": {
+                  "build_num": '"$CIRCLE_BUILD_NUM"',
+                  "sha": "'"$sha"'",
+                  "calypsoProject": "'"$calypsoProject"'"
+                }
+              }
+          }'
   webhook_notify_failed: &webhook_notify_failed
-  	run:
-    	name: Notify webhook of test results
-    	when: on_fail
-    	command: |
-    		  set +o errexit
-	  		  if [[ $CIRCLE_BRANCH != "/tests/"* ]]; then
-	  			exit
-	  		  fi
-    		  curl -X POST "https://a8c-gh-desktop-bridge.go-vip.co/circleciwebhook" \
-    		  -H 'Cache-Control: no-cache'	\
-		  	  -H 'Content-Type: application/json'	\
-  			  -d '{
-  			  	"payload": {
-				  "outcome": "'"success"'",
-				  "status": "'"success"'",
-				  "branch": "'"$BRANCHNAME"'",
-				  "build_url": "'"$CIRCLE_BUILD_URL"'",
-				  "build_parameters": {
-	  			  	"build_num": '"$CIRCLE_BUILD_NUM"',
-	  				"sha": "'"$sha"'",
-	  				"calypsoProject": "'"$calypsoProject"'"
-				  }
-  				}
-  			  }'
+    run:
+    name: Notify webhook of test results
+    when: on_success
+    command: |
+        set +o errexit
+        if [[ $CIRCLE_BRANCH != "/tests/"* ]]; then
+          exit
+        fi
+        curl -X POST "https://a8c-gh-desktop-bridge.go-vip.co/circleciwebhook" \
+        -H 'Cache-Control: no-cache'	\
+        -H 'Content-Type: application/json'	\
+        -d '{
+          "payload": {
+            "outcome": "'"failed"'",
+            "status": "'"failed"'",
+            "branch": "'"$BRANCHNAME"'",
+            "build_url": "'"$CIRCLE_BUILD_URL"'",
+            "build_parameters": {
+              "build_num": '"$CIRCLE_BUILD_NUM"',
+              "sha": "'"$sha"'",
+              "calypsoProject": "'"$calypsoProject"'"
+            }
+          }
+        }'
   webhook_notify: &webhook_notify
-	<<: *webhook_notify_failed
-	<<: *webhook_notify_success
+    <<: *webhook_notify_failed
+    <<: *webhook_notify_success
 
 jobs:
   build:
@@ -222,7 +222,7 @@ jobs:
       - persist_to_workspace:
           root: /Users/distiller/wp-desktop
           paths: *app_cache_paths
-	  - *webhook_notify
+      - *webhook_notify
 
   linux:
     docker:


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
This PR adds a step that calls the GitHub bridge for updating test results on wp-calypso builds and removes the less reliable CircleCI notify functionality.

### Motivation and Context:
The CircleCI notify functionality has been less and less reliable lately. We have switched some of the other repos to use this method and things have been more stable

### How Has This Been Tested:
I used a local version of the GH bridge to kick off tests using this branch instead of the develop branch, like it usually does. I verified that the status for wp-desktop tests was updated for the wp-calypso PR
GitHub PR: https://github.com/Automattic/wp-calypso/pull/29142
CircleCI build: https://circleci.com/gh/Automattic/wp-desktop/28593

