### PR TITLE
[Electron Upgrade] Remove Windows from Circle Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,51 +268,6 @@ jobs:
           paths:
             - release
 
-  windows:
-    macos:
-      xcode: "9.0"
-    shell: /bin/bash --login
-    working_directory: /Users/distiller/wp-desktop
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /Users/distiller/wp-desktop
-      - *restore_nvm
-      - *setup_nvm
-      - *save_nvm
-      - *npm_restore_cache
-      - run:
-          name: Npm install
-          command: |
-            source $HOME/.nvm/nvm.sh
-            nvm use
-            npm ci
-      - *npm_save_cache
-      - run:
-          name: Build Windows
-          environment:
-            WIN_CSC_LINK: resource/certificates/win.p12
-            CSC_FOR_PULL_REQUEST: true # don't do this in production
-            USE_HARD_LINKS: "false" # must be string
-          command: |
-                  set +e
-                  source $HOME/.nvm/nvm.sh
-                  nvm use
-                  make package BUILD_PLATFORM=w
-      - run:
-          name: Release cleanup
-          command: |
-                  set +e
-                  tar -zcvf release/win-unpacked-x64.tar.gz release/win-unpacked
-                  tar -zcvf release/win-unpacked-ia32.tar.gz release/win-ia32-unpacked
-                  rm -rf release/github
-                  rm -rf release/win-unpacked
-                  rm -rf release/win-ia32-unpacked/
-      - persist_to_workspace:
-          root: /Users/distiller/wp-desktop
-          paths:
-            - release
-
   mac:
     macos:
       xcode: "9.0"
@@ -393,14 +348,6 @@ workflows:
               ignore: /tests\/.*/
             tags:
               only: /.*/
-      - windows:
-          requires:
-          - build
-          filters:
-            branches:
-              ignore: /tests\/.*/
-            tags:
-              only: /.*/
       - linux:
           requires:
           - build
@@ -419,7 +366,6 @@ workflows:
               only: /.*/
       - artifacts:
           requires:
-            - windows
             - linux
             - mac
           filters:


### PR DESCRIPTION
Upgrading Electron necessitates we remove the codebase's dependency on prebuilt
binaries. The prebuilt binary repo we have relied on is stale and will break Windows and Linux builds when re-compilation is automatically attempted on a Mac by `node-gyp rebuild`.

This commit removes Windows from the Circle CI config.

### Motivation and Context:
In order to upgrade Electron from v1.x, we are unable to rely on the prebuilt binaries for electron-spellchecker. This changes sets us up to compile native module dependencies from source for all platforms.
<!--- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->

### Todos:
Build and deployment workflows need to be set up in a different environment AppVeyor) for Windows, but this task is not a to-do for this PR.