### PR TITLE
Remove EMIT_STATS from desktop tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
                       CONFIG_ENV=test
                     fi
 
-                    make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=true
+                    make build-source CONFIG_ENV=$CONFIG_ENV
                   else
                     make desktop/config.json CONFIG_ENV=$CONFIG_ENV
                     make build-desktop


### PR DESCRIPTION
Added in a5d87d2c / #539 

I suspect this is slowing down Calypso Desktop tests significantly, however it's hard to tell because of the way Desktop/Calypso tests are set up.

@blowery do we need the stats?