### PR TITLE
Revert workaround for buggy after_sign_hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
         "libnss3"
       ]
     },
+    "afterSign": "./after_sign_hook.js",
     "afterAllArtifactBuild": "./after_sign_hook.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "5.0.0-beta2",
+  "version": "5.0.0-beta3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"


### PR DESCRIPTION
### Description:
This PR reverts a workaround for a bug in `electron-builder` where the `after_sign_hook` was called before the app was signed. 

### Motivation and Context:
https://github.com/Automattic/wp-desktop/pull/775 updated `electron-builder` to a version where the original issue has been fixed. 
Also, we found that the workaround doesn't work well for signing the `.zip` file.

### How Has This Been Tested:
1. Verify that the build on the CI to be green.
2. Tag the head of this branch with a new v5 beta tag and verify that the build is completed, the release on GitHub drafted and the .zip and .dmg binaries signed. 
