### PR TITLE
[e2e] Enable Sign up test

### DIFF
--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -116,7 +116,7 @@ describe( 'Can Log Out', function() {
 	} );
 } );
 
-describe.skip( 'Can Sign up', function() {
+describe( 'Can Sign up', function() {
 	this.timeout( 30000 );
 	const blogName = dataHelper.getNewBlogName();
 	const emailAddress = blogName + '@e2edesktop.test';

--- a/test/tests/lib/pages/checkout-page.js
+++ b/test/tests/lib/pages/checkout-page.js
@@ -10,11 +10,25 @@ class CheckoutPage extends AsyncBaseContainer {
 	}
 
 	async isShoppingCartPresent() {
-		await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			By.css( '.payment-box__content' )
-		);
-		return await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.cart-item' ) );
+		// temp try/catch block
+		// while A/B test for composite checkout is on
+		try {
+			await driverHelper.waitTillPresentAndDisplayed(
+				this.driver,
+				By.css( '.composite-checkout' )
+			);
+			await driverHelper.waitTillPresentAndDisplayed(
+				this.driver,
+				By.css( '.checkout__payment-methods-step' )
+			);
+		} catch ( e ) {
+			console.log( 'Composite checkout is not displayed. Trying with regular checkout...' );
+			await driverHelper.waitTillPresentAndDisplayed(
+				this.driver,
+				By.css( '.payment-box__content' )
+			);
+			await driverHelper.waitTillPresentAndDisplayed( this.driver, By.css( '.cart-item' ) );
+		}
 	}
 
 	async emptyShoppingCart() {


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
<!--- Describe your changes in detail. -->

Re-enable Sign up test.

The test was disabled in https://github.com/Automattic/wp-desktop/pull/794 because it was failing most of the time. The reason for failures was A/B test for checkout was turned on, and the checkout display was switching between two versions. More info here: p58i-8zB-p2

With this fix, I cover both cases - current checkout flow and the new one, composite checkout. But we should re-iterate through this solution once the checkout is switched completely to Composite checkout, or when we implement handling A/B tests in WP-desktop e2e tests. 

### How Has This Been Tested:
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, tests completed to see 
how your change affects other areas of the code, etc. -->

Since I'm based outside the US, I followed changes in this PR https://github.com/Automattic/wp-calypso/pull/39494/files on how to enable Composite checkout for me locally. Then re-build the app and run tests. 

And make sure that tests are passing consistently in CircleCI. 

