### PR TITLE
CircleCI: break 'build' job into macOS job for releases and Linux job for Calypso

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ references:
     restore_cache:
       name: Restore calypso cache
       keys:
-        - v5-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
+        - v6-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
   calypso_finalize_cache: &calypso_finalize_cache
     run:
       name: Finalize calypso cache
@@ -88,7 +88,7 @@ references:
   calypso_save_cache: &calypso_save_cache
     save_cache:
       name: Save calypso cache
-      key: v5-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
+      key: v6-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
       paths: *app_cache_paths
   webhook_notify_success: &webhook_notify_success
     run:
@@ -142,76 +142,75 @@ references:
         }'
 
 
-orbs:
-  wp-desktop:
-    commands:
-      build-and-test:
-        steps: 
-          - run:
-              name: Setup calypso
-              command: |
-                      git submodule init
-                      git submodule update
+commands:
+  build-and-test:
+    steps: 
+      - run:
+          name: Setup calypso
+          command: |
+                  git submodule init
+                  git submodule update
 
-                      if [ -n "${CALYPSO_HASH}" ]; then
-                        cd calypso;
-                        git fetch;
-                        git checkout ${CALYPSO_HASH};
-                      fi
-          - *calypso_prepare_cache
-          - *calypso_restore_cache
-          - *restore_nvm
-          - *setup_nvm
-          - *save_nvm
-          - run:
-              name: Decrypt assets
-              command: |
-                      openssl aes-256-cbc -md md5 -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                      openssl aes-256-cbc -md md5 -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                      openssl aes-256-cbc -md md5 -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-          - *npm_restore_cache
-          - run:
-              name: Npm install
-              command: |
-                      source $HOME/.nvm/nvm.sh
-                      nvm use
-                      npm ci
-                      cd calypso
-                      npm ci
-          - *npm_save_cache
-          - run:
-              name: Build sources
-              no_output_timeout: 20m
-              command: |
-                      source $HOME/.nvm/nvm.sh
-                      nvm use
+                  if [ -n "${CALYPSO_HASH}" ]; then
+                    cd calypso;
+                    git fetch;
+                    git checkout ${CALYPSO_HASH};
+                  fi
+      - *calypso_prepare_cache
+      - *calypso_restore_cache
+      - *restore_nvm
+      - *setup_nvm
+      - *save_nvm
+      - run:
+          name: Decrypt assets
+          command: |
+                  openssl aes-256-cbc -md md5 -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                  openssl aes-256-cbc -md md5 -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                  openssl aes-256-cbc -md md5 -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+      - *npm_restore_cache
+      - run:
+          name: Npm install
+          command: |
+                  source $HOME/.nvm/nvm.sh
+                  nvm use
+                  npm ci
+                  cd calypso
+                  npm ci
+      - *npm_save_cache
+      - run:
+          name: Build sources
+          no_output_timeout: 20m
+          command: |
+                  source $HOME/.nvm/nvm.sh
+                  nvm use
 
-                      # only build the whole bundle when there is no calypso-hash file
-                      if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
-                        make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=false MINIFY_JS=$MINIFY_JS NODE_ARGS="$NODE_ARGS"
-                      else
-                        make desktop/config.json CONFIG_ENV=$CONFIG_ENV
-                        make build-desktop
-                      fi
-          - run:
-              name: Test
-              command: |
-                      set +e
+                  # only build the whole bundle when there is no calypso-hash file
+                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
+                    make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=false MINIFY_JS=$MINIFY_JS NODE_ARGS="$NODE_ARGS"
+                  else
+                    make desktop/config.json CONFIG_ENV=$CONFIG_ENV
+                    make build-desktop
+                  fi
+      - run:
+          name: Test
+          command: |
+                  set +e
 
-                      # At this stage, we can only do canary tests when CONFIG_ENV=test as the electron binary is not signed
-                      # TODO: We might be able to ignore this once we switched to electron-builders auto-update
-                      if [ "$CONFIG_ENV" == "test" ]; then
-                        source $HOME/.nvm/nvm.sh
-                        nvm use
-                        make test
-                      fi
-          - *calypso_finalize_cache
-          - *calypso_save_cache
+                  # At this stage, we can only do canary tests when CONFIG_ENV=test as the electron binary is not signed
+                  # TODO: We might be able to ignore this once we switched to electron-builders auto-update
+                  if [ "$CONFIG_ENV" == "test" ]; then
+                    source $HOME/.nvm/nvm.sh
+                    nvm use
+                    make test
+                  fi
+      - *calypso_finalize_cache
+      - *calypso_save_cache
 
 jobs:
   build:
     docker:
       - image: circleci/node:10.14.0-browsers
+    working_directory: ~/wp-desktop
     environment:
       CONFIG_ENV: test
       MINIFY_JS: false
@@ -219,7 +218,7 @@ jobs:
     steps:
       - checkout
       - *install_linux_dependencies
-      - wp-desktop/build-and-test
+      - build-and-test
       - *webhook_notify_success
       - *webhook_notify_failed
 
@@ -233,7 +232,7 @@ jobs:
       NODE_ARGS: --max_old_space_size=8192
     steps:
       - checkout
-      - wp-desktop/build-and-test
+      - build-and-test
       - persist_to_workspace:
           root: ~/wp-desktop
           paths: *app_cache_paths

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 references:
   restore_nvm: &restore_nvm
@@ -45,6 +45,12 @@ references:
       key: v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
       paths:
         - ~/.npm
+  install_linux_dependencies: &install_linux_dependencies
+    run:
+      name: Install linux dev dependencies
+      command: |
+        apt-get update
+        apt-get -y install libxkbfile-dev libxkbfile-dev:i386 libxss-dev libx11-dev:i386
   app_cache_paths: &app_cache_paths
     - calypso-hash
     - build
@@ -71,7 +77,7 @@ references:
     restore_cache:
       name: Restore calypso cache
       keys:
-        - v4-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
+        - v4-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
   calypso_finalize_cache: &calypso_finalize_cache
     run:
       name: Finalize calypso cache
@@ -82,7 +88,7 @@ references:
   calypso_save_cache: &calypso_save_cache
     save_cache:
       name: Save calypso cache
-      key: v4-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
+      key: v4-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
       paths: *app_cache_paths
   webhook_notify_success: &webhook_notify_success
     run:
@@ -135,94 +141,115 @@ references:
           }
         }'
 
+
+orbs:
+  wp-desktop:
+    commands:
+      build-and-test:
+        steps: 
+          - run:
+              name: Setup calypso
+              command: |
+                      git submodule init
+                      git submodule update
+
+                      if [ -n "${CALYPSO_HASH}" ]; then
+                        cd calypso;
+                        git fetch;
+                        git checkout ${CALYPSO_HASH};
+                      fi
+          - *calypso_prepare_cache
+          - *calypso_restore_cache
+          - *restore_nvm
+          - *setup_nvm
+          - *save_nvm
+          - run:
+              name: Decrypt assets
+              command: |
+                      openssl aes-256-cbc -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                      openssl aes-256-cbc -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                      openssl aes-256-cbc -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+          - *npm_restore_cache
+          - run:
+              name: Npm install
+              command: |
+                      source $HOME/.nvm/nvm.sh
+                      nvm use
+                      npm ci
+                      cd calypso
+                      npm ci
+          - *npm_save_cache
+          - run:
+              name: Build sources
+              no_output_timeout: 20m
+              command: |
+                      # only use the updater when we are building from master or a release branch
+                      # if [[ $CIRCLE_BRANCH =~ ^release(.*)|(^master$) ]]
+                      # then
+                      #   CONFIG_ENV=release
+                      # fi
+
+                      # TODO: update accordingly when code from above changes
+                      CONFIG_ENV=release
+
+                      # only build the whole bundle when there is no calypso-hash file
+                      if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
+                        set +e
+                        source $HOME/.nvm/nvm.sh
+                        nvm use
+
+
+                        if [ -n "${CALYPSO_HASH}" ]; then
+                          CONFIG_ENV=test
+                        fi
+
+                        make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=false MINIFY_JS=$MINIFY_JS NODE_ARGS="$NODE_ARGS"
+                      else
+                        make desktop/config.json CONFIG_ENV=$CONFIG_ENV
+                        make build-desktop
+                      fi
+          - run:
+              name: Test
+              command: |
+                      set +e
+
+                      # At this stage, we can only do canary tests when CONFIG_ENV=test as the electron binary is not signed
+                      # TODO: We might be able to ignore this once we switched to electron-builders auto-update
+                      if [ -n "${CALYPSO_HASH}" ]; then
+                        source $HOME/.nvm/nvm.sh
+                        nvm use
+                        make test
+                      fi
+          - *calypso_finalize_cache
+          - *calypso_save_cache
+
 jobs:
   build:
-    macos:
-      xcode: "9.0"
-    shell: /bin/bash --login
-    working_directory: /Users/distiller/wp-desktop
+    docker:
+      - image: electronuserland/builder:wine-mono
+    environment:
+      MINIFY_JS: false
+      NODE_ARGS: --max_old_space_size=2048
     steps:
       - checkout
-      - run:
-          name: Setup calypso
-          command: |
-                  git submodule init
-                  git submodule update
-
-                  if [ -n "${CALYPSO_HASH}" ]; then
-                    cd calypso;
-                    git fetch;
-                    git checkout ${CALYPSO_HASH};
-                  fi
-      - *calypso_prepare_cache
-      - *calypso_restore_cache
-      - *restore_nvm
-      - *setup_nvm
-      - *save_nvm
-      - run:
-          name: Decrypt assets
-          command: |
-                  openssl aes-256-cbc -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                  openssl aes-256-cbc -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                  openssl aes-256-cbc -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-      - *npm_restore_cache
-      - run:
-          name: Npm install
-          command: |
-                  source $HOME/.nvm/nvm.sh
-                  nvm use
-                  npm ci
-                  cd calypso
-                  npm ci
-      - *npm_save_cache
-      - run:
-          name: Build sources
-          no_output_timeout: 20m
-          command: |
-                  # only use the updater when we are building from master or a release branch
-                  # if [[ $CIRCLE_BRANCH =~ ^release(.*)|(^master$) ]]
-                  # then
-                  #   CONFIG_ENV=release
-                  # fi
-
-                  # TODO: update accordingly when code from above changes
-                  CONFIG_ENV=release
-
-                  # only build the whole bundle when there is no calypso-hash file
-                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
-                    set +e
-                    source $HOME/.nvm/nvm.sh
-                    nvm use
-
-
-                    if [ -n "${CALYPSO_HASH}" ]; then
-                      CONFIG_ENV=test
-                    fi
-
-                    make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=true
-                  else
-                    make desktop/config.json CONFIG_ENV=$CONFIG_ENV
-                    make build-desktop
-                  fi
-      - run:
-          name: Test
-          command: |
-                  set +e
-
-                  # At this stage, we can only do canary tests when CONFIG_ENV=test as the electron binary is not signed
-                  # TODO: We might be able to ignore this once we switched to electron-builders auto-update
-                  if [ -n "${CALYPSO_HASH}" ]; then
-                    source $HOME/.nvm/nvm.sh
-                    nvm use
-                    make test
-                  fi
-      - *calypso_finalize_cache
-      - *calypso_save_cache
-      - persist_to_workspace:
-          root: /Users/distiller/wp-desktop
-          paths: *app_cache_paths
+      - *install_linux_dependencies
+      - wp-desktop/build-and-test
       - *webhook_notify_success
       - *webhook_notify_failed
+
+  build-release:
+    macos:
+      xcode: "9.0"
+    working_directory: ~/wp-desktop
+    environment:
+      MINIFY_JS: true
+      NODE_ARGS: --max_old_space_size=8192
+    steps:
+      - checkout
+      - wp-desktop/build-and-test
+      - persist_to_workspace:
+          root: ~/wp-desktop
+          paths: *app_cache_paths
 
   linux:
     docker:
@@ -236,11 +263,7 @@ jobs:
       - *setup_nvm
       - *save_nvm
       - *npm_restore_cache
-      - run:
-          name: Install linux dev dependencies
-          command: |
-                  apt-get update
-                  apt-get -y install libxkbfile-dev libxkbfile-dev:i386 libxss-dev libx11-dev:i386
+      - *install_linux_dependencies
       - run:
           name: Npm install
           command: |
@@ -386,9 +409,13 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - build-release:
+          filters:
+            tags:
+              only: /.*/
       - windows:
           requires:
-          - build
+          - build-release
           filters:
             branches:
               ignore: /tests.*/
@@ -396,7 +423,7 @@ workflows:
               only: /.*/
       - linux:
           requires:
-          - build
+          - build-release
           filters:
             branches:
               ignore: /tests.*/
@@ -404,7 +431,7 @@ workflows:
               only: /.*/
       - mac:
           requires:
-          - build
+          - build-release
           filters:
             branches:
               ignore: /tests.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ references:
     restore_cache:
       name: Restoring NVM cache
       keys:
-        - nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
-        - nvm-0-33-11-{{ arch }}
+        - v1-nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+        - v1-nvm-0-33-11-{{ arch }}
   setup_nvm: &setup_nvm
     run:
       name: Install nvm and calypso node version
@@ -29,28 +29,28 @@ references:
   save_nvm: &save_nvm
     save_cache:
       name: Saving NVM cache
-      key: nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+      key: v1-nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
       paths:
         - ~/.nvm
   npm_restore_cache: &npm_restore_cache
     restore_cache:
       name: Restore npm cache
       keys:
-        - v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
-        - v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}
-        - v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
+        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}
+        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
   npm_save_cache: &npm_save_cache
     save_cache:
       name: Save npm cache
-      key: v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
+      key: v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
       paths:
         - ~/.npm
   install_linux_dependencies: &install_linux_dependencies
     run:
       name: Install linux dev dependencies
       command: |
-        apt-get update
-        apt-get -y install libxkbfile-dev libxkbfile-dev:i386 libxss-dev libx11-dev:i386
+        sudo apt-get update
+        sudo apt-get -y install libxkbfile-dev libxss-dev uuid-runtime
   app_cache_paths: &app_cache_paths
     - calypso-hash
     - build
@@ -77,7 +77,7 @@ references:
     restore_cache:
       name: Restore calypso cache
       keys:
-        - v4-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
+        - v5-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
   calypso_finalize_cache: &calypso_finalize_cache
     run:
       name: Finalize calypso cache
@@ -88,7 +88,7 @@ references:
   calypso_save_cache: &calypso_save_cache
     save_cache:
       name: Save calypso cache
-      key: v4-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
+      key: v5-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
       paths: *app_cache_paths
   webhook_notify_success: &webhook_notify_success
     run:
@@ -166,9 +166,9 @@ orbs:
           - run:
               name: Decrypt assets
               command: |
-                      openssl aes-256-cbc -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                      openssl aes-256-cbc -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                      openssl aes-256-cbc -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                      openssl aes-256-cbc -md md5 -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                      openssl aes-256-cbc -md md5 -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                      openssl aes-256-cbc -md md5 -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
           - *npm_restore_cache
           - run:
               name: Npm install
@@ -183,26 +183,11 @@ orbs:
               name: Build sources
               no_output_timeout: 20m
               command: |
-                      # only use the updater when we are building from master or a release branch
-                      # if [[ $CIRCLE_BRANCH =~ ^release(.*)|(^master$) ]]
-                      # then
-                      #   CONFIG_ENV=release
-                      # fi
-
-                      # TODO: update accordingly when code from above changes
-                      CONFIG_ENV=release
+                      source $HOME/.nvm/nvm.sh
+                      nvm use
 
                       # only build the whole bundle when there is no calypso-hash file
                       if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
-                        set +e
-                        source $HOME/.nvm/nvm.sh
-                        nvm use
-
-
-                        if [ -n "${CALYPSO_HASH}" ]; then
-                          CONFIG_ENV=test
-                        fi
-
                         make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=false MINIFY_JS=$MINIFY_JS NODE_ARGS="$NODE_ARGS"
                       else
                         make desktop/config.json CONFIG_ENV=$CONFIG_ENV
@@ -215,7 +200,7 @@ orbs:
 
                       # At this stage, we can only do canary tests when CONFIG_ENV=test as the electron binary is not signed
                       # TODO: We might be able to ignore this once we switched to electron-builders auto-update
-                      if [ -n "${CALYPSO_HASH}" ]; then
+                      if [ "$CONFIG_ENV" == "test" ]; then
                         source $HOME/.nvm/nvm.sh
                         nvm use
                         make test
@@ -226,8 +211,9 @@ orbs:
 jobs:
   build:
     docker:
-      - image: electronuserland/builder:wine-mono
+      - image: circleci/node:10.14.0-browsers
     environment:
+      CONFIG_ENV: test
       MINIFY_JS: false
       NODE_ARGS: --max_old_space_size=2048
     steps:
@@ -242,6 +228,7 @@ jobs:
       xcode: "9.0"
     working_directory: ~/wp-desktop
     environment:
+      CONFIG_ENV: release
       MINIFY_JS: true
       NODE_ARGS: --max_old_space_size=8192
     steps:
@@ -253,12 +240,12 @@ jobs:
 
   linux:
     docker:
-      - image: electronuserland/builder:wine-mono
-    working_directory: /wp-desktop
+      - image: circleci/node:10.14.0-browsers
+    working_directory: ~/wp-desktop
     steps:
       - checkout
       - attach_workspace:
-          at: /wp-desktop
+          at: ~/wp-desktop
       - *restore_nvm
       - *setup_nvm
       - *save_nvm
@@ -286,7 +273,7 @@ jobs:
                   rm -rf release/github
                   rm -rf release/linux-unpacked
       - persist_to_workspace:
-          root: /wp-desktop
+          root: ~/wp-desktop
           paths:
             - release
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ NODE_ENV = production
 BUILD_PLATFORM = 
 DEBUG = 
 TEST_PRODUCTION_BINARY = false
+MINIFY_JS = true
+NODE_ARGS = --max_old_space_size=8192
 
 # Set default target
 .DEFAULT_GOAL := build
@@ -85,7 +87,7 @@ endif
 
 # Build calypso bundle
 build-calypso: 
-	@cd $(CALYPSO_DIR) && CALYPSO_ENV=$(CALYPSO_ENV) npm run -s build
+	@cd $(CALYPSO_DIR) && CALYPSO_ENV=$(CALYPSO_ENV) MINIFY_JS=$(MINIFY_JS) NODE_ARGS=$(NODE_ARGS) npm run -s build
 
 	@echo "$(CYAN)$(CHECKMARK) Calypso built$(RESET)"
 


### PR DESCRIPTION
### Description:
<!--- Describe your changes in detail. -->

This updates the CircleCI config to allow Calypso PR builds to run on Linux.

Note that the config actually has very few changes. The large diff is due to the yaml indentation change to make it re-usable.

It is the companion PR to https://github.com/Automattic/wp-calypso/pull/30938.

### Motivation and Context:
<!--- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->

The `build` job of wp-desktop's CircleCI config is run many times a day on calypso PRs. Currently, it runs on a macOS image. This is problematic as it eats into the majority of our CircleCI macOS plan unnecessarily.

Unfortunately, it is not as simple as just changing it to run on Linux as that causes the calypso build to crash with an out of memory error.

The solution I have come up with it to break the `build` job into two separate jobs:

- `build`: This is the job that runs on Calypso PRs. It runs on Linux with JS minifying disabled. This allows it to run without memory errors. It has a bonus of making these PR builds quite a bit faster.
- `build-release`: This is the job that only happens on changes to wp-desktop. It does a full release build of calypso.

The workflow now looks like this:

![image](https://user-images.githubusercontent.com/1773641/53237855-a5b77e00-368f-11e9-9bd5-8b73e358fbcd.png)

### How Has This Been Tested:
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, tests completed to see 
how your change affects other areas of the code, etc. -->

This has been tested both by running on CircleCI (see checks on this PR) and by building locally with `make build`.
