### PR TITLE
Revert "CircleCI: break 'build' job into macOS job for releases and Linux job for Calypso"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
-version: 2.1
+version: 2
 
 references:
   restore_nvm: &restore_nvm
     restore_cache:
       name: Restoring NVM cache
       keys:
-        - v1-nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
-        - v1-nvm-0-33-11-{{ arch }}
+        - nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+        - nvm-0-33-11-{{ arch }}
   setup_nvm: &setup_nvm
     run:
       name: Install nvm and calypso node version
@@ -29,28 +29,22 @@ references:
   save_nvm: &save_nvm
     save_cache:
       name: Saving NVM cache
-      key: v1-nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+      key: nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
       paths:
         - ~/.nvm
   npm_restore_cache: &npm_restore_cache
     restore_cache:
       name: Restore npm cache
       keys:
-        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
-        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}
-        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+        - v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
+        - v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}
+        - v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
   npm_save_cache: &npm_save_cache
     save_cache:
       name: Save npm cache
-      key: v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
+      key: v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
       paths:
         - ~/.npm
-  install_linux_dependencies: &install_linux_dependencies
-    run:
-      name: Install linux dev dependencies
-      command: |
-        sudo apt-get update
-        sudo apt-get -y install libxkbfile-dev libxss-dev uuid-runtime
   app_cache_paths: &app_cache_paths
     - calypso-hash
     - build
@@ -77,7 +71,7 @@ references:
     restore_cache:
       name: Restore calypso cache
       keys:
-        - v6-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
+        - v4-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
   calypso_finalize_cache: &calypso_finalize_cache
     run:
       name: Finalize calypso cache
@@ -88,7 +82,7 @@ references:
   calypso_save_cache: &calypso_save_cache
     save_cache:
       name: Save calypso cache
-      key: v6-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
+      key: v4-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
       paths: *app_cache_paths
   webhook_notify_success: &webhook_notify_success
     run:
@@ -141,10 +135,14 @@ references:
           }
         }'
 
-
-commands:
-  build-and-test:
-    steps: 
+jobs:
+  build:
+    macos:
+      xcode: "9.0"
+    shell: /bin/bash --login
+    working_directory: /Users/distiller/wp-desktop
+    steps:
+      - checkout
       - run:
           name: Setup calypso
           command: |
@@ -164,9 +162,9 @@ commands:
       - run:
           name: Decrypt assets
           command: |
-                  openssl aes-256-cbc -md md5 -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                  openssl aes-256-cbc -md md5 -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                  openssl aes-256-cbc -md md5 -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                  openssl aes-256-cbc -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                  openssl aes-256-cbc -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                  openssl aes-256-cbc -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
       - *npm_restore_cache
       - run:
           name: Npm install
@@ -181,12 +179,27 @@ commands:
           name: Build sources
           no_output_timeout: 20m
           command: |
-                  source $HOME/.nvm/nvm.sh
-                  nvm use
+                  # only use the updater when we are building from master or a release branch
+                  # if [[ $CIRCLE_BRANCH =~ ^release(.*)|(^master$) ]]
+                  # then
+                  #   CONFIG_ENV=release
+                  # fi
+
+                  # TODO: update accordingly when code from above changes
+                  CONFIG_ENV=release
 
                   # only build the whole bundle when there is no calypso-hash file
                   if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
-                    make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=false MINIFY_JS=$MINIFY_JS NODE_ARGS="$NODE_ARGS"
+                    set +e
+                    source $HOME/.nvm/nvm.sh
+                    nvm use
+
+
+                    if [ -n "${CALYPSO_HASH}" ]; then
+                      CONFIG_ENV=test
+                    fi
+
+                    make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=true
                   else
                     make desktop/config.json CONFIG_ENV=$CONFIG_ENV
                     make build-desktop
@@ -198,58 +211,36 @@ commands:
 
                   # At this stage, we can only do canary tests when CONFIG_ENV=test as the electron binary is not signed
                   # TODO: We might be able to ignore this once we switched to electron-builders auto-update
-                  if [ "$CONFIG_ENV" == "test" ]; then
+                  if [ -n "${CALYPSO_HASH}" ]; then
                     source $HOME/.nvm/nvm.sh
                     nvm use
                     make test
                   fi
       - *calypso_finalize_cache
       - *calypso_save_cache
-
-jobs:
-  build:
-    docker:
-      - image: circleci/node:10.14.0-browsers
-    working_directory: ~/wp-desktop
-    environment:
-      CONFIG_ENV: test
-      MINIFY_JS: false
-      NODE_ARGS: --max_old_space_size=2048
-    steps:
-      - checkout
-      - *install_linux_dependencies
-      - build-and-test
+      - persist_to_workspace:
+          root: /Users/distiller/wp-desktop
+          paths: *app_cache_paths
       - *webhook_notify_success
       - *webhook_notify_failed
 
-  build-release:
-    macos:
-      xcode: "9.0"
-    working_directory: ~/wp-desktop
-    environment:
-      CONFIG_ENV: release
-      MINIFY_JS: true
-      NODE_ARGS: --max_old_space_size=8192
-    steps:
-      - checkout
-      - build-and-test
-      - persist_to_workspace:
-          root: ~/wp-desktop
-          paths: *app_cache_paths
-
   linux:
     docker:
-      - image: circleci/node:10.14.0-browsers
-    working_directory: ~/wp-desktop
+      - image: electronuserland/builder:wine-mono
+    working_directory: /wp-desktop
     steps:
       - checkout
       - attach_workspace:
-          at: ~/wp-desktop
+          at: /wp-desktop
       - *restore_nvm
       - *setup_nvm
       - *save_nvm
       - *npm_restore_cache
-      - *install_linux_dependencies
+      - run:
+          name: Install linux dev dependencies
+          command: |
+                  apt-get update
+                  apt-get -y install libxkbfile-dev libxkbfile-dev:i386 libxss-dev libx11-dev:i386
       - run:
           name: Npm install
           command: |
@@ -272,7 +263,7 @@ jobs:
                   rm -rf release/github
                   rm -rf release/linux-unpacked
       - persist_to_workspace:
-          root: ~/wp-desktop
+          root: /wp-desktop
           paths:
             - release
 
@@ -395,13 +386,9 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build-release:
-          filters:
-            tags:
-              only: /.*/
       - windows:
           requires:
-          - build-release
+          - build
           filters:
             branches:
               ignore: /tests.*/
@@ -409,7 +396,7 @@ workflows:
               only: /.*/
       - linux:
           requires:
-          - build-release
+          - build
           filters:
             branches:
               ignore: /tests.*/
@@ -417,7 +404,7 @@ workflows:
               only: /.*/
       - mac:
           requires:
-          - build-release
+          - build
           filters:
             branches:
               ignore: /tests.*/

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,6 @@ NODE_ENV = production
 BUILD_PLATFORM = 
 DEBUG = 
 TEST_PRODUCTION_BINARY = false
-MINIFY_JS = true
-NODE_ARGS = --max_old_space_size=8192
 
 # Set default target
 .DEFAULT_GOAL := build
@@ -87,7 +85,7 @@ endif
 
 # Build calypso bundle
 build-calypso: 
-	@cd $(CALYPSO_DIR) && CALYPSO_ENV=$(CALYPSO_ENV) MINIFY_JS=$(MINIFY_JS) NODE_ARGS=$(NODE_ARGS) npm run -s build
+	@cd $(CALYPSO_DIR) && CALYPSO_ENV=$(CALYPSO_ENV) npm run -s build
 
 	@echo "$(CYAN)$(CHECKMARK) Calypso built$(RESET)"
 


### PR DESCRIPTION
Reverts Automattic/wp-desktop#564

CircleCI builds aren't correctly triggering with these changes. Reverting while I make a solution.