### PR TITLE
[CI] Use Correct Type (int) for pullRequestNum Pipeline Param

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,8 +473,8 @@ parameters:
     type: string
     default: "" 
   pullRequestNum:
-    type: string
-    default: "" 
+    type: integer 
+    default: 0 
   calypsoProject:
     type: string
     default: ""


### PR DESCRIPTION
### Description

This PR amends #762 to use the correct type for the `pullRequestNum` pipeline parameter.

```
Type error for argument pullRequestNum: expected type: string, actual value: \"39001\" (type integer)
```
