### PR TITLE
File Loader: Add .mp4 Extension

### DIFF
--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -48,7 +48,7 @@ module.exports = {
 				loader: 'ignore-loader',
 			},
 			{
-				test: /\.(?:gif|jpg|jpeg|png|svg)$/i,
+				test: /\.(?:gif|jpg|jpeg|mp4|png|svg)$/i,
 				use: {
 					loader: 'file-loader',
 					options: {


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
This adds the `.mp4` file extension to the Webpack File Loader. 

### Motivation and Context:
<!--- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->
For more details, see Automattic/wp-calypso#39707, but essentially, more videos are going to be uploaded to Calypso; this would allow them to be stored in the repo. 

### How Has This Been Tested:
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, tests completed to see 
how your change affects other areas of the code, etc. -->
In all honesty, I'm not really sure how testing works with the Desktop app, but it is just a minor change! 🙂 

