### PR TITLE
[Electron] Updgrade to v4.2.12

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
 engine-strict = true
 save-exact = true
-target = 4.2.9
+target = 4.2.12
 disturl = https://electronjs.org/headers
 runtime = electron
 arch = x64

--- a/package-lock.json
+++ b/package-lock.json
@@ -2256,9 +2256,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.14.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.16.tgz",
-      "integrity": "sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA==",
+      "version": "10.17.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.15.tgz",
+      "integrity": "sha512-daFGV9GSs6USfPgxceDA8nlSe48XrVCJfDeYm7eokxq/ye7iuOH87hKXgMtEAVLFapkczbZsx868PMDT1Y0a6A==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -4559,9 +4559,9 @@
       "dev": true
     },
     "electron": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-4.2.9.tgz",
-      "integrity": "sha512-zC7K3GOiZKmxqllVG/qq/Gx+qQvyolKj5xKKwXMqIGekfokEW2hvoIO5Yh7KCoAh5dqBtpzOJjS4fj1se+YBcg==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-4.2.12.tgz",
+      "integrity": "sha512-EES8eMztoW8gEP5E4GQLP8slrfS2jqTYtHbu36mlu3k1xYAaNPyQQr6mCILkYxqj4l3la4CT2Vcs89CUG62vcQ==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chalk": "2.3.1",
     "check-node-version": "3.2.0",
     "concurrently": "3.5.1",
-    "electron": "4.2.9",
+    "electron": "4.2.12",
     "electron-builder": "21.2.0",
     "electron-chromedriver": "4.2.0",
     "electron-mocha": "2.3.1",


### PR DESCRIPTION
### Description

This PR updates Electron in wp-desktop to [v4.2.12](https://www.electronjs.org/releases/stable?version=4#4.2.12) to take advantage of more recent security and performance fixes since v4.2.9.