### PR TITLE
Update Calypso submodule for 4.1.0-beta2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "4.1.0-beta1",
+  "version": "4.1.0-beta2",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"


### PR DESCRIPTION
### Description:

Updating Calypso ref for the 4.1.0 release to include the fix in https://github.com/Automattic/wp-calypso/pull/31988