### PR TITLE
Fix CircleCI config error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,6 @@ jobs:
                   apt-get update
                   apt-get -y install libxkbfile-dev libxkbfile-dev:i386 libxss-dev libx11-dev:i386
       - run:
-          name: Install dependencies
           name: Npm install
           command: |
             source $HOME/.nvm/nvm.sh


### PR DESCRIPTION
### Description:

`name:` was defined twice in the CircleCI config. This has been causing a few build errors (like [this](https://circleci.com/gh/Automattic/wp-desktop/33634) one) since the CircleCI 2.1 features were enabled for the repo.

### How Has This Been Tested:

CircleCI now runs without errors.
