### PR TITLE
Restore CircleCI branch filter to build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,6 +437,8 @@ workflows:
     jobs:
       - build:
           filters:
+            branches:
+              ignore: /tests\/.*/
             tags:
               only: /.*/
       - windows:


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
This change adds the filter for the build job back in so that it won't run on test branches. 

### Motivation and Context:
<!--- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->
Test branches are currently being run twice. Once by the workflow, once by trigger.

### How Has This Been Tested:
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, tests completed to see 
how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Todos:
<!--- If this PR is a work in progress PR then please state what tasks need to be done. -->
<!-- - [ ] Task 1 -->
<!-- - [ ] Task 2 -->
<!-- - [ ] Task 3 -->
