### PR TITLE
Load SVG images (like Gridicons) with webpack file-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6043,6 +6043,46 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-loader": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-4.2.0.tgz",
+      "integrity": "sha512-+xZnaK5R8kBJrHK0/6HRlrKNamvVS5rjyuju+rnyxRGuwUJwpAMsVzUl5dz6rK8brkzjV6JpcFNjp6NqV0g1OQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+          "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.2.0.tgz",
+          "integrity": "sha512-5EwsCNhfFTZvUreQhx/4vVQpJ/lnCAkgoIHLhSpp4ZirE+4hzFvdJi0FMub6hxbFVBJYSpeVVmon+2e7uEGRrA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
+      }
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "2.13.1",
     "eslint-plugin-react": "5.2.2",
     "ffmpeg-static": "2.4.0",
+    "file-loader": "4.2.0",
     "fs-extra": "7.0.1",
     "ignore-loader": "0.1.2",
     "json-loader": "0.5.7",

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -3,7 +3,6 @@
  */
 var path = require( 'path' );
 var webpack = require( 'webpack' );
-var fs = require( 'fs' );
 
 module.exports = {
 	target: 'node',
@@ -33,6 +32,18 @@ module.exports = {
 			{
 				test: /\.(sc|sa|c)ss$/,
 				loader: 'ignore-loader',
+			},
+			{
+				test: /\.(?:gif|jpg|jpeg|png|svg)$/i,
+				use: {
+					loader: 'file-loader',
+					options: {
+						name: '[name]-[hash].[ext]',
+						outputPath: 'images',
+						publicPath: '/calypso/images/',
+						emitFile: false,
+					},
+				},
 			},
 		],
 	},


### PR DESCRIPTION
Use the loader to generate correct URLs for server-side rendered images and icons, e.g., in `EnvironmentBadge`. Emitting the files is not necessary, as the actual assets are provided by the client Calypso bundle.

The desktop server bundle is every used only in production mode. Development server runs the classic Calypso as a server running on `calypso.localhost:3000` and points the Electron browser to that server.
