### PR TITLE
Try/minimize canary triggering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,6 +437,8 @@ workflows:
     jobs:
       - build:
           filters:
+            branches:
+              ignore: /tests\/.*/
             tags:
               only: /.*/
       - windows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -438,6 +438,7 @@ workflows:
       - build:
           filters:
             branches:
+              only: /.*/
               ignore: /tests\/.*/
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ parameters:
   calypsoProject:
     type: string
     default: ""
+  isCalypsoCanaryRun:
+    type: boolean
+    default: false
 
 orbs:
   win: circleci/windows@2.2.0
@@ -438,7 +441,6 @@ workflows:
       - build:
           filters:
             branches:
-              only: /.*/
               ignore: /tests\/.*/
             tags:
               only: /.*/
@@ -476,3 +478,10 @@ workflows:
               ignore: /tests\/.*/
             tags:
               only: /.*/
+  calypso-canary:
+    when: << pipeline.parameters.isCalypsoCanaryRun >>
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: /tests\/.*/


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
In order for the Calypso wp desktop canaries to run we had to remove a filter from the build job in the workflow. Because a branch is created for each canary run, this had the unintended consequence of running the workflow twice.  

This PR creates a separate workflow that will run when a parameter is set to true. This parameter will be set by the desktop bridge when the workflow is triggered.

### Motivation and Context:
We want to avoid running the job twice to save on CircleCI resources, as well as to prevent confusion with the link to the build from the Calypso pr. I saw a case where the link in the PR went to the other workflow. Changing to this way eliminates that factor.

### How Has This Been Tested:
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, tests completed to see 
how your change affects other areas of the code, etc. -->

I tested this by making the change to update the variable in the desktop bridge and pointing it to this branch. When the bridge was triggered, only one workflow was triggered and it had the new `calypso-canary` workflow name.
