### PR TITLE
gitmodules: use https instead of ssh for calypso URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wp-calypso"]
 	path = calypso
-	url = git@github.com:Automattic/wp-calypso.git
+	url = https://github.com/Automattic/wp-calypso.git


### PR DESCRIPTION
### Description:

The syntax used expects SSH to be configured.  In the CircleCI tests,
the checkout process will use git config will to replace
"https://github.com" with the suitable SSH URL:

`git config --global url."ssh://git@github.com".insteadOf
"https://github.com" || true`

By switching to HTTPS, users that pull the repo with submodules
recursively won't require SSH configuration.  Given the above
git URL rewriting, this change shouldn't impact CI tests.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

### Motivation and Context:
Building this project on a system that doesn't have SSH configured for github.com.

### How Has This Been Tested:
`git clone https://github.com/cjp256/wp-desktop --recurse-submodules --branch=url`
