### PR TITLE
CircleCI: Use mirror for downloading Electron binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,10 @@ references:
         nvm install "$NODE_VERSION"
         nvm alias default "$NODE_VERSION"
         nvm use "$NODE_VERSION"
+
+        # Use an Electron mirror to avoid issues downloading Electron binaries from Github
+        # Documented in https://github.com/electron/chromedriver#custom-mirror
+        echo 'export ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"' >> $BASH_ENV
   save_nvm: &save_nvm
     save_cache:
       name: Saving NVM cache


### PR DESCRIPTION
### Description:

This updates `npm` to use a mirror for downloading Electron binaries. This is documented [here](https://github.com/electron/chromedriver#custom-mirror) and [here](https://electronjs.org/docs/tutorial/installation#custom-mirrors-and-caches).

### Motivation and Context:

All CircleCI builds are currently failing with this error:

```
> electron-chromedriver@1.8.0 install /home/circleci/wp-desktop/node_modules/electron-chromedriver
> node ./download-chromedriver.js

/home/circleci/wp-desktop/node_modules/electron-chromedriver/download-chromedriver.js:30
  if (err != null) throw err
                   ^

Error: GET https://github.com/electron/electron/releases/download/v1.8.0/chromedriver-v1.8.0-linux-x64.zip returned 403
```

The failure is not seen locally so it seems likely this is a CircleCI/Github issue. I have contacted CircleCI to try resolve this.
