### PR TITLE
[e2e] Add Sign up flow - take 2

### DIFF
--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -3,11 +3,13 @@ const webdriver = require( 'selenium-webdriver' );
 const chrome = require( 'selenium-webdriver/chrome' );
 const EditorPage = require( './lib/pages/editor-page' );
 const LoginPage = require( './lib/pages/login-page' );
+const SignupStepsPage = require( './lib/pages/signup-steps-page' );
 const PostEditorToolbarComponent = require( './lib/components/post-editor-toolbar-component' );
 const NavBarComponent = require( './lib/components/nav-bar-component' );
 const ProfilePage = require( './lib/pages/profile-page' );
 const ReaderPage = require( './lib/pages/reader-page' );
 const ViewPostPage = require( './lib/pages/view-post-page' );
+const ChecklistPage = require( './lib/pages/checklist-page' );
 
 const dataHelper = require( './lib/data-helper' );
 let options = new chrome.Options();
@@ -40,9 +42,9 @@ before( async function() {
 describe( 'User Can log in', function() {
 	this.timeout( 30000 );
 
-	step( 'Delete all cookies', async function() {
-		await driver.manage().deleteAllCookies();
-		return await driver.sleep( 1000 );
+	step( 'Clear local storage', async function() {
+		await driver.executeScript( 'window.localStorage.clear();' );
+		return await driver.sleep( 3000 );
 	} );
 
 	step( 'Can log in', async function() {
@@ -112,6 +114,62 @@ describe( 'Can Log Out', function() {
 
 	step( 'Can see app login page after logging out', async function() {
 		return await LoginPage.Expect( driver );
+	} );
+} );
+
+describe( 'Can Sign up', function() {
+	this.timeout( 30000 );
+	const blogName = dataHelper.getNewBlogName();
+	const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
+	const emailAddress = blogName + process.env.E2E_MAILOSAUR_INBOX;
+
+	step( 'Clear local storage', async function() {
+		await driver.executeScript( 'window.localStorage.clear();' );
+		return await driver.sleep( 3000 );
+	} );
+
+	step( 'Can navigate to Create account', async function() {
+		let loginPage = await LoginPage.Expect( driver );
+		await loginPage.hideGdprBanner();
+		await loginPage.openCreateAccountPage();
+		return await SignupStepsPage.Expect( driver );
+	} );
+
+	step( 'Can see the "Site Topic" page, and enter the site topic', async function() {
+		const signupStepsPage = await SignupStepsPage.Expect( driver );
+		return await signupStepsPage.aboutSite();
+	} );
+
+	step( 'Choose a theme page', async function() {
+		const signupStepsPage = await SignupStepsPage.Expect( driver );
+		return await signupStepsPage.selectTheme();
+	} );
+
+	step(
+		'Can search for a blog name, can see and select a free .wordpress address',
+		async function() {
+			const signupStepsPage = await SignupStepsPage.Expect( driver );
+			return await signupStepsPage.selectDomain( blogName );
+		}
+	);
+
+	step( 'Can see the plans page and pick the free plan', async function() {
+		const signupStepsPage = await SignupStepsPage.Expect( driver );
+		return await signupStepsPage.selectFreePlan();
+	} );
+
+	step( 'Can see the account page, enter account details and submit', async function() {
+		const signupStepsPage = await SignupStepsPage.Expect( driver );
+		return await signupStepsPage.enterAccountDetailsAndSubmit(
+			emailAddress,
+			blogName,
+			process.env.E2EPASSWORD
+		);
+	} );
+
+	step( 'Can then see the onboarding checklist', async function() {
+		const checklistPage = await ChecklistPage.Expect( driver );
+		return await checklistPage.isChecklistPresent();
 	} );
 } );
 

--- a/test/tests/lib/data-helper.js
+++ b/test/tests/lib/data-helper.js
@@ -1,6 +1,7 @@
 /** @format */
 
 const phrase = require( 'asana-phrase' );
+const map = require( 'lodash' );
 
 String.prototype.toProperCase = function() {
 	return this.replace( /\w\S*/g, function( txt ) {
@@ -8,8 +9,23 @@ String.prototype.toProperCase = function() {
 	} );
 };
 
+function getRandomInt( min, max ) {
+	return Math.floor( Math.random() * ( max - min + 1 ) ) + min;
+}
+
 exports.randomPhrase = function() {
 	let gen = phrase.default32BitFactory().randomPhrase();
 	return `${ gen[ 1 ].toProperCase() } ${ gen[ 2 ].toProperCase() } ${ gen[ 3 ].toProperCase() } ${ gen[ 4 ].toProperCase() }`;
+};
+
+exports.getNewBlogName = function() {
+	return `e2eflowtesting${ new Date().getTime().toString() }${ getRandomInt( 100, 999 ) }desktop`;
+};
+
+exports.getExpectedFreeAddresses = async function( searchTerm ) {
+	const suffixes = [ '.wordpress.com', 'blog.wordpress.com', 'site.wordpress.com', '.home.blog' ];
+	return map( suffixes, suffix => {
+		return searchTerm + suffix;
+	} );
 };
 

--- a/test/tests/lib/driver-helper.js
+++ b/test/tests/lib/driver-helper.js
@@ -266,3 +266,11 @@ exports.waitForFieldClearable = function( driver, selector ) {
 			}' to be clearable`
 	);
 };
+
+exports.selectElementByText = async function( driver, selector, text ) {
+	const element = async () => {
+		const allElements = await driver.findElements( selector );
+		return await webdriver.promise.filter( allElements, async e => ( await e.getText() ) === text );
+	};
+	return await this.clickWhenClickable( driver, element );
+};

--- a/test/tests/lib/pages/checklist-page.js
+++ b/test/tests/lib/pages/checklist-page.js
@@ -1,0 +1,21 @@
+/** @format */
+
+const { By } = require( 'selenium-webdriver' );
+const AsyncBaseContainer = require( '../async-base-container' );
+const driverHelper = require( '../driver-helper' );
+
+class ChecklistPage extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.checklist' ) );
+	}
+
+	async isChecklistPresent() {
+		return await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			By.css( '.checklist__tasks' ),
+			20000
+		);
+	}
+}
+
+module.exports = ChecklistPage;

--- a/test/tests/lib/pages/login-page.js
+++ b/test/tests/lib/pages/login-page.js
@@ -15,6 +15,8 @@ class LoginPage extends AsyncBaseContainer {
 		const passwordSelector = By.name( 'password' );
 		const submitSelector = By.css( 'button.is-primary' );
 
+		await this.hideGdprBanner();
+
 		await driverHelper.waitTillPresentAndDisplayed( driver, userNameSelector );
 		await driverHelper.setWhenSettable( driver, userNameSelector, username );
 
@@ -23,6 +25,22 @@ class LoginPage extends AsyncBaseContainer {
 		} );
 		await driverHelper.clickWhenClickable( driver, submitSelector );
 		return await driver.sleep( 1000 );
+	}
+
+	async hideGdprBanner() {
+		const gdprBannerButton = By.css( '.gdpr-banner__acknowledge-button' );
+		try {
+			await driverHelper.waitTillPresentAndDisplayed( this.driver, gdprBannerButton, 5000 );
+			return await driverHelper.clickWhenClickable( this.driver, gdprBannerButton );
+		} catch ( e ) {
+			console.log( 'GDPR button is not present.' );
+			return true;
+		}
+	}
+
+	async openCreateAccountPage() {
+		const element = By.css( '.auth__links a' );
+		return await driverHelper.clickWhenClickable( this.driver, element );
 	}
 }
 

--- a/test/tests/lib/pages/signup-steps-page.js
+++ b/test/tests/lib/pages/signup-steps-page.js
@@ -1,0 +1,87 @@
+/** @format */
+
+const { By } = require( 'selenium-webdriver' );
+const AsyncBaseContainer = require( '../async-base-container' );
+const driverHelper = require( '../driver-helper' );
+
+class SignupStepsPage extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.signup__steps' ) );
+	}
+
+	async aboutSite() {
+		const siteNameForm = By.css( '#siteTitle' );
+		const siteName = 'e2eflowtesting desktop app';
+
+		const siteTopicForm = By.css( '#siteTopic' );
+		const aboutSite = 'about e2eflowtesting desktop app';
+
+		const shareCheckbox = By.css( '#share' );
+		const comfortableScale = By.css( '.segmented-control__text' );
+		const submitButton = By.css( '.about__submit-wrapper .is-primary' );
+
+		await driverHelper.setWhenSettable( this.driver, siteNameForm, siteName );
+		await driverHelper.setWhenSettable( this.driver, siteTopicForm, aboutSite );
+
+		await driverHelper.clickWhenClickable( this.driver, shareCheckbox );
+		await driverHelper.selectElementByText( this.driver, comfortableScale, '3' );
+
+		return await driverHelper.clickWhenClickable( this.driver, submitButton );
+	}
+
+	async selectTheme() {
+		const themeSelector = By.css( '.theme' );
+
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.is-themes' ) );
+		await driverHelper.clickWhenClickable( this.driver, themeSelector );
+	}
+
+	async selectDomain( domainName ) {
+		const searchDomainField = By.css( '.search__input' );
+
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.register-domain-step__search' )
+		);
+		await driverHelper.setWhenSettable( this.driver, searchDomainField, domainName );
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.domain-suggestion__content' )
+		);
+
+		return await this.selectFreeAddress();
+	}
+
+	async selectFreeAddress() {
+		return await driverHelper.selectElementByText(
+			this.driver,
+			By.css( '.domain-product-price__price' ),
+			'Free'
+		);
+	}
+
+	async selectFreePlan() {
+		const plansPage = By.css( '.is-plans' );
+		const freePlanButton = By.css( '.is-free-plan' );
+
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, plansPage );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, freePlanButton );
+		return await driverHelper.clickWhenClickable( this.driver, freePlanButton );
+	}
+
+	async enterAccountDetailsAndSubmit( email, username, password ) {
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.signup-form' ) );
+
+		await driverHelper.setWhenSettable( this.driver, By.css( '#email' ), email );
+		await driverHelper.setWhenSettable( this.driver, By.css( '#username' ), username );
+		await driverHelper.setWhenSettable( this.driver, By.css( '#password' ), password, {
+			secureValue: true,
+		} );
+
+		await driverHelper.clickWhenClickable( this.driver, By.css( 'button.signup-form__submit' ) );
+
+		return await this.driver.sleep( 5000 );
+	}
+}
+
+module.exports = SignupStepsPage;


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
This PR adds a new test to e2e tests suite - Sign up test. 

Similar to wp-calypso Sign up specs, this is a basic sign up process with a free domain and free plan chosen. 

### Motivation and Context:
<!--- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->
Expand wp-desktop e2e tests suite. Let's start with the sign up flow and evaluate benefits :) 

### How Has This Been Tested:
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, tests completed to see 
how your change affects other areas of the code, etc. -->
Run tests locally or in CircleCI. Make sure they are passing. Some inconsistencies still could happen. If that's the case, please share CircleCI URL or the error message from your console in this PR so I can investigate further. 

**NOTE:** This PR is a copy of https://github.com/Automattic/wp-desktop/pull/731, only without the change where the version of calypso(hash) was changed. Since @nsakaimbo and I couldn't find the way how to fix previous PR and revert calypso change, I opened a new one. 