### PR TITLE
Revert "CircleCI: Use mirror for downloading Electron binaries"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,6 @@ references:
         nvm install "$NODE_VERSION"
         nvm alias default "$NODE_VERSION"
         nvm use "$NODE_VERSION"
-
-        # Use an Electron mirror to avoid issues downloading Electron binaries from Github
-        # Documented in https://github.com/electron/chromedriver#custom-mirror
-        echo 'export ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"' >> $BASH_ENV
   save_nvm: &save_nvm
     save_cache:
       name: Saving NVM cache


### PR DESCRIPTION
Reverts Automattic/wp-desktop#579

The mirror seems to cause intermittent failures like this 😞 

```
Error: Generated checksum for "electron-v1.7.16-linux-x64.zip" did not match expected checksum.
```

However, Github seems to be working again, so lets revert this.