### PR TITLE
Lock to node 10

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-calypso/.nvmrc
+10.16.3

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ CURRENT_NODE_VERSION := $(shell node --version | sed -n 's/v\{0,1\}\(.*\)/\1/p')
 # Check that the current node & npm versions are the versions Calypso expects to ensure it is built safely.
 check-node-version-parity:
 ifneq ("$(CALYPSO_NODE_VERSION)", "$(CURRENT_NODE_VERSION)")
-	$(error Please ensure that wp-desktop is using NodeJS $(CALYPSO_NODE_VERSION) to match wp-calypso before continuing. 	Current NodeJS version: $(CURRENT_NODE_VERSION))
+	$(warning Please ensure that wp-desktop is using NodeJS $(CALYPSO_NODE_VERSION) to match wp-calypso before continuing. 	Current NodeJS version: $(CURRENT_NODE_VERSION))
 else 
 	@echo $(GREEN)$(CHECKMARK) Current NodeJS version is on par with Calypso \($(CALYPSO_NODE_VERSION)\) $(RESET)
 endif


### PR DESCRIPTION
This PR does 2 things:
- Replace wp-calypso `.nvmrc` symlink with an `.nvmrc` file referencing the current wp-calypso Node v10 version.
- Make the Node desktop/calypso version mismatch error a warning (don't fail the build)

This should allow to for wp-desktop to run on node v10 while wp-calypso moves ahead.

When wp-desktop is ready to move to Node v12 (and #686 is fixed), this PR can simply be reverted.

This should allow wp-calypso to move ahead with https://github.com/Automattic/wp-calypso/pull/37031