### PR TITLE
Fix how we look for modules in the test build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ test: rebuild-deps
 
 	@$(MAKE) desktop$/config.json CONFIG_ENV=$(CONFIG_ENV)
 	
-	@NODE_PATH=calypso$/server$(ENV_PATH_SEP)calypso$/client npx webpack --config .$/webpack.config.test.js
+	@NODE_PATH=calypso$/server$(ENV_PATH_SEP)calypso$/client npx webpack --mode production --config .$/webpack.config.test.js
 	@CALYPSO_PATH=`pwd` npx electron-mocha --inline-diffs --timeout 15000 .$/build$/desktop-test.js
 
 distclean: clean

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -57,6 +57,7 @@ module.exports = {
 	resolve: {
 		extensions: [ '.js', '.jsx', '.json' ],
 		modules: [
+			'node_modules',
 			path.join( __dirname, 'calypso', 'node_modules' ),
 			path.join( __dirname, 'node_modules' ),
 			path.join( __dirname, 'calypso', 'server' ),


### PR DESCRIPTION
We were missing a relative 'node_modules' as the first entry, which forced modules to always be found in one the latter places in the resolve.modules config. This led to libraries loading the wrong version of some dependencies, depending on what was in the root, or not finding nested dependencies.

Also, set the mode on the webpack build for the test resources to suppress the associated warning.

