### PR TITLE
[e2e] Highlight elements during tests executions

### DIFF
--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -167,7 +167,6 @@ describe( 'Can Sign up', function() {
 	step( 'Can see checkout page', async function() {
 		const checkoutPage = await CheckoutPage.Expect( driver );
 		await checkoutPage.isShoppingCartPresent();
-		await driver.sleep( 20000 );
 	} );
 } );
 

--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -166,7 +166,8 @@ describe( 'Can Sign up', function() {
 
 	step( 'Can see checkout page', async function() {
 		const checkoutPage = await CheckoutPage.Expect( driver );
-		return await checkoutPage.isShoppingCartPresent();
+		await checkoutPage.isShoppingCartPresent();
+		await driver.sleep( 20000 );
 	} );
 } );
 

--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -117,7 +117,7 @@ describe( 'Can Log Out', function() {
 } );
 
 describe( 'Can Sign up', function() {
-	this.timeout( 30000 );
+	this.timeout( 90000 );
 	const blogName = dataHelper.getNewBlogName();
 	const emailAddress = blogName + '@e2edesktop.test';
 

--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -98,7 +98,7 @@ describe( 'Publish a New Post', function() {
 	} );
 } );
 
-describe.skip( 'Can Log Out', function() {
+describe( 'Can Log Out', function() {
 	this.timeout( 30000 );
 
 	step( 'Can view profile to log out', async function() {
@@ -116,7 +116,7 @@ describe.skip( 'Can Log Out', function() {
 	} );
 } );
 
-describe.skip( 'Can Sign up', function() {
+describe( 'Can Sign up', function() {
 	this.timeout( 30000 );
 	const blogName = dataHelper.getNewBlogName();
 	const emailAddress = blogName + '@e2edesktop.test';

--- a/test/tests/lib/driver-helper.js
+++ b/test/tests/lib/driver-helper.js
@@ -24,6 +24,7 @@ exports.clickWhenClickable = async function( driver, selector, waitOverride ) {
 			return driver.findElement( selector ).then(
 				async function( element ) {
 					await self.highlightElement( driver, element );
+					await driver.sleep( 300 );
 					return element.click().then(
 						function() {
 							return true;
@@ -241,6 +242,7 @@ exports.setWhenSettable = function(
 			await self.waitForFieldClearable( driver, selector );
 			const element = await driver.findElement( selector );
 			await self.highlightElement( driver, element );
+			await driver.sleep( 300 );
 			if ( pauseBetweenKeysMS === 0 ) {
 				await element.sendKeys( value );
 			} else {

--- a/test/tests/lib/driver-helper.js
+++ b/test/tests/lib/driver-helper.js
@@ -6,13 +6,24 @@ const { forEach } = require( 'lodash' );
 const explicitWaitMS = 20000;
 const by = webdriver.By;
 
-exports.clickWhenClickable = function( driver, selector, waitOverride ) {
+exports.highlightElement = async function( driver, element, color = 'gold' ) {
+	if ( process.env.HIGHLIGHT_ELEMENT === 'true' ) {
+		return await driver.executeScript(
+			`arguments[0].setAttribute('style', 'background: ${color}; border: 3px solid red;');`,
+			element
+		);
+	}
+};
+
+exports.clickWhenClickable = async function( driver, selector, waitOverride ) {
+	let self = this;
 	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
 
 	return driver.wait(
 		function() {
 			return driver.findElement( selector ).then(
-				function( element ) {
+				async function( element ) {
+					await self.highlightElement( driver, element );
 					return element.click().then(
 						function() {
 							return true;
@@ -48,11 +59,13 @@ exports.waitTillNotPresent = function( driver, selector, waitOverride ) {
 };
 
 exports.followLinkWhenFollowable = function( driver, selector, waitOverride ) {
+	let self = this;
 	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
 	return driver.wait(
 		function() {
 			return driver.findElement( selector ).then(
-				function( element ) {
+				async function( element ) {
+					await self.highlightElement( driver, element );
 					return element.getAttribute( 'href' ).then(
 						function( href ) {
 							driver.get( href );
@@ -74,12 +87,14 @@ exports.followLinkWhenFollowable = function( driver, selector, waitOverride ) {
 };
 
 exports.waitTillPresentAndDisplayed = function( driver, selector, waitOverride ) {
+	let self = this;
 	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
 
 	return driver.wait(
 		function() {
 			return driver.findElement( selector ).then(
-				function( element ) {
+				async function( element ) {
+					await self.highlightElement( driver, element, '' );
 					return element.isDisplayed().then(
 						function() {
 							return true;
@@ -102,12 +117,14 @@ exports.waitTillPresentAndDisplayed = function( driver, selector, waitOverride )
 };
 
 exports.isEventuallyPresentAndDisplayed = function( driver, selector, waitOverride ) {
+	let self = this;
 	const timeoutWait = waitOverride ? waitOverride : explicitWaitMS;
 
 	return driver
 		.wait( function() {
 			return driver.findElement( selector ).then(
-				function( element ) {
+				async function( element ) {
+					await self.highlightElement( driver, element, '' );
 					return element.isDisplayed().then(
 						function() {
 							return true;
@@ -133,12 +150,14 @@ exports.isEventuallyPresentAndDisplayed = function( driver, selector, waitOverri
 };
 
 exports.clickIfPresent = function( driver, selector, attempts ) {
+	let self = this;
 	if ( attempts === undefined ) {
 		attempts = 1;
 	}
 	for ( let x = 0; x < attempts; x++ ) {
 		driver.findElement( selector ).then(
-			function( element ) {
+			async function( element ) {
+				await self.highlightElement( driver, element );
 				element.click().then(
 					function() {
 						return true;
@@ -221,6 +240,7 @@ exports.setWhenSettable = function(
 		async function() {
 			await self.waitForFieldClearable( driver, selector );
 			const element = await driver.findElement( selector );
+			await self.highlightElement( driver, element );
 			if ( pauseBetweenKeysMS === 0 ) {
 				await element.sendKeys( value );
 			} else {
@@ -240,10 +260,13 @@ exports.setWhenSettable = function(
 };
 
 exports.waitForFieldClearable = function( driver, selector ) {
+	let self = this;
+
 	return driver.wait(
 		function() {
 			return driver.findElement( selector ).then(
-				element => {
+				async element => {
+					await self.highlightElement( driver, element, '' );
 					return element.clear().then(
 						function() {
 							return element.getAttribute( 'value' ).then( value => {

--- a/test/tests/lib/driver-helper.js
+++ b/test/tests/lib/driver-helper.js
@@ -96,6 +96,7 @@ exports.waitTillPresentAndDisplayed = function( driver, selector, waitOverride )
 			return driver.findElement( selector ).then(
 				async function( element ) {
 					await self.highlightElement( driver, element, '' );
+					await driver.sleep( 300 );
 					return element.isDisplayed().then(
 						function() {
 							return true;

--- a/test/tests/lib/pages/checkout-page.js
+++ b/test/tests/lib/pages/checkout-page.js
@@ -15,7 +15,8 @@ class CheckoutPage extends AsyncBaseContainer {
 		try {
 			await driverHelper.waitTillPresentAndDisplayed(
 				this.driver,
-				By.css( '.composite-checkout' )
+				By.css( '.composite-checkout' ),
+				this.explicitWaitMS * 2
 			);
 			// await driverHelper.waitTillPresentAndDisplayed(
 			// 	this.driver,

--- a/test/tests/lib/pages/login-page.js
+++ b/test/tests/lib/pages/login-page.js
@@ -30,8 +30,9 @@ class LoginPage extends AsyncBaseContainer {
 	async hideGdprBanner() {
 		const gdprBannerButton = By.css( '.gdpr-banner__acknowledge-button' );
 		try {
-			await driverHelper.waitTillPresentAndDisplayed( this.driver, gdprBannerButton, 5000 );
-			return await driverHelper.clickWhenClickable( this.driver, gdprBannerButton );
+			await driverHelper.waitTillPresentAndDisplayed( this.driver, gdprBannerButton, 3000 );
+			await driverHelper.clickWhenClickable( this.driver, gdprBannerButton );
+			return await driverHelper.waitTillNotPresent( this.driver, gdprBannerButton, 3000 );
 		} catch ( e ) {
 			console.log( 'GDPR button is not present.' );
 			return true;
@@ -40,6 +41,7 @@ class LoginPage extends AsyncBaseContainer {
 
 	async openCreateAccountPage() {
 		const element = By.css( '.auth__links a' );
+		await driverHelper.isEventuallyPresentAndDisplayed( this.driver, element );
 		return await driverHelper.clickWhenClickable( this.driver, element );
 	}
 }

--- a/test/tests/lib/pages/profile-page.js
+++ b/test/tests/lib/pages/profile-page.js
@@ -10,13 +10,14 @@ const by = webdriver.By;
 
 class ProfilePage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, by.css( '.me-profile-settings' ) );
+		super( driver, by.css( '.sidebar__region' ) );
 	}
 
 	async clickSignOut() {
 		const signOutSelector = by.css( 'button.sidebar__me-signout-button' );
-		await driverHelper.clickWhenClickable( this.driver, signOutSelector );
 		await this.driver.sleep( 1000 );
+		await driverHelper.clickWhenClickable( this.driver, signOutSelector );
+		return await this.driver.sleep( 1000 );
 	}
 }
 

--- a/test/tests/lib/pages/signup-steps-page.js
+++ b/test/tests/lib/pages/signup-steps-page.js
@@ -53,6 +53,7 @@ class SignupStepsPage extends AsyncBaseContainer {
 	}
 
 	async selectFreeAddress() {
+		await driverHelper.scrollIntoView( this.driver, By.css( '.domain-suggestion' ) );
 		return await driverHelper.selectElementByText(
 			this.driver,
 			By.css( '.domain-product-price__price' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
<!--- Describe your changes in detail. -->
Highlight elements during tests execution. 

An element that the test is waiting for is rounded _red_. 
An element that the test is clicking or typing is rounded _red_ and colored _yellow_ .

Example:
<img width="1736" alt="Screenshot 2020-03-23 at 12 22 07" src="https://user-images.githubusercontent.com/7116222/77311851-2f0d0a00-6d01-11ea-928d-fc6ca038771f.png">


### Motivation and Context:
<!--- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->
With this update, it should be much easier to spot where and why the test has failed. 

### How Has This Been Tested:
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, tests completed to see 
how your change affects other areas of the code, etc. -->
Look at [the video of the executed tests](https://circleci.com/gh/Automattic/wp-desktop/56602#artifacts/containers/0). Are the elements highlighted? Is it useful? :) 

### Additional:

- Logout and Signup tests are enabled again - https://github.com/Automattic/wp-desktop/pull/812/commits/4f41ae5d065bb5c3afe825149cdfd9e1fb7fcb77
- 300ms delay before clicking or typing - https://github.com/Automattic/wp-desktop/pull/812/commits/bf60b16eeb591805d9f1cbb224194783ea823f2b With highlighted elements, I noticed that element has been clicked (colored yellow) but nothing has happened. I added additional 300ms wait before it, to give it a time to finish loading and be displayed properly. 
- Increase timeout for signup processing to finish - https://github.com/Automattic/wp-desktop/pull/812/commits/e401e0f1597976f618522e22be19c813e615b7ff
- Scroll into view 'Free' domain button - https://github.com/Automattic/wp-desktop/pull/812/commits/a1988907a41d3de7164ddd0467b6562e0f80db23 Sometimes, Signup test was failing on Domains screen because a free domain wad displayed but not visible, and the test couldn't click on it. 
- Change Profile page selector to improve clicking on Logout button - https://github.com/Automattic/wp-desktop/pull/812/commits/77d271c20303ac0da0b43bd317b6bfbf7932277a Fixes https://github.com/Automattic/wp-desktop/issues/811

I re-ran tests [10+ times](https://circleci.com/gh/Automattic/workflows/wp-desktop/tree/e2e%252Fadd%252Fhighlight-elements) after these changes, and e2es for Mac passed every time. It looks consistent 🤞 