### PR TITLE
[CI] Remove pullRequestNum param

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,9 +472,6 @@ parameters:
   sha:
     type: string
     default: "" 
-  pullRequestNum:
-    type: integer 
-    default: 0 
   calypsoProject:
     type: string
     default: ""


### PR DESCRIPTION
### Description

It seems the Circle v2 API and/or the Circle Config v2.1 environment has problems resolving integer parameters. Have tried setting the parameter's `type` field to both `integer` and `string` with no success:
    
> Type error for argument pullRequestNum: expected type: string, actual value: "39001" (type integer)
    
> Type error for argument pullRequestNum: expected type: integer, actual value: "39001" (type string)
   
The above error results in the canary build job being blocked/unable to build. This parameter is not sent back to the canary bridge by wp-desktop, so let's exclude it for now.

From config.yml:

Payload -- success

```
 -d '{
              "payload": {
                "outcome": "'"success"'",
                "status": "'"success"'",
                "branch": "'"$BRANCHNAME"'",
                "build_url": "'"$CIRCLE_BUILD_URL"'",
                "build_parameters": {
                  "build_num": '"$CIRCLE_BUILD_NUM"',
                  "sha": "'"$sha"'",
                  "calypsoProject": "'"$calypsoProject"'"
                }
              }
```

Payload -- failure

```
 -d '{
          "payload": {
            "outcome": "'"failed"'",
            "status": "'"failed"'",
            "branch": "'"$BRANCHNAME"'",
            "build_url": "'"$CIRCLE_BUILD_URL"'",
            "build_parameters": {
              "build_num": '"$CIRCLE_BUILD_NUM"',
              "sha": "'"$sha"'",
              "calypsoProject": "'"$calypsoProject"'"
            }
```

Searching for the parameter `pullRequestNum` seems to indicate it is unused in the config.yml file and the rest of the codebase.