### PR TITLE
Add lerna packages to calypso cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,9 +200,6 @@ jobs:
 
                     make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=true
                   else
-                    # We need to build the lerna packages
-                    npm run build-packages
-
                     make desktop/config.json CONFIG_ENV=$CONFIG_ENV
                     make build-desktop
                   fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ references:
     - calypso/server
     - calypso/config
     - calypso/package.json
+    - calypso/packages
     - calypso/npm-shrinkwrap.json
     - calypso/.nvmrc
   calypso_prepare_cache: &calypso_prepare_cache
@@ -70,7 +71,7 @@ references:
     restore_cache:
       name: Restore calypso cache
       keys:
-        - v2-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
+        - v3-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
   calypso_finalize_cache: &calypso_finalize_cache
     run:
       name: Finalize calypso cache
@@ -81,7 +82,7 @@ references:
   calypso_save_cache: &calypso_save_cache
     save_cache:
       name: Save calypso cache
-      key: v2-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
+      key: v3-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
       paths: *app_cache_paths
   webhook_notify_success: &webhook_notify_success
     run:
@@ -199,6 +200,9 @@ jobs:
 
                     make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=true
                   else
+                    # We need to build the lerna packages
+                    npm run build-packages
+
                     make desktop/config.json CONFIG_ENV=$CONFIG_ENV
                     make build-desktop
                   fi


### PR DESCRIPTION
For subsequent desktop CI builds where calypso is cached, we need to cache the new lerna packages as well.

Update #542 and #543 after merging. 