### PR TITLE
[Security] Update MacOS Entitlements

### DIFF
--- a/resource/macos/entitlements.mac.inherit.plist
+++ b/resource/macos/entitlements.mac.inherit.plist
@@ -2,15 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
-        <key>com.apple.security.cs.allow-jit</key>
-        <true/>
         <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-        <true/>
-        <key>com.apple.security.cs.disable-executable-page-protection</key>
-        <true/>
-        <key>com.apple.security.cs.disable-library-validation</key>
-        <true/>
-        <key>com.apple.security.cs.allow-dyld-environment-variables</key>
         <true/>
     </dict>
 </plist>

--- a/resource/macos/entitlements.mac.plist
+++ b/resource/macos/entitlements.mac.plist
@@ -2,15 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
-        <key>com.apple.security.cs.allow-jit</key>
-        <true/>
         <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-        <true/>
-        <key>com.apple.security.cs.disable-executable-page-protection</key>
-        <true/>
-        <key>com.apple.security.cs.disable-library-validation</key>
-        <true/>
-        <key>com.apple.security.cs.allow-dyld-environment-variables</key>
         <true/>
     </dict>
 </plist>


### PR DESCRIPTION
### Description

A security vulnerability was recently reported for MacOS (described in #790) in which the author described injection on macOS Catalina via the `Disable Library Validation` entitlement. Turns out this is a non-issue on Catalina, but unnecessary entitlements were discovered as part of this investigation.

This PR removes entitlements that the application doesn't need, as they are all potential attack vectors and should only be enabled if truly required for the application to function.

### How Was This Tested

Builds were generated (using a `v1.0.0` tag) using the updated entitlement configuration, and I confirmed the application continues to function as expected (this included verifying behavior of the auto-updater mechanism).

(Note: the auto-updater can only be tested if there is a _published_  release of the current version on Github, which I only enabled temporarily for testing purposes.)

~~TEMP: [v1.0.0 Release](https://github.com/Automattic/wp-desktop/releases/tag/v1.0.0)~~ Temporary release deleted.

* [WordPress.com-1.0.0-mac.zip](https://drive.google.com/open?id=10EsQoKgNPircokZosJAxQOTGOjG7Xc2u)
* [WordPress.com-1.0.0.dmg](https://drive.google.com/open?id=10EsQoKgNPircokZosJAxQOTGOjG7Xc2u)

Resolves #790 