### PR TITLE
Extending no output timeout to give build time to complete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,7 @@ jobs:
       - *npm_save_cache
       - run:
           name: Build sources
+          no_output_timeout: 20m
           command: |
                   # only use the updater when we are building from master or a release branch
                   # if [[ $CIRCLE_BRANCH =~ ^release(.*)|(^master$) ]]


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
This extends the timeout for the build step. 

### Motivation and Context:
When running tests from wp-calypso, the builds were often times failing because the build step would time out after 10 minutes of no output. 

### How Has This Been Tested:
I ran a manual kickoff of the tests. In this build, the timeout is changed and the tests passed after more than 10 minutes of no output.

https://circleci.com/gh/Automattic/wp-desktop/28741#config/containers/0