### PR TITLE
[Makefile] Use absolute path for calypso/.nvmrc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ endif
 
 # Sed to strip leading v to ensure 'v1.2.3' and '1.2.3' can match.
 # The .nvmrc file may contain either, `node --version` prints with 'v' prefix.
-CALYPSO_NODE_VERSION := $(shell cat calypso/.nvmrc | sed -n 's/v\{0,1\}\(.*\)/\1/p')
+CALYPSO_NODE_VERSION := $(shell cat $(THIS_DIR)/calypso/.nvmrc | sed -n 's/v\{0,1\}\(.*\)/\1/p')
 CURRENT_NODE_VERSION := $(shell node --version | sed -n 's/v\{0,1\}\(.*\)/\1/p')
 
 .PHONY: check-version-parity


### PR DESCRIPTION
### Description

Minor fix to Makefile to use the full path to the Calypso .nvmrc. (This allows us to invoke the Makefile from other directories with `make -f path/to/Makefile <target>`.)