### PR TITLE
[Notarization] Streamline Notarization Logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,13 +391,13 @@ jobs:
       #             source $HOME/.nvm/nvm.sh
       #             nvm use
       #             make test TEST_PRODUCTION_BINARY=true
-      - run:
-          name: e2e Tests
-          command: |
-                  killall touristd
-                  killall UserNotificationCenter
+      # - run:
+      #     name: e2e Tests
+      #     command: |
+      #             killall touristd
+      #             killall UserNotificationCenter
 
-                  make e2e
+      #             make e2e
       - run:
           name: Release cleanup
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,13 +391,13 @@ jobs:
       #             source $HOME/.nvm/nvm.sh
       #             nvm use
       #             make test TEST_PRODUCTION_BINARY=true
-      # - run:
-      #     name: e2e Tests
-      #     command: |
-      #             killall touristd
-      #             killall UserNotificationCenter
+      - run:
+          name: e2e Tests
+          command: |
+                  killall touristd
+                  killall UserNotificationCenter
 
-      #             make e2e
+                  make e2e
       - run:
           name: Release cleanup
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,15 +292,15 @@ jobs:
           root: ~/wp-desktop
           paths:
             - release
-  
+
   windows:
-    executor: 
+    executor:
       name: win/default
     working_directory: C:\Users\circleci\wp-desktop
     environment:
       CSC_LINK: .\resource\certificates\win.p12
       CSC_FOR_PULL_REQUEST: true
-    steps: 
+    steps:
       - checkout
       - attach_workspace:
           at: C:\Users\circleci\wp-desktop
@@ -316,9 +316,9 @@ jobs:
       - run:
           name: Npm install
           command: |
-                # The release of nodejs currently being used by Calypso includes a buggy version 
-                # of node-gyp for Windows. This workaround unblocks Windows builds until Calypso node 
-                # includes node-gyp >= 6.0.1, at which point this snippet and node-gyp in wp-desktop 
+                # The release of nodejs currently being used by Calypso includes a buggy version
+                # of node-gyp for Windows. This workaround unblocks Windows builds until Calypso node
+                # includes node-gyp >= 6.0.1, at which point this snippet and node-gyp in wp-desktop
                 # devDependencies can be reverted.
                 # Ref: https://github.com/nodejs/node-gyp/issues/1933
                 npm config set node_gyp "$(Get-Location)\node_modules\node-gyp\bin\node-gyp.js"
@@ -328,8 +328,8 @@ jobs:
           command: |
                 # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
                 # Ref: https://travis-ci.community/t/codesigning-on-windows/
-                # 
-                # Fix: Import .p12 into the local certificate store. Sign Tool will use 
+                #
+                # Fix: Import .p12 into the local certificate store. Sign Tool will use
                 # package.json's `certificateSubjectName` to find the imported cert.
                 Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
 
@@ -349,7 +349,7 @@ jobs:
           shell: bash.exe
       - persist_to_workspace:
           root: C:\Users\circleci\wp-desktop
-          paths: 
+          paths:
             - release
 
   mac:
@@ -374,6 +374,7 @@ jobs:
       - *npm_save_cache
       - run:
           name: Build Mac
+          no_output_timeout: 30m
           environment:
             CSC_LINK: resource/certificates/mac.p12
             CSC_FOR_PULL_REQUEST: true # don't do this in production

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ WordPress.com for Desktop is an [Electron](https://github.com/atom/electron) wra
 
 1. Clone this repository locally
 1. Update the Calypso submodule with:
- - `git submodule init`
- - `git submodule update`
+
+- `git submodule init`
+- `git submodule update`
+
 1. Create a `calypso/config/secrets.json` file and fill it with [secrets](docs/secrets.md)
 1. `npm install` will download all the required packages
 1. `make build` to create the builds
@@ -25,6 +27,16 @@ The app is split between Electron code and Calypso code, and so the [development
 
 1. Set the environment variables `E2EUSERNAME` and `E2EPASSWORD`.
 2. Use `npm run e2e` or `make e2e` to invoke the test suite.
+
+# MacOS Notarization
+
+Per the current [Electron docs](https://www.electron.build/configuration/dmg), DMG signing is disabled by default as it will "lead to unwanted errors in combination with notarization requirements." Only the app bundle is zipped and submitted to Apple for notarization.
+
+## Extracting Published ZIP Archive in MacOS 10.15 (Catalina)
+
+There is a [known bug](https://github.com/electron-userland/electron-builder/issues/4299#issuecomment-544683923) in which extracting notarized contents from a zip archive via double-click will lead to an invalid .app bundle that cannot be opened in macOS 10.15. Instead, the bundled app should be extracted via `ditto`:
+
+`ditto -x -k <zip archive> <destination folder>`
 
 # Building & Packaging a Release
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ There is a [known bug](https://github.com/electron-userland/electron-builder/iss
 
 `ditto -x -k <zip archive> <destination folder>`
 
+## Verification
+
+Notarization status of an application bundle can be verified via the `codesign`, `stapler` and `spctl` utilities:
+
+`codesign --test-requirement="=notarized" --verify --verbose WordPress.com.app`
+
+`xrun stapler validate WordPress.com.app`
+
+`spctl -a -v WordPress.com.app`
+
 # Building & Packaging a Release
 
 While running the app locally in a development environment is great, you will eventually need to [build a release version](docs/release.md) you can share.

--- a/after_sign_hook.js
+++ b/after_sign_hook.js
@@ -24,10 +24,10 @@ module.exports = async function( context ) {
 		return;
 	}
 
-	try {
-		const app = path.join( context.appOutDir, `${ context.packager.appInfo.productFilename }.app` );
-		const appName = path.basename( app );
+	const app = path.join( context.appOutDir, `${ context.packager.appInfo.productFilename }.app` );
+	const appName = path.basename( app );
 
+	try {
 		const start = new Date();
 		console.log( `  • notarizing ${ appName }...` );
 		await notarize( {

--- a/after_sign_hook.js
+++ b/after_sign_hook.js
@@ -39,7 +39,6 @@ module.exports = async function( context ) {
 		} )
 		console.log( `  • done notarizing ${ appName }, took ${ elapsed( start ) }` );
 	} catch ( error ) {
-		console.log( error.message );
 		throw ( error );
 	}
 }

--- a/after_sign_hook.js
+++ b/after_sign_hook.js
@@ -27,18 +27,14 @@ module.exports = async function( context ) {
 	const app = path.join( context.appOutDir, `${ context.packager.appInfo.productFilename }.app` );
 	const appName = path.basename( app );
 
-	try {
-		const start = new Date();
-		console.log( `  • notarizing ${ appName }...` );
-		await notarize( {
-			appBundleId: APP_ID,
-			appPath: app,
-			appleId: NOTARIZATION_ID,
-			appleIdPassword: NOTARIZATION_PWD,
-			ascProvider: NOTARIZATION_ASC_PROVIDER,
-		} )
-		console.log( `  • done notarizing ${ appName }, took ${ elapsed( start ) }` );
-	} catch ( error ) {
-		throw ( error );
-	}
+	const start = new Date();
+	console.log( `  • notarizing ${ appName }...` );
+	await notarize( {
+		appBundleId: APP_ID,
+		appPath: app,
+		appleId: NOTARIZATION_ID,
+		appleIdPassword: NOTARIZATION_PWD,
+		ascProvider: NOTARIZATION_ASC_PROVIDER,
+	} )
+	console.log( `  • done notarizing ${ appName }, took ${ elapsed( start ) }` );
 }

--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
         "libnss3"
       ]
     },
-    "afterSign": "./after_sign_hook.js",
-    "afterAllArtifactBuild": "./after_sign_hook.js"
+    "afterSign": "./after_sign_hook.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "5.0.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "1.0.0",
+  "version": "5.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"


### PR DESCRIPTION
### Description:

Some minor cleanup of notarization logic.

Per the current [Electron docs](https://www.electron.build/configuration/dmg), DMG signing is disabled by default as it will "lead to unwanted errors in combination with notarization requirements." Only the app bundle is zipped and submitted to Apple for notarization. Also worth pointing out that `electron-notarize` does not support DMG notarization anyway, so the extraneous logic should be removed.

This PR removes the unnecessary (and unused) call to submit the DMG for notarization, and adds some notes to the README regarding correct extraction of the notarized app from the published .zip artifact.

### Motivation and Context:

As a result of investigating the issue reported in #792, a deeper dive into existing notarization logic was conducted and some efficiencies/refactors were identified. Turns out #792 is a non-issue (this is a bug in Mac OS 10.15 resulting from default extraction invoked by double-clicking a zip archive. Instead, use `ditto` as specified in the README).

### How Has This Been Tested:

Tested by submitting tagged test release to Apple.

[Before](https://circleci.com/gh/Automattic/wp-desktop/54504):

```
 • signing         file=release/mac/WordPress.com.app identityName=Developer ID Application: Automattic, Inc. (XXXXX) identityHash=XXXXX provisioningProfile=none
afterSign hook triggered

// ...

Notarizing com.automattic.wordpress found at /Users/distiller/wp-desktop/release/mac/WordPress.com.app
Done notarizing com.automattic.wordpress
  • building        target=macOS zip arch=x64 file=release/WordPress.com-5.0.0-mac.zip
  • building        target=DMG arch=x64 file=release/WordPress.com-5.0.0.dmg
  • building embedded block map  file=release/WordPress.com-5.0.0-mac.zip
  • publishing      publisher=Github (owner: Automattic, project: wp-desktop, version: 5.0.0)
  • uploading       file=WordPress.com-5.0.0-mac.zip provider=GitHub

// Note: DMG notarization is not triggered (but is unnecessary anyway)
```

 After:

```
  • signing         file=release/mac/WordPress.com.app identityName=Developer ID Application: Automattic, Inc. (XXXXX) identityHash=XXXXX provisioningProfile=none
  • notarizing WordPress.com.app...
  • done notarizing WordPress.com.app, took 4 minutes, 1 seconds
  • building        target=DMG arch=x64 file=release/WordPress.com-1.0.0.dmg
  • building block map  blockMapFile=release/WordPress.com-1.0.0.dmg.blockmap
```