### PR TITLE
Removes the section loader

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -15,13 +15,6 @@ module.exports = {
 				loader: path.join( __dirname, 'calypso', 'server', 'bundler', 'extensions-loader' )
 			},
 			{
-				include: path.join( __dirname, 'calypso', 'client/sections.js' ),
-				use: {
-					loader: path.join( __dirname, 'calypso', 'server', 'bundler', 'sections-loader' ),
-					options: { forceRequire: true, onlyIsomorphic: true },
-				},
-			},
-			{
 				test: /\.html$/,
 				loader: 'html-loader'
 			},


### PR DESCRIPTION
Pairs with Automattic/wp-calypso#32705

This patch removes the section loader from the desktop webpack config.
