### PR TITLE
[.gitignore] Ignore Decrypted Certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ publish/node_modules/
 resource/secrets
 build
 dev-app-update.yml
+resource/certificates/mac.p12
+resource/certificates/win.p12


### PR DESCRIPTION
### Description

This PR ensures the decrypted Mac and Win code signing certificates are ignored so they are never committed to the repo by mistake (easy to do with `git add .`).