### PR TITLE
CircleCI: Don't trigger build on push to test branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,10 +410,14 @@ workflows:
     jobs:
       - build:
           filters:
+            branches:
+              ignore: /tests.*/
             tags:
               only: /.*/
       - build-release:
           filters:
+            branches:
+              ignore: /tests.*/
             tags:
               only: /.*/
       - windows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,13 +411,13 @@ workflows:
       - build:
           filters:
             branches:
-              ignore: /tests.*/
+              ignore: /tests\/.*/
             tags:
               only: /.*/
       - build-release:
           filters:
             branches:
-              ignore: /tests.*/
+              ignore: /tests\/.*/
             tags:
               only: /.*/
       - windows:
@@ -425,7 +425,7 @@ workflows:
           - build-release
           filters:
             branches:
-              ignore: /tests.*/
+              ignore: /tests\/.*/
             tags:
               only: /.*/
       - linux:
@@ -433,7 +433,7 @@ workflows:
           - build-release
           filters:
             branches:
-              ignore: /tests.*/
+              ignore: /tests\/.*/
             tags:
               only: /.*/
       - mac:
@@ -441,7 +441,7 @@ workflows:
           - build-release
           filters:
             branches:
-              ignore: /tests.*/
+              ignore: /tests\/.*/
             tags:
               only: /.*/
       - artifacts:
@@ -451,6 +451,6 @@ workflows:
             - mac
           filters:
             branches:
-              ignore: /tests.*/
+              ignore: /tests\/.*/
             tags:
               only: /.*/


### PR DESCRIPTION
### Description:

In order to test Calypso PRs, branches with the format `tests/` are pushed to wp-desktop. To stop the push building as well as the API, yesterday we enabled "Only Build Pull Requests" on the project.

This is a small config change to exclude these branches from being triggered on pushes. It doesn't prevent API triggered builds on test branches (see [this](https://circleci.com/gh/Automattic/wp-desktop/33919) build).

It will allow us to disabled "Only Build Pull Requests" so that our release workflow is uninterrupted (we can build on tags and release branches).

### How Has This Been Tested:

I have mirrored these changes to [`tests/dont-trigger`](https://github.com/Automattic/wp-desktop/tree/tests/dont-trigger). I tested that pushes to these branches do not appear [in the CircleCI UI](https://circleci.com/gh/Automattic/wp-desktop/tree/tests/dont-trigger) and that API builds can still be triggered (see [this](https://circleci.com/gh/Automattic/wp-desktop/33919) build).


