### PR TITLE
Use the @automattic/calypso-polyfills package to polyfill the JS environment

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,10 @@ const electronVersion = require( 'electron/package.json' ).version;
 
 module.exports = {
 	presets: [
-		[ '@babel/env', { targets: { electron: electronVersion }, useBuiltIns: 'usage', corejs: '3.6.1' } ],
+		[
+			'@babel/env',
+			{ targets: { electron: electronVersion }, useBuiltIns: 'entry', corejs: '3.6' },
+		],
 		'@babel/react',
 		'@babel/preset-typescript',
 	],

--- a/desktop/index.js
+++ b/desktop/index.js
@@ -1,3 +1,5 @@
+require( '@automattic/calypso-polyfills' );
+
 /**
  * Internal dependencies
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,24 @@
       "integrity": "sha512-AsnBZN3a8/JcNt+KPkGGODaA4c7l3W5+WpeKgGSbstSLxqWtTXqd1ieJGBQ8IFCtRg8DmmKUcSkIkUc0A4p3YA==",
       "dev": true
     },
+    "@automattic/calypso-polyfills": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@automattic/calypso-polyfills/-/calypso-polyfills-1.0.0.tgz",
+      "integrity": "sha512-VWeG7tGQyEglnLneWWgY+tF+G6liJy2i5OZUsSY+UURmLP5tGTCNW5HCYEla3RRyJOCES+0JMAoMxYDsA8KgMw==",
+      "requires": {
+        "core-js": "3.6.3",
+        "isomorphic-fetch": "2.2.1",
+        "regenerator-runtime": "0.13.3",
+        "svg4everybody": "2.1.9"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.3.tgz",
+          "integrity": "sha512-DOO9b18YHR+Wk5kJ/c5YFbXuUETreD4TrvXb6edzqZE3aAEd0eJIAWghZ9HttMuiON8SVCnU3fqA4rPxRDD1HQ=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -4075,11 +4093,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.1.tgz",
-      "integrity": "sha512-186WjSik2iTGfDjfdCZAxv2ormxtKgemjC3SI6PL31qOA0j5LhTDVjHChccoc7brwLvpvLPiMyRlcO88C4l1QQ=="
-    },
     "core-js-compat": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.1.tgz",
@@ -7861,8 +7874,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -7917,6 +7929,15 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -8981,6 +9002,15 @@
       "integrity": "sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==",
       "requires": {
         "semver": "^5.4.1"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-gyp": {
@@ -10258,6 +10288,11 @@
         "regenerate": "^1.4.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+    },
     "regenerator-transform": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
@@ -11315,6 +11350,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "svg4everybody": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/svg4everybody/-/svg4everybody-2.1.9.tgz",
+      "integrity": "sha1-W9n23vwTOFmgRGRtR0P6vCjbfi0="
     },
     "symbol-observable": {
       "version": "1.0.1",
@@ -12708,6 +12748,11 @@
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "xvfb-maybe": "0.2.1"
   },
   "dependencies": {
+    "@automattic/calypso-polyfills": "1.0.0",
     "acorn": "6.1.1",
-    "core-js": "3.6.1",
     "debug": "2.6.8",
     "electron-fetch": "1.2.1",
     "electron-spellchecker": "github:nsakaimbo/electron-spellchecker-prebuilt#electron-spellchecker-v1.1.2-prebuild",

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -33,9 +33,14 @@ module.exports = {
 				test: /\.js$/,
 				loader: 'babel-loader',
 				include: filepath => {
-					// is it the chalk module? Then transpile it, too
+					// is it one of the npm dependencies we want to transpile?
 					const lastIndex = filepath.lastIndexOf( '/node_modules/' );
-					return lastIndex !== -1 && filepath.startsWith( '/node_modules/chalk/', lastIndex );
+					if ( lastIndex === -1 ) {
+						return false;
+					}
+					return [ 'chalk', '@automattic/calypso-polyfills' ].some( pkg =>
+						filepath.startsWith( `/node_modules/${ pkg }/`, lastIndex )
+					);
 				},
 			},
 			{


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/38819

Uses the new `@automattic/calypso-polyfills` package to ensure that features like `globalThis` or `Array.prototype.flat` are polyfilled in the Electron server environment.

**How to test:**
Verify that after updating Calypso to the latest master, you don't get runtime errors like these described in https://github.com/Automattic/wp-calypso/issues/38819 and that the desktop app runs correctly.
