### PR TITLE
[tests] Temporarily Skip "Sign-Up" Flow Tests

### DIFF
--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -164,10 +164,11 @@ describe( 'Can Sign up', function() {
 		);
 	} );
 
-	step( 'Can see checkout page', async function() {
-		const checkoutPage = await CheckoutPage.Expect( driver );
-		return await checkoutPage.isShoppingCartPresent();
-	} );
+	// FIXME: this test has been failing consistently since merged.
+	// step( 'Can see checkout page', async function() {
+	// 	const checkoutPage = await CheckoutPage.Expect( driver );
+	// 	return await checkoutPage.isShoppingCartPresent();
+	// } );
 } );
 
 after( async function() {

--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -116,7 +116,7 @@ describe( 'Can Log Out', function() {
 	} );
 } );
 
-describe( 'Can Sign up', function() {
+describe.skip( 'Can Sign up', function() {
 	this.timeout( 30000 );
 	const blogName = dataHelper.getNewBlogName();
 	const emailAddress = blogName + '@e2edesktop.test';
@@ -164,11 +164,10 @@ describe( 'Can Sign up', function() {
 		);
 	} );
 
-	// FIXME: this test has been failing consistently since merged.
-	// step( 'Can see checkout page', async function() {
-	// 	const checkoutPage = await CheckoutPage.Expect( driver );
-	// 	return await checkoutPage.isShoppingCartPresent();
-	// } );
+	step( 'Can see checkout page', async function() {
+		const checkoutPage = await CheckoutPage.Expect( driver );
+		return await checkoutPage.isShoppingCartPresent();
+	} );
 } );
 
 after( async function() {


### PR DESCRIPTION
### Description

Temporarily disable flakey tests (seems A/B testing within the checkout flow is the likely culprit for inconsistent performance).