### PR TITLE
Try/fix bridge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
       - *install_linux_dependencies
       - run:
           command: |
-            echo ${CALYPSO_HASH}
+            echo $CALYPSO_HASH
       - *setup_calypso
       - *calypso_prepare_cache
       - *calypso_restore_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,9 @@ jobs:
     steps:
       - checkout
       - *install_linux_dependencies
-	  - run: echo ${CALYPSO_HASH}
+	  - run: 
+		  command: |
+			echo ${CALYPSO_HASH}
       - *setup_calypso
       - *calypso_prepare_cache
       - *calypso_restore_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,19 @@
 version: 2.1
 
+# Circle API v2 build trigger parameters
+# Ref: https://circleci.com/docs/2.0/pipeline-variables/
+# Ref: https://circleci.com/docs/2.0/reusing-config/#parameter-syntax
+parameters:
+  CALYPSO_HASH:
+    type: string
+    default: ""
+  sha:
+    type: string
+    default: ""
+  calypsoProject:
+    type: string
+    default: ""
+
 orbs:
   win: circleci/windows@2.2.0
 
@@ -200,20 +214,6 @@ references:
             }
           }
         }'
-
-# Circle API v2 build trigger parameters
-# Ref: https://circleci.com/docs/2.0/pipeline-variables/
-# Ref: https://circleci.com/docs/2.0/reusing-config/#parameter-syntax
-parameters:
-  CALYPSO_HASH:
-    type: string
-    default: ""
-  sha:
-    type: string
-    default: ""
-  calypsoProject:
-    type: string
-    default: ""
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,8 +423,6 @@ workflows:
     jobs:
       - build:
           filters:
-            branches:
-              ignore: /tests\/.*/
             tags:
               only: /.*/
       - windows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,20 @@ references:
           }
         }'
 
+# Circle API v2 build trigger parameters
+# Ref: https://circleci.com/docs/2.0/pipeline-variables/
+# Ref: https://circleci.com/docs/2.0/reusing-config/#parameter-syntax
+parameters:
+  CALYPSO_HASH:
+    type: string
+    default: ""
+  sha:
+    type: string
+    default: ""
+  calypsoProject:
+    type: string
+    default: ""
+
 jobs:
   build:
     docker:
@@ -217,9 +231,6 @@ jobs:
     steps:
       - checkout
       - *install_linux_dependencies
-      - run:
-          command: |
-            echo $CALYPSO_HASH
       - *setup_calypso
       - *calypso_prepare_cache
       - *calypso_restore_cache
@@ -462,17 +473,3 @@ workflows:
               ignore: /tests\/.*/
             tags:
               only: /.*/
-
-# Circle API v2 build trigger parameters
-# Ref: https://circleci.com/docs/2.0/pipeline-variables/
-# Ref: https://circleci.com/docs/2.0/reusing-config/#parameter-syntax
-parameters:
-  CALYPSO_HASH:
-    type: string
-    default: "" 
-  sha:
-    type: string
-    default: "" 
-  calypsoProject:
-    type: string
-    default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,9 +217,9 @@ jobs:
     steps:
       - checkout
       - *install_linux_dependencies
-	  - run: 
-		  command: |
-			echo ${CALYPSO_HASH}
+      - run:
+          command: |
+            echo ${CALYPSO_HASH}
       - *setup_calypso
       - *calypso_prepare_cache
       - *calypso_restore_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,7 @@ jobs:
     steps:
       - checkout
       - *install_linux_dependencies
+	  - run: echo ${CALYPSO_HASH}
       - *setup_calypso
       - *calypso_prepare_cache
       - *calypso_restore_cache


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
<!--- Describe your changes in detail. -->
This PR makes some updates to the config to help the triggering of builds for Calypso builds work. 

The first change was to move the parameters to the top. They didn't seem to be consistently populating when they were at the bottom.

The second was to remove the filter for the build job. We need to it to be able to run for tests branches or the trigger won't work.

### Motivation and Context:
<!--- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->
The updates to the config to move it to version 2.1 caused some issues with the desktop bridge. 

### How Has This Been Tested:
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, tests completed to see 
how your change affects other areas of the code, etc. -->
I ran the desktop bridge locally, pointing to this branch and triggered jobs. With these changes the builds showed up in CircleCI as expected, used the correct version, and then reported back to the bridge with the correct status.

https://circleci.com/gh/Automattic/wp-desktop/53358 and https://circleci.com/gh/Automattic/wp-desktop/53363 were builds I triggered that passed.

### Screenshots (if appropriate):

### Todos:
<!--- If this PR is a work in progress PR then please state what tasks need to be done. -->
<!-- - [ ] Task 1 -->
<!-- - [ ] Task 2 -->
<!-- - [ ] Task 3 -->
