### PR TITLE
Mirror move to file refs in calypso

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ references:
     restore_cache:
       name: Restore calypso cache
       keys:
-        - v3-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
+        - v4-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
   calypso_finalize_cache: &calypso_finalize_cache
     run:
       name: Finalize calypso cache
@@ -82,7 +82,7 @@ references:
   calypso_save_cache: &calypso_save_cache
     save_cache:
       name: Save calypso cache
-      key: v3-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
+      key: v4-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
       paths: *app_cache_paths
   webhook_notify_success: &webhook_notify_success
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
                   nvm use
                   npm ci
                   cd calypso
-                  npx lerna bootstrap
+                  npm ci
       - *npm_save_cache
       - run:
           name: Build sources

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ endif
 
 # Build calypso bundle
 build-calypso: 
-	@cd $(CALYPSO_DIR) && NODE_ENV=$(NODE_ENV) CALYPSO_ENV=$(CALYPSO_ENV) npm run -s build
+	@cd $(CALYPSO_DIR) && CALYPSO_ENV=$(CALYPSO_ENV) npm run -s build
 
 	@echo "$(CYAN)$(CHECKMARK) Calypso built$(RESET)"
 
@@ -93,7 +93,7 @@ build-calypso:
 calypso-dev: 
 	@echo "$(CYAN)Starting Calypso...$(RESET)"
 
-	@cd $(CALYPSO_DIR) && NODE_ENV=$(NODE_ENV) CALYPSO_ENV=$(CALYPSO_ENV) npm run -s start
+	@cd $(CALYPSO_DIR) && CALYPSO_ENV=$(CALYPSO_ENV) npm run -s start
 
 # Build desktop bundle
 build-desktop:
@@ -101,7 +101,7 @@ ifeq ($(NODE_ENV),development)
 	@echo "$(CYAN)$(CHECKMARK) Starting Desktop Server...$(RESET)"
 endif
 
-	@NODE_ENV=$(NODE_ENV) NODE_PATH=calypso$/server$(ENV_PATH_SEP)calypso$/client CALYPSO_SERVER=true npx webpack --config $(THIS_DIR)$/webpack.config.js
+	NODE_PATH=calypso$/server$(ENV_PATH_SEP)calypso$/client CALYPSO_SERVER=true npx webpack --config $(THIS_DIR)$/webpack.config.js
 
 	@echo "$(CYAN)$(CHECKMARK) Desktop built$(RESET)"
 


### PR DESCRIPTION
Companion to https://github.com/Automattic/wp-calypso/pull/30681

Moves to using `npm ci` to install calypso in one place and drops NODE_ENV usage when triggering calypso build steps that may kick off an install. NODE_ENV=production skips the install of devDependencies, which calypso needs to build itself.