### PR TITLE
Transpile the chalk module to ES5

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -30,6 +30,15 @@ module.exports = {
 				exclude: /node_modules/,
 			},
 			{
+				test: /\.js$/,
+				loader: 'babel-loader',
+				include: filepath => {
+					// is it the chalk module? Then transpile it, too
+					const lastIndex = filepath.lastIndexOf( '/node_modules/' );
+					return lastIndex !== -1 && filepath.startsWith( '/node_modules/chalk/', lastIndex );
+				},
+			},
+			{
 				test: /\.(sc|sa|c)ss$/,
 				loader: 'ignore-loader',
 			},


### PR DESCRIPTION
A minimalistic fix for https://github.com/Automattic/wp-calypso/issues/38527. The desktop server bundle is compiled in the `wp-desktop` repo and imports modules from the `calypso/` directory and its `node_modules`. One of the dependencies is `chalk@3`, which ships untranspiled ES6 code (const and let, for .. of, default arguments, shorthand getters, you name it).

The Calypso itself is OK, because `chalk` is used only in server code which runs on latest Node. But the Electron version we use apparently doesn't support some of the syntax.

**How to test:**
Build desktop locally (`make build`) with the latest commit of the Calypso repo. Run the desktop app you just built.

Before this patch, I was getting the JS error modal as shown in https://github.com/Automattic/wp-calypso/issues/38527. After this patch it's gone and the app starts OK.