### PR TITLE
[CI] Enable Circle v2 API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,8 @@ jobs:
       CONFIG_ENV: release
       MINIFY_JS: true
       NODE_ARGS: --max_old_space_size=3072
+      BRANCHNAME: << pipeline.git.branch >>
+      CALYPSO_HASH: << pipeline.parameters.CALYPSO_HASH >>
     steps:
       - checkout
       - *install_linux_dependencies
@@ -457,3 +459,20 @@ workflows:
               ignore: /tests\/.*/
             tags:
               only: /.*/
+
+# Circle API v2 build trigger parameters
+# Ref: https://circleci.com/docs/2.0/pipeline-variables/
+# Ref: https://circleci.com/docs/2.0/reusing-config/#parameter-syntax
+parameters:
+  CALYPSO_HASH:
+    type: string
+    default: "" 
+  sha:
+    type: string
+    default: "" 
+  pullRequestNum:
+    type: string
+    default: "" 
+  calypsoProject:
+    type: string
+    default: ""


### PR DESCRIPTION
### Description

In order to support the recent Electron upgrade, we are now using Circle config v2.1 (in order to support native builds on Windows, Mac and Linux). This had the unintended side effect of breaking the canary build job, since canary uses Circle's v1.1 API endpoint which does *not* support pipelines when triggering builds ([ref](https://discuss.circleci.com/t/2-1-requires-pipelines-but-pipelines-are-enabled-in-project-settings/30484/7)).

There is an open PR against the wp-desktop-gh-bridge bridge (canary API trigger) to use the Circle v2 API. This change adds the required v2 API syntax to ensure canary builds are triggered by way of the updated API call.

### How Has This Been Tested

Refer to github/Automattic/wp-desktop-gh-bridge#13 for details on how the updated API call has been tested against changes in this branch.