### PR TITLE
[mac] Enable LSFileQuarantineEnabled for OSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,10 @@
       "category": "public.app-category.social-networking",
       "entitlements": "./resource/macos/entitlements.mac.plist",
       "entitlementsInherit": "./resource/macos/entitlements.mac.inherit.plist",
-      "hardenedRuntime": true
+      "hardenedRuntime": true,
+      "extendInfo": {
+        "LSFileQuarantineEnabled": true
+      }
     },
     "dmg": {
       "title": "WordPress.com Installer",


### PR DESCRIPTION
This change makes it so files created by the application (and subprocesses) are quarantined by default. When quarantining files, the system automatically associates the app name, bundle id with the quarantined file whenever possible. This mitigates attacks via remote code execution.

This change is in response to a recently revealed vulnerability in which a user editing a post may run malicious code by double-clicking an executable downloaded via Opt+Click. This would bypass Mac OS's Gatekeeper completely. 

Adding the `LSFileQuarantineEnabled` flag ensures that Gatekeeper will correctly flag such files and prevent them from running.

### How Has This Been Tested:
Behavior in both the current release of the application (v4.6.0) and a custom build with this patch was tested with a variety of media (`.terminal` executable and media such as `.png` and `.mp3`).

- The current stable release (v4.6.0) allowed the executable to run. A build with this patch did not.
- This patch does not appear to interrupt expected interaction with other media types (such as audio and images). 

<p align="center">
<img width="416" alt="Screen Shot 2020-01-10 at 5 54 10 PM" src="https://user-images.githubusercontent.com/8979548/72192056-3abf8480-33d2-11ea-89bd-2c90bd93307f.png">
</p>