### PR TITLE
[Electron Upgrade] Update Linux Circle Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ references:
       name: Install linux dev dependencies
       command: |
         sudo apt-get update
-        sudo apt-get -y install libxkbfile-dev libxss-dev uuid-runtime
+        sudo apt-get -y install libxkbfile-dev libxss-dev libxext-dev libx11-dev uuid-runtime
   app_cache_paths: &app_cache_paths
     - calypso-hash
     - build


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
This PR adds `libxext-dev` and `libx11-dev` to the Circle config as requirements for building the native electron-spellchecker module on Linux (per [release.md](https://github.com/Automattic/wp-desktop/blob/develop/docs/release.md)).

**Question**: Since the goal is to compile native modules in the target environment, are these changes sufficient, or do we need to add the `machine` executor to the Linux job?

Ref: https://circleci.com/docs/2.0/executor-types/

<!--- Describe your changes in detail. -->

### Motivation and Context:
In order to upgrade Electron from v1.x, we are unable to rely on the prebuilt binaries for electron-spellchecker. This changes sets us up to compile native module dependencies from source for all platforms.
<!--- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->

### Todos:
<!--- If this PR is a work in progress PR then please state what tasks need to be done. -->
- [ ] Build on Linux, functional smoke test