### PR TITLE
[CI] Add sha and calypsoProject pipeline parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,8 @@ jobs:
       NODE_ARGS: --max_old_space_size=3072
       BRANCHNAME: << pipeline.git.branch >>
       CALYPSO_HASH: << pipeline.parameters.CALYPSO_HASH >>
+      sha: << pipeline.parameters.sha >>
+      calypsoProject: << pipeline.parameters.calypsoProject >>
     steps:
       - checkout
       - *install_linux_dependencies


### PR DESCRIPTION
### Description

This PR is a follow-on to #762 that adds the `sha` and `calypsoProject` parameters sent by the canary bridge webhook.
