### PR TITLE
Electron upgrade v4.2.9 fix spellchecker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,19 @@
       "integrity": "sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==",
       "dev": true
     },
+    "@aabuhijleh/electron-remote": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@aabuhijleh/electron-remote/-/electron-remote-1.4.0.tgz",
+      "integrity": "sha512-EG4ZXxqbFY4lpX55vctwz14mFrEOcOHFCMLH5z5lOl6fiviTqscy86tSlKwEE3/o3ExtdPr2tECgCogYYL7d+g==",
+      "requires": {
+        "debug": "^2.5.1",
+        "hashids": "^1.1.1",
+        "lodash.get": "^4.4.2",
+        "pify": "^2.3.0",
+        "rxjs": "^5.0.0-beta.12",
+        "xmlhttprequest": "^1.8.0"
+      }
+    },
     "@automattic/calypso-polyfills": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@automattic/calypso-polyfills/-/calypso-polyfills-1.0.0.tgz",
@@ -19,13 +32,6 @@
         "isomorphic-fetch": "2.2.1",
         "regenerator-runtime": "0.13.3",
         "svg4everybody": "2.1.9"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.6.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.3.tgz",
-          "integrity": "sha512-DOO9b18YHR+Wk5kJ/c5YFbXuUETreD4TrvXb6edzqZE3aAEd0eJIAWghZ9HttMuiON8SVCnU3fqA4rPxRDD1HQ=="
-        }
       }
     },
     "@babel/code-frame": {
@@ -2213,23 +2219,19 @@
         "ajv-keywords": "^3.1.0"
       }
     },
-    "@paulcbetts/cld": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@paulcbetts/cld/-/cld-2.4.6.tgz",
-      "integrity": "sha1-qZL2vEPKshKsLESIpnHPMC+LYuc=",
+    "@felixrieseberg/spellchecker": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@felixrieseberg/spellchecker/-/spellchecker-4.0.12.tgz",
+      "integrity": "sha512-jLAPnRALB1I6Un8ldHVJfJid7m2R1qXoafFF/95sdm7R5VPOsZ3xTreZ/wLKO5x9AdsD2t9zpOcjDFTsCf3VzQ==",
       "requires": {
-        "glob": "^5.0.10",
-        "nan": "^2.0.5",
-        "rimraf": "^2.4.0",
-        "underscore": "^1.6.0"
-      }
-    },
-    "@paulcbetts/spellchecker": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@paulcbetts/spellchecker/-/spellchecker-4.0.6.tgz",
-      "integrity": "sha512-9lhLEvWfAB00n2oOM/S08sna9AuFk+b+bPk8ficpSa2X0Ll40PahMwfFS3G54nqQBIFFZgTPrhoHtCLAao0xmg==",
-      "requires": {
-        "nan": "^2.0.0"
+        "nan": "^2.14.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        }
       }
     },
     "@sindresorhus/is": {
@@ -3732,6 +3734,17 @@
         }
       }
     },
+    "cld": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/cld/-/cld-2.5.1.tgz",
+      "integrity": "sha512-DwdvvcFVizwDdPCocoPPReFk3BwLEaTZ3RzFgJ4jLzsBzJKUC3cTna0ZmAZG4tFtMmQdl0ciso3+ijkH3OPZPA==",
+      "requires": {
+        "glob": "^5.0.10",
+        "nan": "^2.9.2",
+        "rimraf": "^2.4.0",
+        "underscore": "^1.6.0"
+      }
+    },
     "cli-boxes": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
@@ -4045,6 +4058,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "core-js": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.3.tgz",
+      "integrity": "sha512-DOO9b18YHR+Wk5kJ/c5YFbXuUETreD4TrvXb6edzqZE3aAEd0eJIAWghZ9HttMuiON8SVCnU3fqA4rPxRDD1HQ=="
     },
     "core-js-compat": {
       "version": "3.6.1",
@@ -5036,36 +5054,56 @@
         }
       }
     },
-    "electron-remote": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/electron-remote/-/electron-remote-1.3.0.tgz",
-      "integrity": "sha512-i00MD42fzlmyhsYRUDrMM104OQTT/soEmBmZ707CZ3k/nwa0rrB3a3mpxvR0EI2Q+Xw2VBdhWbk2gYmyg0PS0g==",
-      "requires": {
-        "debug": "^2.5.1",
-        "hashids": "^1.1.1",
-        "lodash.get": "^4.4.2",
-        "pify": "^2.3.0",
-        "rxjs": "^5.0.0-beta.12",
-        "xmlhttprequest": "^1.8.0"
-      }
-    },
     "electron-spellchecker": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/electron-spellchecker/-/electron-spellchecker-1.1.2.tgz",
-      "integrity": "sha512-AdzD/Q82Svk9EDTc65vRr271UPLVIxsruKJM0iwqxEG9Y/CogNhEAJz/asV0BFWom4tpdB6cHcLbYePb11Musw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/electron-spellchecker/-/electron-spellchecker-2.2.1.tgz",
+      "integrity": "sha512-IqxJmYq/5qyTNo9ONxHr9D/9UxiXVvDbl01s2f71S3aAHtDIc7I7qqEycvNUlFGR1WVBgFc/VzV4+deQwxgikA==",
       "requires": {
-        "@paulcbetts/cld": "^2.4.6",
-        "@paulcbetts/spellchecker": "^4.0.6",
+        "@aabuhijleh/electron-remote": "^1.4.0",
+        "@felixrieseberg/spellchecker": "^4.0.12",
         "bcp47": "^1.1.2",
-        "debug": "^2.6.3",
-        "electron-remote": "^1.1.1",
-        "keyboard-layout": "^2.0.7",
-        "lru-cache": "^4.0.2",
+        "cld": "^2.5.1",
+        "debug": "^4.1.1",
+        "keyboard-layout": "^2.0.16",
+        "lru-cache": "^5.1.1",
         "mkdirp": "^0.5.1",
-        "pify": "^2.3.0",
+        "pify": "^4.0.1",
         "rxjs": "^5.0.1",
         "rxjs-serial-subscription": "^0.1.1",
         "spawn-rx": "^2.0.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
       }
     },
     "electron-to-chromium": {
@@ -7975,6 +8013,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -9257,7 +9296,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "psl": {
       "version": "1.1.32",
@@ -12063,7 +12103,8 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yargs": {
       "version": "13.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9931,11 +9931,11 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.1.tgz",
+      "integrity": "sha1-Omm9+fDKCphjAzcNRwj3K9+sg1Y=",
       "requires": {
-        "symbol-observable": "1.0.1"
+        "symbol-observable": "^1.0.1"
       }
     },
     "rxjs-serial-subscription": {
@@ -10380,6 +10380,21 @@
         "debug": "^2.5.1",
         "lodash.assign": "^4.2.0",
         "rxjs": "^5.1.1"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "5.5.12",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+          "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+        }
       }
     },
     "spdx-correct": {
@@ -10660,9 +10675,9 @@
       "integrity": "sha1-W9n23vwTOFmgRGRtR0P6vCjbfi0="
     },
     "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "table": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "acorn": "6.1.1",
     "debug": "2.6.8",
     "electron-fetch": "1.2.1",
-    "electron-spellchecker": "1.1.2",
+    "electron-spellchecker": "2.2.1",
     "electron-updater": "4.0.0",
     "express": "4.15.3",
     "js-yaml": "3.12.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "lodash.debounce": "4.0.8",
     "nan": "2.11.1",
     "portscanner": "1.2.0",
+    "rxjs": "5.0.1",
     "semver": "5.6.0",
     "superagent": "1.8.5"
   },


### PR DESCRIPTION
### Description

This PR restores spellchecker functionality, which was lost as a result of upgrading Electron in wp-desktop. The expected behavior is fixed by:

#### 1. Attaching the spellchecker after the editor iframe is loaded.

In order to address a limitation of updated Electron's spellcheck API, we need to ensure that the spellchecker is attached after the Gutenberg editor is fully loaded. We could have listened for the window event [directly](https://github.com/Automattic/wp-calypso/blob/e1face4840c4d7710a66d76d90bf1ff810dede8b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js#L798), but this wouldn't be aligned with the existing architecture that relays Calypso events to Electron via Calypso's `client/lib/desktop` module. Instead, we create a corresponding redux event in Calypso and send _that_ to Electron's preload script.

See the corresponding Calypso PR at github/Automattic/wp-calypso#38986.

#### 2. Circumventing the spellchecker's early exit condition

`electron-spellchecker`'s currently implementation assumes that content in the document body is being actively edited when `attachToInput` is called.

https://github.com/electron-userland/electron-spellchecker/blob/7227d61415c47dfa247828da3b62bbb3330095aa/src/spell-check-handler.js#L206

The Calypso editor doesn't satisfy this assumption when a post (either existing or new) is loaded. As a workaround, we inject a dummy observable to prevent the method from exiting before the user begins to make edits.

### To Test

1. Build and run the application, ensuring to check out the appropriate patch of Calypso that wires up the `editor-loaded` event
2. Start editing an existing or new post
3. Misspellings should be highlighted in active text areas, per the screenshots attached

<p = align="center">
<img width="685" alt="Screen Shot 2020-01-16 at 7 19 21 PM" src="https://user-images.githubusercontent.com/8979548/72829449-cd6ee780-3c4c-11ea-832b-df3641ecfbdc.png">
<br>
<img width="681" alt="Screen Shot 2020-01-16 at 7 19 11 PM" src="https://user-images.githubusercontent.com/8979548/72829371-a4e6ed80-3c4c-11ea-915f-3cffeba30ec0.png">
</p>