### PR TITLE
CircleCI: Merge build and build-release jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,8 +203,8 @@ jobs:
       - image: circleci/node:10.14.0-browsers
     working_directory: ~/wp-desktop
     environment:
-      CONFIG_ENV: test
-      MINIFY_JS: false
+      CONFIG_ENV: release
+      MINIFY_JS: true
       NODE_ARGS: --max_old_space_size=2048
     steps:
       - checkout
@@ -225,31 +225,6 @@ jobs:
       - *calypso_save_cache
       - *webhook_notify_success
       - *webhook_notify_failed
-
-  build-release:
-    macos:
-      xcode: "9.0"
-    working_directory: ~/wp-desktop
-    environment:
-      CONFIG_ENV: release
-      MINIFY_JS: true
-      NODE_ARGS: --max_old_space_size=8192
-    steps:
-      - checkout
-      - *setup_calypso
-      - *calypso_prepare_cache
-      - *calypso_restore_cache
-      - *restore_nvm
-      - *setup_nvm
-      - *save_nvm
-      - *decrypt_assets
-      - *npm_restore_cache
-      - *npm_install
-      - *npm_save_cache
-      - *build_sources
-      - *test
-      - *calypso_finalize_cache
-      - *calypso_save_cache
       - persist_to_workspace:
           root: ~/wp-desktop
           paths: *app_cache_paths
@@ -418,15 +393,9 @@ workflows:
               ignore: /tests\/.*/
             tags:
               only: /.*/
-      - build-release:
-          filters:
-            branches:
-              ignore: /tests\/.*/
-            tags:
-              only: /.*/
       - windows:
           requires:
-          - build-release
+          - build
           filters:
             branches:
               ignore: /tests\/.*/
@@ -434,7 +403,7 @@ workflows:
               only: /.*/
       - linux:
           requires:
-          - build-release
+          - build
           filters:
             branches:
               ignore: /tests\/.*/
@@ -442,7 +411,7 @@ workflows:
               only: /.*/
       - mac:
           requires:
-          - build-release
+          - build
           filters:
             branches:
               ignore: /tests\/.*/


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:

This merges the `build` and `build-release` CircleCI jobs into a single `build` job.

### Motivation and Context:
<!--- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->

A number of months ago, I made some changes (https://github.com/Automattic/wp-desktop/pull/569) to split the macOS `build` job into `build-release` and `build`. This allowed us to dramatically reduce our CircleCI macOS usage by only triggering the Linux `build` job from Calypso PRs.

However, at the time, it was not possible to do a full release build of Calypso on the CircleCI Linux containers due to memory constraints. That is why we also have a `build-release` job running on macOS that is triggered as part of the workflow for `wp-desktop` itself.

Fortunately,  a number of recent changes mean that the split is no longer needed and it is now possible to do a full build of Calypso on the Linux container, so we can merge the two jobs again 😄 

### How Has This Been Tested:
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, tests completed to see 
how your change affects other areas of the code, etc. -->

You can see that this PR is green so the full build works. I have also triggered a build with the API as we do for Calypso PRs [here](https://circleci.com/gh/Automattic/wp-desktop/42920).

### Screenshots (if appropriate):

Here is what the CircleCI workflow looks like now:

<img width="730" alt="Screenshot 2019-07-24 at 10 34 35" src="https://user-images.githubusercontent.com/1773641/61783422-abacb900-adff-11e9-8eb1-baef4ec6e3b0.png">
