### PR TITLE
[Electron Upgrade] Add e2e Utility Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ publish/node_modules/
 resource/secrets
 build
 dev-app-update.yml
+test/logs/

--- a/desktop/bin/run-e2e-tests.js
+++ b/desktop/bin/run-e2e-tests.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+const { exec, spawn } = require( 'child_process' )
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+const project = path.join( __dirname, '../..');
+const nodeModules = path.join( project, 'node_modules', '.bin' );
+
+const date = ( new Date() ).toJSON().replace( /:/g, '-' );
+const logDir = path.join( project, 'test', 'logs', `${date}` );
+
+let driver;
+let app;
+
+function wait( t, fn ) {
+    return new Promise( function( resolve ) {
+        setTimeout( resolve.bind( null, fn), t )
+    } );
+}
+
+function initDriver() {
+    let log = fs.openSync( path.join( logDir, `chromedriver-${date}.log` ), 'a' );
+
+    driver = spawn( 'node', [ 'chromedriver', '--port=9515', '--verbose' ], 
+        { stdio: [ 'ignore', log, log ], detached: true, cwd: nodeModules });
+
+    return new Promise( ( resolve, reject ) => {
+        if ( driver ) {
+            resolve();
+        } else {
+            reject( "failed to initialize chromedriver" );
+        }
+    })
+}
+
+function initApp() {
+    // TODO: Mac-only for now, but builtAppDir and startCmd can be constructed per platform.
+    let builtAppDir = path.join( project, 'release', 'mac', 'WordPress.com.app', 'Contents', 'MacOS' );
+    let startCmd = './'
+
+    let log = fs.openSync( path.join( logDir, `app-${date}.log` ), 'a' );
+
+    app = spawn( startCmd + 'WordPress.com', [ 
+        '--disable-renderer-backgrounding', '--disable-http-cache', 
+        '--start-maximized', '--remote-debugging-port=9222' ], 
+        { stdio: [ 'ignore', log, log ], detached: true, cwd: builtAppDir } 
+    );
+
+    return new Promise( (resolve, reject) => {
+        if ( app ) {
+            resolve();
+        } else {
+            reject ( 'Failed to initialize app.' );
+        }
+    } )
+}
+
+function runTests() {
+    const mocha = path.join( nodeModules, 'mocha' );
+    const e2e = path.join( project, 'test', 'tests', 'e2e.js');
+    const args = '--timeout 20000';
+
+    const cmd = `node "${mocha}" "${e2e}" ${args}`;
+
+    return new Promise( (resolve, reject) => {
+        let tests = exec( cmd, ( error, stdout, stderr ) => {
+            if ( error ) {
+                reject( error );
+                return
+            } else {
+                resolve( stdout? stdout : stderr );
+            }
+        } );
+        tests.stdout.pipe( process.stdout );
+        tests.stderr.pipe( process.stderr );
+    })
+}
+
+// Handle both user-initiated (SIGINT) and normal termination.
+process.on( 'SIGINT', function() {
+    handleExit();
+    process.exit();
+})
+
+process.on( 'exit', handleExit );
+
+function handleExit() {
+    if ( driver ) {
+        driver.kill();
+    }
+
+    if ( app ) {
+        app.kill();
+    }
+}
+
+function usernameExists() {
+    return ( process.env.E2EUSERNAME && process.env.E2EUSERNAME !== '' ) ? true : false;
+}
+
+function passwordExists() {
+    return ( process.env.E2EPASSWORD && process.env.E2EPASSWORD !== '' ) ? true : false;
+}
+
+function initLogDir() {
+    if ( !fs.existsSync( logDir ) ) {
+        fs.mkdirSync( logDir );
+    }
+}
+
+function run() {
+    const appInitWait = 5000;
+
+    if ( !usernameExists() ) {
+        console.log("Environmental variable E2EUSERNAME not set, exiting.");
+        process.exit();
+    }
+
+    if ( !passwordExists() ) {
+        console.log("Environmental variable E2EPASSWORD not set, exiting.");
+        process.exit();
+    }
+
+    initLogDir();
+
+    initApp()
+        .then ( async function() {
+            await wait( appInitWait );
+            return initDriver();
+        })
+        .then( runTests )
+        .catch( ( error ) => console.log( error ) )
+        .finally( function() {
+            process.exit();
+        })
+}
+
+run();

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:app": "make build CONFIG_ENV=release NODE_ENV=production CALYPSO_ENV=desktop",
     "install-if-deps-outdated": "node calypso/bin/install-if-deps-outdated.js",
     "dev": "make start CONFIG_ENV=development NODE_ENV=development CALYPSO_ENV=desktop-development",
-    "e2e": "mocha test/tests/e2e.js --timeout 20000"
+    "e2e": "node ./desktop/bin/run-e2e-tests.js"
   },
   "keywords": [
     "desktop",


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
This PR adds a command-line utility script for invoking the e2e tests suite.

### Motivation and Context:

- **Simplifying and automating developer workflow**: To-date, invoking the e2e test suite locally has been a tedious process, with the developer having to keep track of and manually enter the steps necessary (Chromedriver, `BINARY_PATH`, mocha, etc) to run the tests on their local machine. This script greatly simplifies invoking the tests via the command `npm run e2e`, with the developer only having to add the environment variables for their WP test account (`E2EUSERNAME` and `E2EPASSWORD`).

- **Prepare for testing on all platforms**: Currently, CI tests are run against the Mac build only, and the corresponding Circle config is bash-centric. This utility sets the stage for running the test suite on all platforms (not just Mac) in the future.

Logging of both chromedriver and the application are saved to the test/logs folder.

### How Has This Been Tested:
To test:

1. Make the application with `make build`,
2. Set WP test credentials by exporting `E2ESUERNAME` and `E2EPASSWORD`
3. Execute e2e tests with `npm run e2e`