### PR TITLE
Fix test runner exit code

### DIFF
--- a/test/run/run-e2e-tests.js
+++ b/test/run/run-e2e-tests.js
@@ -84,6 +84,7 @@ async function run() {
     }
     catch ( err ) {
         console.error( err );
+        process.exitCode = 1;
     }
     finally {
         // Explicitly call process.exit to ensure that spawned processes are killed.

--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -57,7 +57,7 @@ describe( 'User Can log in', function() {
 	} );
 } );
 
-describe( 'Publish a New Post', function() {
+describe.skip( 'Publish a New Post', function() {
 	this.timeout( 30000 );
 	const blogPostTitle = dataHelper.randomPhrase();
 	const blogPostQuote =
@@ -116,7 +116,7 @@ describe( 'Can Log Out', function() {
 	} );
 } );
 
-describe( 'Can Sign up', function() {
+describe.skip( 'Can Sign up', function() {
 	this.timeout( 30000 );
 	const blogName = dataHelper.getNewBlogName();
 	const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );

--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -57,46 +57,46 @@ describe( 'User Can log in', function() {
 	} );
 } );
 
-// describe( 'Publish a New Post', function() {
-// 	this.timeout( 30000 );
-// 	const blogPostTitle = dataHelper.randomPhrase();
-// 	const blogPostQuote =
-// 		'“Whenever you find yourself on the side of the majority, it is time to pause and reflect.”\n- Mark Twain';
+describe( 'Publish a New Post', function() {
+	this.timeout( 30000 );
+	const blogPostTitle = dataHelper.randomPhrase();
+	const blogPostQuote =
+		'“Whenever you find yourself on the side of the majority, it is time to pause and reflect.”\n- Mark Twain';
 
-// 	step( 'Can navigate to post editor', async function() {
-// 		const navbarComponent = await NavBarComponent.Expect( driver );
-// 		return await navbarComponent.clickCreateNewPost();
-// 	} );
+	step( 'Can navigate to post editor', async function() {
+		const navbarComponent = await NavBarComponent.Expect( driver );
+		return await navbarComponent.clickCreateNewPost();
+	} );
 
-// 	step( 'Can enter post title and content', async function() {
-// 		const editorPage = await EditorPage.Expect( driver );
-// 		await editorPage.enterTitle( blogPostTitle );
-// 		await editorPage.enterContent( blogPostQuote + '\n' );
+	step( 'Can enter post title and content', async function() {
+		const editorPage = await EditorPage.Expect( driver );
+		await editorPage.enterTitle( blogPostTitle );
+		await editorPage.enterContent( blogPostQuote + '\n' );
 
-// 		let errorShown = await editorPage.errorDisplayed();
-// 		return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
-// 	} );
+		let errorShown = await editorPage.errorDisplayed();
+		return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
+	} );
 
-// 	step( 'Can publish and view content', async function() {
-// 		const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
-// 		await postEditorToolbarComponent.ensureSaved();
-// 		return await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
-// 	} );
+	step( 'Can publish and view content', async function() {
+		const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
+		await postEditorToolbarComponent.ensureSaved();
+		return await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
+	} );
 
-// 	step( 'Can see correct post title', async function() {
-// 		const viewPostPage = await ViewPostPage.Expect( driver );
-// 		let postTitle = await viewPostPage.postTitle();
-// 		return assert.strictEqual(
-// 			postTitle.toLowerCase(),
-// 			blogPostTitle.toLowerCase(),
-// 			'The published blog post title is not correct'
-// 		);
-// 	} );
+	step( 'Can see correct post title', async function() {
+		const viewPostPage = await ViewPostPage.Expect( driver );
+		let postTitle = await viewPostPage.postTitle();
+		return assert.strictEqual(
+			postTitle.toLowerCase(),
+			blogPostTitle.toLowerCase(),
+			'The published blog post title is not correct'
+		);
+	} );
 
-// 	step( 'Can return to reader', async function() {
-// 		return await driver.get( loggedInUrl );
-// 	} );
-// } );
+	step( 'Can return to reader', async function() {
+		return await driver.get( loggedInUrl );
+	} );
+} );
 
 describe( 'Can Log Out', function() {
 	this.timeout( 30000 );

--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -116,7 +116,7 @@ describe( 'Can Log Out', function() {
 	} );
 } );
 
-describe.skip( 'Can Sign up', function() {
+describe( 'Can Sign up', function() {
 	this.timeout( 30000 );
 	const blogName = dataHelper.getNewBlogName();
 	const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );

--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -57,46 +57,46 @@ describe( 'User Can log in', function() {
 	} );
 } );
 
-describe( 'Publish a New Post', function() {
-	this.timeout( 30000 );
-	const blogPostTitle = dataHelper.randomPhrase();
-	const blogPostQuote =
-		'“Whenever you find yourself on the side of the majority, it is time to pause and reflect.”\n- Mark Twain';
+// describe( 'Publish a New Post', function() {
+// 	this.timeout( 30000 );
+// 	const blogPostTitle = dataHelper.randomPhrase();
+// 	const blogPostQuote =
+// 		'“Whenever you find yourself on the side of the majority, it is time to pause and reflect.”\n- Mark Twain';
 
-	step( 'Can navigate to post editor', async function() {
-		const navbarComponent = await NavBarComponent.Expect( driver );
-		return await navbarComponent.clickCreateNewPost();
-	} );
+// 	step( 'Can navigate to post editor', async function() {
+// 		const navbarComponent = await NavBarComponent.Expect( driver );
+// 		return await navbarComponent.clickCreateNewPost();
+// 	} );
 
-	step( 'Can enter post title and content', async function() {
-		const editorPage = await EditorPage.Expect( driver );
-		await editorPage.enterTitle( blogPostTitle );
-		await editorPage.enterContent( blogPostQuote + '\n' );
+// 	step( 'Can enter post title and content', async function() {
+// 		const editorPage = await EditorPage.Expect( driver );
+// 		await editorPage.enterTitle( blogPostTitle );
+// 		await editorPage.enterContent( blogPostQuote + '\n' );
 
-		let errorShown = await editorPage.errorDisplayed();
-		return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
-	} );
+// 		let errorShown = await editorPage.errorDisplayed();
+// 		return assert.strictEqual( errorShown, false, 'There is an error shown on the editor page!' );
+// 	} );
 
-	step( 'Can publish and view content', async function() {
-		const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
-		await postEditorToolbarComponent.ensureSaved();
-		return await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
-	} );
+// 	step( 'Can publish and view content', async function() {
+// 		const postEditorToolbarComponent = await PostEditorToolbarComponent.Expect( driver );
+// 		await postEditorToolbarComponent.ensureSaved();
+// 		return await postEditorToolbarComponent.publishAndViewContent( { useConfirmStep: true } );
+// 	} );
 
-	step( 'Can see correct post title', async function() {
-		const viewPostPage = await ViewPostPage.Expect( driver );
-		let postTitle = await viewPostPage.postTitle();
-		return assert.strictEqual(
-			postTitle.toLowerCase(),
-			blogPostTitle.toLowerCase(),
-			'The published blog post title is not correct'
-		);
-	} );
+// 	step( 'Can see correct post title', async function() {
+// 		const viewPostPage = await ViewPostPage.Expect( driver );
+// 		let postTitle = await viewPostPage.postTitle();
+// 		return assert.strictEqual(
+// 			postTitle.toLowerCase(),
+// 			blogPostTitle.toLowerCase(),
+// 			'The published blog post title is not correct'
+// 		);
+// 	} );
 
-	step( 'Can return to reader', async function() {
-		return await driver.get( loggedInUrl );
-	} );
-} );
+// 	step( 'Can return to reader', async function() {
+// 		return await driver.get( loggedInUrl );
+// 	} );
+// } );
 
 describe( 'Can Log Out', function() {
 	this.timeout( 30000 );

--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -116,61 +116,61 @@ describe( 'Can Log Out', function() {
 	} );
 } );
 
-// describe( 'Can Sign up', function() {
-// 	this.timeout( 30000 );
-// 	const blogName = dataHelper.getNewBlogName();
-// 	const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-// 	const emailAddress = blogName + process.env.E2E_MAILOSAUR_INBOX;
+describe( 'Can Sign up', function() {
+	this.timeout( 30000 );
+	const blogName = dataHelper.getNewBlogName();
+	const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
+	const emailAddress = blogName + process.env.E2E_MAILOSAUR_INBOX;
 
-// 	step( 'Clear local storage', async function() {
-// 		await driver.executeScript( 'window.localStorage.clear();' );
-// 		return await driver.sleep( 3000 );
-// 	} );
+	step( 'Clear local storage', async function() {
+		await driver.executeScript( 'window.localStorage.clear();' );
+		return await driver.sleep( 3000 );
+	} );
 
-// 	step( 'Can navigate to Create account', async function() {
-// 		let loginPage = await LoginPage.Expect( driver );
-// 		await loginPage.hideGdprBanner();
-// 		await loginPage.openCreateAccountPage();
-// 		return await SignupStepsPage.Expect( driver );
-// 	} );
+	step( 'Can navigate to Create account', async function() {
+		let loginPage = await LoginPage.Expect( driver );
+		await loginPage.hideGdprBanner();
+		await loginPage.openCreateAccountPage();
+		return await SignupStepsPage.Expect( driver );
+	} );
 
-// 	step( 'Can see the "Site Topic" page, and enter the site topic', async function() {
-// 		const signupStepsPage = await SignupStepsPage.Expect( driver );
-// 		return await signupStepsPage.aboutSite();
-// 	} );
+	step( 'Can see the "Site Topic" page, and enter the site topic', async function() {
+		const signupStepsPage = await SignupStepsPage.Expect( driver );
+		return await signupStepsPage.aboutSite();
+	} );
 
-// 	step( 'Choose a theme page', async function() {
-// 		const signupStepsPage = await SignupStepsPage.Expect( driver );
-// 		return await signupStepsPage.selectTheme();
-// 	} );
+	step( 'Choose a theme page', async function() {
+		const signupStepsPage = await SignupStepsPage.Expect( driver );
+		return await signupStepsPage.selectTheme();
+	} );
 
-// 	step(
-// 		'Can search for a blog name, can see and select a free .wordpress address',
-// 		async function() {
-// 			const signupStepsPage = await SignupStepsPage.Expect( driver );
-// 			return await signupStepsPage.selectDomain( blogName );
-// 		}
-// 	);
+	step(
+		'Can search for a blog name, can see and select a free .wordpress address',
+		async function() {
+			const signupStepsPage = await SignupStepsPage.Expect( driver );
+			return await signupStepsPage.selectDomain( blogName );
+		}
+	);
 
-// 	step( 'Can see the plans page and pick the free plan', async function() {
-// 		const signupStepsPage = await SignupStepsPage.Expect( driver );
-// 		return await signupStepsPage.selectFreePlan();
-// 	} );
+	step( 'Can see the plans page and pick the free plan', async function() {
+		const signupStepsPage = await SignupStepsPage.Expect( driver );
+		return await signupStepsPage.selectFreePlan();
+	} );
 
-// 	step( 'Can see the account page, enter account details and submit', async function() {
-// 		const signupStepsPage = await SignupStepsPage.Expect( driver );
-// 		return await signupStepsPage.enterAccountDetailsAndSubmit(
-// 			emailAddress,
-// 			blogName,
-// 			process.env.E2EPASSWORD
-// 		);
-// 	} );
+	step( 'Can see the account page, enter account details and submit', async function() {
+		const signupStepsPage = await SignupStepsPage.Expect( driver );
+		return await signupStepsPage.enterAccountDetailsAndSubmit(
+			emailAddress,
+			blogName,
+			process.env.E2EPASSWORD
+		);
+	} );
 
-// 	step( 'Can then see the onboarding checklist', async function() {
-// 		const checklistPage = await ChecklistPage.Expect( driver );
-// 		return await checklistPage.isChecklistPresent();
-// 	} );
-// } );
+	step( 'Can then see the onboarding checklist', async function() {
+		const checklistPage = await ChecklistPage.Expect( driver );
+		return await checklistPage.isChecklistPresent();
+	} );
+} );
 
 after( async function() {
 	this.timeout( 30000 );

--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -116,61 +116,61 @@ describe( 'Can Log Out', function() {
 	} );
 } );
 
-describe( 'Can Sign up', function() {
-	this.timeout( 30000 );
-	const blogName = dataHelper.getNewBlogName();
-	const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-	const emailAddress = blogName + process.env.E2E_MAILOSAUR_INBOX;
+// describe( 'Can Sign up', function() {
+// 	this.timeout( 30000 );
+// 	const blogName = dataHelper.getNewBlogName();
+// 	const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
+// 	const emailAddress = blogName + process.env.E2E_MAILOSAUR_INBOX;
 
-	step( 'Clear local storage', async function() {
-		await driver.executeScript( 'window.localStorage.clear();' );
-		return await driver.sleep( 3000 );
-	} );
+// 	step( 'Clear local storage', async function() {
+// 		await driver.executeScript( 'window.localStorage.clear();' );
+// 		return await driver.sleep( 3000 );
+// 	} );
 
-	step( 'Can navigate to Create account', async function() {
-		let loginPage = await LoginPage.Expect( driver );
-		await loginPage.hideGdprBanner();
-		await loginPage.openCreateAccountPage();
-		return await SignupStepsPage.Expect( driver );
-	} );
+// 	step( 'Can navigate to Create account', async function() {
+// 		let loginPage = await LoginPage.Expect( driver );
+// 		await loginPage.hideGdprBanner();
+// 		await loginPage.openCreateAccountPage();
+// 		return await SignupStepsPage.Expect( driver );
+// 	} );
 
-	step( 'Can see the "Site Topic" page, and enter the site topic', async function() {
-		const signupStepsPage = await SignupStepsPage.Expect( driver );
-		return await signupStepsPage.aboutSite();
-	} );
+// 	step( 'Can see the "Site Topic" page, and enter the site topic', async function() {
+// 		const signupStepsPage = await SignupStepsPage.Expect( driver );
+// 		return await signupStepsPage.aboutSite();
+// 	} );
 
-	step( 'Choose a theme page', async function() {
-		const signupStepsPage = await SignupStepsPage.Expect( driver );
-		return await signupStepsPage.selectTheme();
-	} );
+// 	step( 'Choose a theme page', async function() {
+// 		const signupStepsPage = await SignupStepsPage.Expect( driver );
+// 		return await signupStepsPage.selectTheme();
+// 	} );
 
-	step(
-		'Can search for a blog name, can see and select a free .wordpress address',
-		async function() {
-			const signupStepsPage = await SignupStepsPage.Expect( driver );
-			return await signupStepsPage.selectDomain( blogName );
-		}
-	);
+// 	step(
+// 		'Can search for a blog name, can see and select a free .wordpress address',
+// 		async function() {
+// 			const signupStepsPage = await SignupStepsPage.Expect( driver );
+// 			return await signupStepsPage.selectDomain( blogName );
+// 		}
+// 	);
 
-	step( 'Can see the plans page and pick the free plan', async function() {
-		const signupStepsPage = await SignupStepsPage.Expect( driver );
-		return await signupStepsPage.selectFreePlan();
-	} );
+// 	step( 'Can see the plans page and pick the free plan', async function() {
+// 		const signupStepsPage = await SignupStepsPage.Expect( driver );
+// 		return await signupStepsPage.selectFreePlan();
+// 	} );
 
-	step( 'Can see the account page, enter account details and submit', async function() {
-		const signupStepsPage = await SignupStepsPage.Expect( driver );
-		return await signupStepsPage.enterAccountDetailsAndSubmit(
-			emailAddress,
-			blogName,
-			process.env.E2EPASSWORD
-		);
-	} );
+// 	step( 'Can see the account page, enter account details and submit', async function() {
+// 		const signupStepsPage = await SignupStepsPage.Expect( driver );
+// 		return await signupStepsPage.enterAccountDetailsAndSubmit(
+// 			emailAddress,
+// 			blogName,
+// 			process.env.E2EPASSWORD
+// 		);
+// 	} );
 
-	step( 'Can then see the onboarding checklist', async function() {
-		const checklistPage = await ChecklistPage.Expect( driver );
-		return await checklistPage.isChecklistPresent();
-	} );
-} );
+// 	step( 'Can then see the onboarding checklist', async function() {
+// 		const checklistPage = await ChecklistPage.Expect( driver );
+// 		return await checklistPage.isChecklistPresent();
+// 	} );
+// } );
 
 after( async function() {
 	this.timeout( 30000 );

--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -57,7 +57,7 @@ describe( 'User Can log in', function() {
 	} );
 } );
 
-describe.skip( 'Publish a New Post', function() {
+describe( 'Publish a New Post', function() {
 	this.timeout( 30000 );
 	const blogPostTitle = dataHelper.randomPhrase();
 	const blogPostQuote =


### PR DESCRIPTION
### Description

This PR ensures the correct exit code is used by the Node process when test invocation fails or errors out. (Turns out setting `stdio: 'inherit'` on a child process isn't sufficient for this purpose).

Confirmed that this works as expected in CI.