### PR TITLE
Adapt desktop server build after Calypso server folder rename

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ references:
     - resource/certificates/win.p12
     - resource/certificates/mac.p12
     - calypso/public
-    - calypso/server
+    - calypso/client/server
     - calypso/config
     - calypso/package.json
     - calypso/packages

--- a/desktop/server/server.js
+++ b/desktop/server/server.js
@@ -26,7 +26,7 @@ function showFailure( app ) {
 }
 
 function startServer( running_cb ) {
-	var boot = require( 'boot' );
+	var boot = require( 'server/boot' );
 	var http = require( 'http' );
 	var server = http.createServer( boot() );
 

--- a/package.json
+++ b/package.json
@@ -103,10 +103,7 @@
         "filter": [
           "public/**/*",
           "!public/**/*.css.map",
-          "server/pages/**/*",
-          "!server/pages/test",
-          "!server/pages/README.md",
-          "server/bundler/assets*.json",
+          "client/server/bundler/assets*.json",
           "config/*(secrets|_shared|desktop).json"
         ]
       }

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -16,7 +16,7 @@ module.exports = {
 			{
 				include: path.join( __dirname, 'calypso', 'client/sections.js' ),
 				use: {
-					loader: path.join( __dirname, 'calypso', 'server', 'bundler', 'sections-loader' ),
+					loader: path.join( __dirname, 'calypso', 'client', 'server', 'bundler', 'sections-loader' ),
 					options: { forceRequire: true, onlyIsomorphic: true },
 				},
 			},
@@ -75,9 +75,7 @@ module.exports = {
 
 		// These are Calypso server modules we don't need, so let's not bundle them
 		'webpack.config',
-		'bundler/hot-reloader',
-		'devdocs/search-index',
-		'devdocs/components-usage-stats.json',
+		'server/devdocs/search-index',
 	],
 	resolve: {
 		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
@@ -85,10 +83,12 @@ module.exports = {
 			'node_modules',
 			path.join( __dirname, 'calypso', 'node_modules' ),
 			path.join( __dirname, 'node_modules' ),
-			path.join( __dirname, 'calypso', 'server' ),
 			path.join( __dirname, 'calypso', 'client' ),
 			path.join( __dirname, 'desktop' ),
 		],
+		alias: {
+			config: 'server/config',
+		},
 	},
 	plugins: [
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]abtest$/, 'lodash/noop' ), // Depends on BOM


### PR DESCRIPTION
This will fix the desktop build after https://github.com/Automattic/wp-calypso/pull/38190 is merged. Reacts to rename of the `calypso/server/` folder to `calypso/client/server/`.