### PR TITLE
Documentation: Correct a secrets link.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,7 @@
 1. Clone this repository locally.
     - `git submodule init`
     - `git submodule update`
-1. Create a `calypso/config/secrets.json` file and fill it with [secrets](docs/secrets.md)
+1. Create a `calypso/config/secrets.json` file and fill it with [secrets](secrets.md)
 1. `npm install` will download all the required packages
 1. `make build` to create the builds
 1. Find the built apps in the `release` folder


### PR DESCRIPTION
This PR corrects the link to detailed instructions for generating secrets required for development.

**Testing Instructions**
Verify the updated link in `docs/install.md` takes you to `docs/secrets.md`, instead of a GitHub 404.

_This is a redo of #658 , which was based on the wrong branch._