### PR TITLE
Reintroduce changes from #564 with update to use CircleCI 2.0 syntax only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2
 
 references:
   restore_nvm: &restore_nvm
@@ -32,6 +32,13 @@ references:
       key: v1-nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
       paths:
         - ~/.nvm
+  decrypt_assets: &decrypt_assets
+    run:
+      name: Decrypt assets
+      command: |
+              openssl aes-256-cbc -md md5 -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+              openssl aes-256-cbc -md md5 -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+              openssl aes-256-cbc -md md5 -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
   npm_restore_cache: &npm_restore_cache
     restore_cache:
       name: Restore npm cache
@@ -45,6 +52,15 @@ references:
       key: v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
       paths:
         - ~/.npm
+  npm_install: &npm_install
+    run:
+      name: Npm install
+      command: |
+              source $HOME/.nvm/nvm.sh
+              nvm use
+              npm ci
+              cd calypso
+              npm ci
   install_linux_dependencies: &install_linux_dependencies
     run:
       name: Install linux dev dependencies
@@ -63,6 +79,18 @@ references:
     - calypso/packages
     - calypso/npm-shrinkwrap.json
     - calypso/.nvmrc
+  setup_calypso: &setup_calypso
+    run:
+      name: Setup calypso
+      command: |
+              git submodule init
+              git submodule update
+
+              if [ -n "${CALYPSO_HASH}" ]; then
+                cd calypso;
+                git fetch;
+                git checkout ${CALYPSO_HASH};
+              fi
   calypso_prepare_cache: &calypso_prepare_cache
     run:
       name: Prepare calypso cache
@@ -90,6 +118,34 @@ references:
       name: Save calypso cache
       key: v6-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
       paths: *app_cache_paths
+  build_sources: &build_sources
+    run:
+        name: Build sources
+        no_output_timeout: 20m
+        command: |
+                source $HOME/.nvm/nvm.sh
+                nvm use
+
+                # only build the whole bundle when there is no calypso-hash file
+                if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
+                  make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=false MINIFY_JS=$MINIFY_JS NODE_ARGS="$NODE_ARGS"
+                else
+                  make desktop/config.json CONFIG_ENV=$CONFIG_ENV
+                  make build-desktop
+                fi
+  test: &test
+    run:
+      name: Test
+      command: |
+              set +e
+
+              # At this stage, we can only do canary tests when CONFIG_ENV=test as the electron binary is not signed
+              # TODO: We might be able to ignore this once we switched to electron-builders auto-update
+              if [ "$CONFIG_ENV" == "test" ]; then
+                source $HOME/.nvm/nvm.sh
+                nvm use
+                make test
+              fi
   webhook_notify_success: &webhook_notify_success
     run:
       name: Notify webhook of successful build
@@ -141,71 +197,6 @@ references:
           }
         }'
 
-
-commands:
-  build-and-test:
-    steps: 
-      - run:
-          name: Setup calypso
-          command: |
-                  git submodule init
-                  git submodule update
-
-                  if [ -n "${CALYPSO_HASH}" ]; then
-                    cd calypso;
-                    git fetch;
-                    git checkout ${CALYPSO_HASH};
-                  fi
-      - *calypso_prepare_cache
-      - *calypso_restore_cache
-      - *restore_nvm
-      - *setup_nvm
-      - *save_nvm
-      - run:
-          name: Decrypt assets
-          command: |
-                  openssl aes-256-cbc -md md5 -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                  openssl aes-256-cbc -md md5 -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                  openssl aes-256-cbc -md md5 -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-      - *npm_restore_cache
-      - run:
-          name: Npm install
-          command: |
-                  source $HOME/.nvm/nvm.sh
-                  nvm use
-                  npm ci
-                  cd calypso
-                  npm ci
-      - *npm_save_cache
-      - run:
-          name: Build sources
-          no_output_timeout: 20m
-          command: |
-                  source $HOME/.nvm/nvm.sh
-                  nvm use
-
-                  # only build the whole bundle when there is no calypso-hash file
-                  if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
-                    make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=false MINIFY_JS=$MINIFY_JS NODE_ARGS="$NODE_ARGS"
-                  else
-                    make desktop/config.json CONFIG_ENV=$CONFIG_ENV
-                    make build-desktop
-                  fi
-      - run:
-          name: Test
-          command: |
-                  set +e
-
-                  # At this stage, we can only do canary tests when CONFIG_ENV=test as the electron binary is not signed
-                  # TODO: We might be able to ignore this once we switched to electron-builders auto-update
-                  if [ "$CONFIG_ENV" == "test" ]; then
-                    source $HOME/.nvm/nvm.sh
-                    nvm use
-                    make test
-                  fi
-      - *calypso_finalize_cache
-      - *calypso_save_cache
-
 jobs:
   build:
     docker:
@@ -218,7 +209,20 @@ jobs:
     steps:
       - checkout
       - *install_linux_dependencies
-      - build-and-test
+      - *setup_calypso
+      - *calypso_prepare_cache
+      - *calypso_restore_cache
+      - *restore_nvm
+      - *setup_nvm
+      - *save_nvm
+      - *decrypt_assets
+      - *npm_restore_cache
+      - *npm_install
+      - *npm_save_cache
+      - *build_sources
+      - *test
+      - *calypso_finalize_cache
+      - *calypso_save_cache
       - *webhook_notify_success
       - *webhook_notify_failed
 
@@ -232,7 +236,20 @@ jobs:
       NODE_ARGS: --max_old_space_size=8192
     steps:
       - checkout
-      - build-and-test
+      - *setup_calypso
+      - *calypso_prepare_cache
+      - *calypso_restore_cache
+      - *restore_nvm
+      - *setup_nvm
+      - *save_nvm
+      - *decrypt_assets
+      - *npm_restore_cache
+      - *npm_install
+      - *npm_save_cache
+      - *build_sources
+      - *test
+      - *calypso_finalize_cache
+      - *calypso_save_cache
       - persist_to_workspace:
           root: ~/wp-desktop
           paths: *app_cache_paths

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
-version: 2
+version: 2.1
 
 references:
   restore_nvm: &restore_nvm
     restore_cache:
       name: Restoring NVM cache
       keys:
-        - nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
-        - nvm-0-33-11-{{ arch }}
+        - v1-nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+        - v1-nvm-0-33-11-{{ arch }}
   setup_nvm: &setup_nvm
     run:
       name: Install nvm and calypso node version
@@ -29,22 +29,28 @@ references:
   save_nvm: &save_nvm
     save_cache:
       name: Saving NVM cache
-      key: nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+      key: v1-nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
       paths:
         - ~/.nvm
   npm_restore_cache: &npm_restore_cache
     restore_cache:
       name: Restore npm cache
       keys:
-        - v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
-        - v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}
-        - v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
+        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}
+        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
   npm_save_cache: &npm_save_cache
     save_cache:
       name: Save npm cache
-      key: v1-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
+      key: v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/npm-shrinkwrap.json" }}
       paths:
         - ~/.npm
+  install_linux_dependencies: &install_linux_dependencies
+    run:
+      name: Install linux dev dependencies
+      command: |
+        sudo apt-get update
+        sudo apt-get -y install libxkbfile-dev libxss-dev uuid-runtime
   app_cache_paths: &app_cache_paths
     - calypso-hash
     - build
@@ -71,7 +77,7 @@ references:
     restore_cache:
       name: Restore calypso cache
       keys:
-        - v4-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
+        - v6-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
   calypso_finalize_cache: &calypso_finalize_cache
     run:
       name: Finalize calypso cache
@@ -82,7 +88,7 @@ references:
   calypso_save_cache: &calypso_save_cache
     save_cache:
       name: Save calypso cache
-      key: v4-calypso-{{ arch }}-{{ checksum "calypso-current-hash" }}
+      key: v6-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
       paths: *app_cache_paths
   webhook_notify_success: &webhook_notify_success
     run:
@@ -135,14 +141,10 @@ references:
           }
         }'
 
-jobs:
-  build:
-    macos:
-      xcode: "9.0"
-    shell: /bin/bash --login
-    working_directory: /Users/distiller/wp-desktop
-    steps:
-      - checkout
+
+commands:
+  build-and-test:
+    steps: 
       - run:
           name: Setup calypso
           command: |
@@ -162,9 +164,9 @@ jobs:
       - run:
           name: Decrypt assets
           command: |
-                  openssl aes-256-cbc -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                  openssl aes-256-cbc -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
-                  openssl aes-256-cbc -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                  openssl aes-256-cbc -md md5 -d -in resource/calypso/secrets.json.enc -out calypso/config/secrets.json -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                  openssl aes-256-cbc -md md5 -d -in resource/certificates/mac.p12.enc -out resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
+                  openssl aes-256-cbc -md md5 -d -in resource/certificates/win.p12.enc -out resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
       - *npm_restore_cache
       - run:
           name: Npm install
@@ -179,27 +181,12 @@ jobs:
           name: Build sources
           no_output_timeout: 20m
           command: |
-                  # only use the updater when we are building from master or a release branch
-                  # if [[ $CIRCLE_BRANCH =~ ^release(.*)|(^master$) ]]
-                  # then
-                  #   CONFIG_ENV=release
-                  # fi
-
-                  # TODO: update accordingly when code from above changes
-                  CONFIG_ENV=release
+                  source $HOME/.nvm/nvm.sh
+                  nvm use
 
                   # only build the whole bundle when there is no calypso-hash file
                   if [ "$(cat calypso-current-hash)" != "$(cat calypso-hash)" ]; then
-                    set +e
-                    source $HOME/.nvm/nvm.sh
-                    nvm use
-
-
-                    if [ -n "${CALYPSO_HASH}" ]; then
-                      CONFIG_ENV=test
-                    fi
-
-                    make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=true
+                    make build-source CONFIG_ENV=$CONFIG_ENV EMIT_STATS=false MINIFY_JS=$MINIFY_JS NODE_ARGS="$NODE_ARGS"
                   else
                     make desktop/config.json CONFIG_ENV=$CONFIG_ENV
                     make build-desktop
@@ -211,36 +198,58 @@ jobs:
 
                   # At this stage, we can only do canary tests when CONFIG_ENV=test as the electron binary is not signed
                   # TODO: We might be able to ignore this once we switched to electron-builders auto-update
-                  if [ -n "${CALYPSO_HASH}" ]; then
+                  if [ "$CONFIG_ENV" == "test" ]; then
                     source $HOME/.nvm/nvm.sh
                     nvm use
                     make test
                   fi
       - *calypso_finalize_cache
       - *calypso_save_cache
-      - persist_to_workspace:
-          root: /Users/distiller/wp-desktop
-          paths: *app_cache_paths
+
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10.14.0-browsers
+    working_directory: ~/wp-desktop
+    environment:
+      CONFIG_ENV: test
+      MINIFY_JS: false
+      NODE_ARGS: --max_old_space_size=2048
+    steps:
+      - checkout
+      - *install_linux_dependencies
+      - build-and-test
       - *webhook_notify_success
       - *webhook_notify_failed
 
+  build-release:
+    macos:
+      xcode: "9.0"
+    working_directory: ~/wp-desktop
+    environment:
+      CONFIG_ENV: release
+      MINIFY_JS: true
+      NODE_ARGS: --max_old_space_size=8192
+    steps:
+      - checkout
+      - build-and-test
+      - persist_to_workspace:
+          root: ~/wp-desktop
+          paths: *app_cache_paths
+
   linux:
     docker:
-      - image: electronuserland/builder:wine-mono
-    working_directory: /wp-desktop
+      - image: circleci/node:10.14.0-browsers
+    working_directory: ~/wp-desktop
     steps:
       - checkout
       - attach_workspace:
-          at: /wp-desktop
+          at: ~/wp-desktop
       - *restore_nvm
       - *setup_nvm
       - *save_nvm
       - *npm_restore_cache
-      - run:
-          name: Install linux dev dependencies
-          command: |
-                  apt-get update
-                  apt-get -y install libxkbfile-dev libxkbfile-dev:i386 libxss-dev libx11-dev:i386
+      - *install_linux_dependencies
       - run:
           name: Npm install
           command: |
@@ -263,7 +272,7 @@ jobs:
                   rm -rf release/github
                   rm -rf release/linux-unpacked
       - persist_to_workspace:
-          root: /wp-desktop
+          root: ~/wp-desktop
           paths:
             - release
 
@@ -386,9 +395,13 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - build-release:
+          filters:
+            tags:
+              only: /.*/
       - windows:
           requires:
-          - build
+          - build-release
           filters:
             branches:
               ignore: /tests.*/
@@ -396,7 +409,7 @@ workflows:
               only: /.*/
       - linux:
           requires:
-          - build
+          - build-release
           filters:
             branches:
               ignore: /tests.*/
@@ -404,7 +417,7 @@ workflows:
               only: /.*/
       - mac:
           requires:
-          - build
+          - build-release
           filters:
             branches:
               ignore: /tests.*/

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ NODE_ENV = production
 BUILD_PLATFORM = 
 DEBUG = 
 TEST_PRODUCTION_BINARY = false
+MINIFY_JS = true
+NODE_ARGS = --max_old_space_size=8192
 
 # Set default target
 .DEFAULT_GOAL := build
@@ -85,7 +87,7 @@ endif
 
 # Build calypso bundle
 build-calypso: 
-	@cd $(CALYPSO_DIR) && CALYPSO_ENV=$(CALYPSO_ENV) npm run -s build
+	@cd $(CALYPSO_DIR) && CALYPSO_ENV=$(CALYPSO_ENV) MINIFY_JS=$(MINIFY_JS) NODE_ARGS=$(NODE_ARGS) npm run -s build
 
 	@echo "$(CYAN)$(CHECKMARK) Calypso built$(RESET)"
 


### PR DESCRIPTION
### Description:

I reverted https://github.com/Automattic/wp-desktop/pull/564 quite soon after merging as Calypso API builds were not triggering due to a bug with triggering CircleCI 2.1 builds with the API (see [here](https://discuss.circleci.com/t/circleci-2-1-is-it-possible-to-trigger-a-job-through-api/26294)).

This reintroduces those changes with the addition of converting the CircleCI config to use 2.0 syntax only. This means it is a little more verbose but will be able to be trigger by the API. You can see a build triggered by the API [here](https://circleci.com/gh/Automattic/wp-desktop/33848).

The only unreviewed changes are in https://github.com/Automattic/wp-desktop/commit/1b56c494b77b78fe8f5b85d4e1fbd96aac9c6260 and are purely syntax changes to the config. There are no functional changes.
