### PR TITLE
Fix Electron-Updater (Broken with Catalina Patch)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,3 +169,8 @@ clean:
 	@rm -rf .$/build
 
 .PHONY: test build-source
+
+apply-patch:
+	@echo "Applying module patches..."
+
+	patch "./node_modules/electron-updater/out/MacUpdater.js" "./resource/macos/electron-updater.patch" 

--- a/desktop-config/config-updater.json
+++ b/desktop-config/config-updater.json
@@ -10,6 +10,7 @@
 		"downloadUrl": "https://github.com/Automattic/wp-desktop/releases",
 		"apiUrl": "https://api.github.com/repos/Automattic/wp-desktop/releases",
 		"delay": 2000,
-		"interval": 600000
+		"interval": 600000,
+		"updaterCacheDirName": "WordPress.com/__update__"
 	}
 }

--- a/desktop/env.js
+++ b/desktop/env.js
@@ -34,6 +34,14 @@ process.env.CALYPSO_ENV = config.calypso_config;
 // Set app config path
 app.setPath( 'userData', path.join( app.getPath( 'appData' ), config.appPathName ) );
 
+app.isPackaged = ( () => {
+	const execFile = path.basename( process.execPath ).toLowerCase();
+	if ( process.platform === 'win32' ) {
+		return execFile !== 'electron.exe'
+	}
+	return execFile !== 'electron'
+} )()
+
 // If debug is enabled then setup the debug target
 if ( Settings.isDebug() ) {
 	process.env.DEBUG_COLORS = config.debug.colors;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "build/desktop.js",
   "scripts": {
     "preinstall": "make check-node-version-parity",
-    "postinstall": "make rebuild-deps",
+    "postinstall": "make apply-patch && make rebuild-deps",
     "setup": "npm run install-if-deps-outdated && ( check-node-version --package || exit 0 ) && cd ./calypso && node ./bin/install-if-deps-outdated.js",
     "build:app": "make build CONFIG_ENV=release NODE_ENV=production CALYPSO_ENV=desktop",
     "install-if-deps-outdated": "node calypso/bin/install-if-deps-outdated.js",

--- a/resource/macos/electron-updater.patch
+++ b/resource/macos/electron-updater.patch
@@ -1,0 +1,9 @@
+184,189c184
+<               _this.nativeUpdater.setFeedURL({
+<                 url: getServerUrl(),
+<                 headers: {
+<                   "Cache-Control": "no-cache"
+<                 }
+<               });
+---
+>               _this.nativeUpdater.setFeedURL( getServerUrl(), { "Cache-Control": "no-cache" } );


### PR DESCRIPTION
**Update 11/28**: Code changes so far seem to have fixed the updater on Mac. However the "differential update" (i.e. blockmap) mechanism on Windows isn't working, and the cause seems fairly deep-rooted in the internals of `electron-builder` and `electron-updater` and inconsistencies with the very stale version of Electron currently in use.

<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

In order to get the application to build on Mac OS 10.15, we had to upgrade electron-updater to v21.2.0 in #706. However, because of incompatibilities with Electron 1.7.16, the auto-update mechanism in develop (as of SHA 2c0a992) was broken.

### Description:

The newer version of `electron-updater` expects an updated interface to select Electron APIs (which will not be available until Electron is upgraded). This PR (which should be reverted with the upgrade) patches Electron for the following APIs:

- Add `app.isPackaged` (indicating whether or not the application is packaged for release)
- Modify the internals of new `electron-updater` to use the (outdated) version of of the call to `setFeedURL`

### How Has This Been Tested:

- Change the `version` number in package.json (to an earlier version than current)
- Build and install the application with `make build CONFIG_ENV=release` config
- Note that the auto-updater prompt is displayed. The application should be updated if "Update and Restart" is selected.

### Screenshots:

<img width="800" alt="Screen Shot 2019-11-26 at 3 10 29 PM" src="https://user-images.githubusercontent.com/8979548/69745567-777c3880-1110-11ea-8f2f-53f2a507c128.png">

### Todos:
<!--- If this PR is a work in progress PR then please state what tasks need to be done. -->
<!-- - [ ] Task 1 -->
<!-- - [ ] Task 2 -->
<!-- - [ ] Task 3 -->
- [x] Confirmed working on Mac
- [ ] Confirmed working on Linux
- [ ] ~~Confirmed working on Windows~~
