### PR TITLE
Updater allow downgrade to stable channel

### DIFF
--- a/desktop/app-handlers/updater/auto-updater/index.js
+++ b/desktop/app-handlers/updater/auto-updater/index.js
@@ -39,8 +39,12 @@ class AutoUpdater extends Updater {
 		autoUpdater.on( 'update-downloaded', this.onDownloaded.bind( this ) );
 
 		autoUpdater.autoInstallOnAppQuit = false;
+		autoUpdater.allowDowngrade = true;
+		autoUpdater.channel = 'stable';
+		autoUpdater.allowPrerelease = false;
 
 		if ( this.beta ) {
+			autoUpdater.channel = 'beta';
 			autoUpdater.allowPrerelease = true;
 		}
 	}

--- a/desktop/app-handlers/updater/index.js
+++ b/desktop/app-handlers/updater/index.js
@@ -22,7 +22,7 @@ module.exports = function() {
 	if ( Config.updater ) {
 		app.on( 'will-finish-launching', function() {
 			const beta = settings.getSetting( 'release-channel' ) === 'beta';
-			debug( 'Update channel', settings.getSetting( 'release-channel' ), beta )
+			debug( 'Update channel', settings.getSetting( 'release-channel' ) )
 			if ( platform.isOSX() || platform.isWindows() || process.env.APPIMAGE ) {
 				debug( 'Auto Update' )
 				updater = new AutoUpdater( {


### PR DESCRIPTION
When a user opts out of the beta channel the next update check should allow the user to downgrade to the latest stable version.

### How to test
1. Create `dev-app-update.yml` in your wp-desktop project root with the following content:
    ```yml
    owner: adlk
    repo: wp-desktop-test
    provider: github
   ```
1. Change the `version` in `package.json` to `3.9.0-beta1`
1. Run the app with `make dev-server` & `make dev` 
1. Make sure that in preferences the `stable` channel is selected
1. Wait for the updater to prompt
