### PR TITLE
[Upgrade Electron] Appveyor Config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifeq ($(OS),Windows_NT)
-	FILE_PATH_SEP := \
+	FILE_PATH_SEP := $(strip \)
 	ENV_PATH_SEP := ;
 else
 	FILE_PATH_SEP := /

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,50 @@
+environment:
+  CSC_ENC_KEY: 
+    secure: <TODO>
+  CSC_KEY_PASSWORD:
+    secure: <TODO>
+  GH_TOKEN:
+    secure: <TODO>
+  APPVEYOR_RDP_PASSWORD:
+    secure: <TODO>
+  CSC_LINK: .\resource\certificates\win.p12
+
+image: Visual Studio 2017
+
+configuration:
+  - Release
+
+install:
+  - ps: Install-Product node 10
+  - cinst make
+  - npm ci
+
+for:
+  # default build / .exe / signed
+  - matrix:
+      only:
+        - configuration: Release
+    before_build: 
+      - openssl aes-256-cbc -d -in .\resource\certificates\win.p12.enc -out %CSC_LINK% -k "%CSC_ENC_KEY%"
+      - openssl aes-256-cbc -d -in .\resource\secrets\config.json.enc -out .\config.json -k "%CSC_ENC_KEY%"
+    build_script:
+      - make build
+      - make test
+      - 7z x -a -ttar -so release\win-unpacked-x64.tar release\win-unpacked | 7z a -si release\win-unpacked-x64.tar.gz
+      - 7z x -a -ttar -so release\win-unpacked-ia32.tar release\win-ia32-unpacked | 7z a -si release\win-unpacked-ia32.tar.gz
+      - rmdir /s release\win-unpacked
+      - rmdir /s release\win-ia32-unpacked
+      - rmdir /s release\github
+
+artifacts:
+  - path: release\
+
+cache:
+  - node_modules
+  - '%APPDATA%\npm-cache'
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml
+
+# RDP Debug mode
+# on_finish:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
This PR adds an AppVeyor config file for Windows.

### Motivation and Context:
<!--- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->
Since upgrading Electron necessitates we move to native builds on all platforms, we're using AppVeyor to build the application for Windows.

### How Has This Been Tested:
With minimal syntax changes, I've been able to invoke the makefile in a Windows environment (with MSYS and MINGW, which are both included in AppVeyor's Windows 10 image).

### Blocker

Testing locally reveals there is an open issue against Calypso that prevents the application from being built on Windows 10.

While a fix is pending, one option might be to use a combined Linux/Windows pipeline.

Background/info in [this gist](https://gist.github.com/nsakaimbo/3e783dceddbf5ee0033e46c897a4625d).

### Todos:
<!--- If this PR is a work in progress PR then please state what tasks need to be done. -->
- [ ] Given current blocker on Calypso, determine next steps (refer to proposals in the gist linked above)
- [ ] Replace proper values for `CSC_ENC_KEY`, `CSC_KEY_PASSWORD`, `GH_TOKEN` and `APPVEYOR_RDP_PASSWORD`
- [ ] Implement linux/Windows pipeline?
- [ ] Verify and test the script, tweak and update as necessary