### PR TITLE
feat(logging): replace debug with custom logger

### DIFF
--- a/desktop/app-handlers/crash-reporting/index.js
+++ b/desktop/app-handlers/crash-reporting/index.js
@@ -6,17 +6,17 @@
 const electron = require( 'electron' );
 const app = electron.app;
 const crashReporter = electron.crashReporter;
-const debug = require( 'debug' )( 'desktop:crash-reporting' );
 
 /**
  * Internal dependencies
  */
 const Config = require( 'lib/config' );
+const log = require( 'lib/logger' )( 'desktop:crash-reporting' );
 
 module.exports = function() {
 	if ( Config.crash_reporter.electron ) {
 		app.on( 'will-finish-launching', function() {
-			debug( 'Crash reporter started' );
+			log.info( 'Crash reporter started' );
 
 			crashReporter.start( {
 				productName: Config.description,

--- a/desktop/app-handlers/exceptions/index.js
+++ b/desktop/app-handlers/exceptions/index.js
@@ -12,6 +12,7 @@ const dialog = electron.dialog;
  */
 const crashTracker = require( 'lib/crash-tracker' );
 const system = require( 'lib/system' );
+const log = require( 'lib/logger' )( 'desktop:exceptions', { handleExceptions: true } );
 
 /**
  * Module variables
@@ -66,7 +67,7 @@ function exceptionHandler( error ) {
 		return;
 	}
 
-	console.log( 'uncaughtException (fatal)', error, error.stack, typeof error );
+	log.error( error );
 
 	if ( crashTracker.isEnabled() ) {
 		crashTracker.track( 'exception', { name: error.name, message: error.message, stack: error.stack }, function() {

--- a/desktop/app-handlers/logging/index.js
+++ b/desktop/app-handlers/logging/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const ipcHandler = require( './ipc-handler' );
+
+module.exports = function() {
+	ipcHandler.listen();
+}

--- a/desktop/app-handlers/logging/ipc-handler/index.js
+++ b/desktop/app-handlers/logging/ipc-handler/index.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * External Dependencies
+ */
+const { ipcMain: ipc } = require( 'electron' );
+
+module.exports = {
+    /**
+     * JSON object that stores references to loggers initialized
+     * by calls from the renderer process over IPC (keyed by `namespace`).
+     */
+	_loggers: {},
+
+    /**
+     * Gets the logging object for the provided `namespace` (and creates a logger
+     * if one doesn't exist). Logger references are tracked in the private
+     * `_loggers` object and keyed by `namespace`.
+     * @param {String} namespace Namespace of the logger to be used or initialized.
+     * @param {Any} options Logger configuration.
+	 * @returns {Object} Logger instance.
+     */
+	_getLogger: function( namespace, options ) {
+		let logger = this._loggers[namespace];
+		if ( !logger ) {
+			logger = require( 'lib/logger' )( namespace, options );
+			this._loggers[namespace] = logger;
+		}
+		return logger;
+	},
+
+    /**
+     * Registers an ipc listener on the `log` channel to relay logging
+     * events from the renderer process.
+     */
+	listen: function() {
+		ipc.on( 'log', ( _, level, namespace, options, message, meta ) => {
+			const logger = this._getLogger( namespace, options );
+
+			switch ( level ) {
+				case 'error':
+					logger.error( message, meta );
+					break;
+				case 'warn':
+					logger.warn( message, meta );
+					break;
+				case 'info':
+					logger.info( message, meta );
+					break;
+				case 'debug':
+					logger.debug( message, meta );
+					break;
+				case 'silly':
+					logger.silly( message, meta );
+					break;
+			}
+		} )
+	}
+}

--- a/desktop/app-handlers/logging/ipc-handler/index.js
+++ b/desktop/app-handlers/logging/ipc-handler/index.js
@@ -12,14 +12,14 @@ module.exports = {
      */
 	loggers: {},
 
-    /**
-     * Gets the logging object for the provided `namespace` (and creates a logger
-     * if one doesn't exist). Logger references are tracked in the private
-     * `loggers` object and keyed by `namespace`.
-     * @param {String} namespace Namespace of the logger to be used or initialized.
-     * @param {Any} options Logger configuration.
-	 * @returns {Object} Logger instance.
-     */
+	/**
+	* Gets the logging object for the provided `namespace` (and creates a logger
+	* if one doesn't exist). Logger references are tracked in the `loggers`
+	* object and keyed by `namespace`.
+	* @param {String} namespace Namespace of the logger to be used or initialized.
+	* @param {Any} options Logger configuration.
+	* @returns {Object} Logger instance.
+	*/
 	getLogger: function( namespace, options ) {
 		let logger = this.loggers[namespace];
 		if ( !logger ) {

--- a/desktop/app-handlers/logging/ipc-handler/index.js
+++ b/desktop/app-handlers/logging/ipc-handler/index.js
@@ -10,21 +10,21 @@ module.exports = {
      * JSON object that stores references to loggers initialized
      * by calls from the renderer process over IPC (keyed by `namespace`).
      */
-	_loggers: {},
+	loggers: {},
 
     /**
      * Gets the logging object for the provided `namespace` (and creates a logger
      * if one doesn't exist). Logger references are tracked in the private
-     * `_loggers` object and keyed by `namespace`.
+     * `loggers` object and keyed by `namespace`.
      * @param {String} namespace Namespace of the logger to be used or initialized.
      * @param {Any} options Logger configuration.
 	 * @returns {Object} Logger instance.
      */
-	_getLogger: function( namespace, options ) {
-		let logger = this._loggers[namespace];
+	getLogger: function( namespace, options ) {
+		let logger = this.loggers[namespace];
 		if ( !logger ) {
 			logger = require( 'lib/logger' )( namespace, options );
-			this._loggers[namespace] = logger;
+			this.loggers[namespace] = logger;
 		}
 		return logger;
 	},
@@ -35,7 +35,7 @@ module.exports = {
      */
 	listen: function() {
 		ipc.on( 'log', ( _, level, namespace, options, message, meta ) => {
-			const logger = this._getLogger( namespace, options );
+			const logger = this.getLogger( namespace, options );
 
 			switch ( level ) {
 				case 'error':

--- a/desktop/app-handlers/printer/index.js
+++ b/desktop/app-handlers/printer/index.js
@@ -6,13 +6,17 @@
 const electron = require( 'electron' );
 const ipc = electron.ipcMain;
 const BrowserWindow = electron.BrowserWindow;
-const debug = require( 'debug' )( 'desktop:printer' );
+
+/**
+ * Internal dependencies
+ */
+const log = require( 'lib/logger' )( 'desktop:printer' );
 
 module.exports = function() {
 	ipc.on( 'print', function( event, title, html ) {
 		let printer = new BrowserWindow( { width: 350, height: 300, title: title } );
 
-		debug( 'Printing HTML' );
+		log.debug( 'Printing HTML' );
 
 		printer.loadURL( 'data:text/html,' + encodeURIComponent( html ) );
 

--- a/desktop/app-handlers/updater/auto-updater/index.js
+++ b/desktop/app-handlers/updater/auto-updater/index.js
@@ -5,7 +5,6 @@
  */
 const { app } = require( 'electron' );
 const { autoUpdater } = require( 'electron-updater' )
-const debug = require( 'debug' )( 'desktop:updater:auto' );
 
 /**
  * Internal dependencies
@@ -15,6 +14,7 @@ const Config = require( 'lib/config' );
 const debugTools = require( 'lib/debug-tools' );
 const { bumpStat, sanitizeVersion, getPlatform } = require( 'lib/desktop-analytics' );
 const Updater = require( 'lib/updater' );
+const log = require( 'lib/logger' )( 'desktop:updater:auto' );
 
 const statsPlatform = getPlatform( process.platform )
 const sanitizedVersion = sanitizeVersion( app.getVersion() );
@@ -22,7 +22,7 @@ const sanitizedVersion = sanitizeVersion( app.getVersion() );
 const getStatsString = ( isBeta ) => `${statsPlatform}${isBeta ? '-b' : ''}-${sanitizedVersion}`;
 
 function dialogDebug( message ) {
-	debug( message );
+	log.info( message );
 
 	if ( Config.build === 'updater' ) {
 		debugTools.dialog( message );
@@ -56,17 +56,17 @@ class AutoUpdater extends Updater {
 	}
 
 	onAvailable( info ) {
-		debug( 'New update is available', info.version )
+		log.info( 'New update is available', info.version )
 		bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-needs-update` );
 	}
 
 	onNotAvailable() {
-		debug( 'No update is available' )
+		log.info( 'No update is available' )
 		bumpStat( 'wpcom-desktop-update-check', `${getStatsString( this.beta )}-no-update` );
 	}
 
 	onDownloaded( info ) {
-		debug( 'Update downloaded', info.version );
+		log.info( 'Update downloaded', info.version );
 
 		this.setVersion( info.version );
 		this.notify();
@@ -92,7 +92,7 @@ class AutoUpdater extends Updater {
 	}
 
 	onError( event ) {
-		debug( 'Update error', event );
+		log.error( 'Update error', event );
 
 		bumpStat( 'wpcom-desktop-update', `${getStatsString( this.beta )}-update-error` );
 	}

--- a/desktop/app-handlers/updater/auto-updater/index.js
+++ b/desktop/app-handlers/updater/auto-updater/index.js
@@ -92,7 +92,7 @@ class AutoUpdater extends Updater {
 	}
 
 	onError( event ) {
-		log.error( 'Update error', event );
+		log.error( 'Update error: ', event );
 
 		bumpStat( 'wpcom-desktop-update', `${getStatsString( this.beta )}-update-error` );
 	}

--- a/desktop/app-handlers/updater/index.js
+++ b/desktop/app-handlers/updater/index.js
@@ -4,7 +4,6 @@
  * External Dependencies
  */
 const { app } = require( 'electron' );
-const debug = require( 'debug' )( 'desktop:updater' );
 
 /**
  * Internal dependencies
@@ -14,22 +13,23 @@ const Config = require( 'lib/config' );
 const settings = require( 'lib/settings' );
 const AutoUpdater = require( './auto-updater' );
 const ManualUpdater = require( './manual-updater' );
+const log = require( 'lib/logger' )( 'desktop:updater' );
 
 let updater = false;
 
 module.exports = function() {
-	debug( 'Updater config is', Config.updater )
+	log.info( 'Updater config: ', Config.updater )
 	if ( Config.updater ) {
 		app.on( 'will-finish-launching', function() {
 			const beta = settings.getSetting( 'release-channel' ) === 'beta';
-			debug( 'Update channel', settings.getSetting( 'release-channel' ) )
+			log.info( `Update channel: '${settings.getSetting( 'release-channel' )}'` );
 			if ( platform.isOSX() || platform.isWindows() || process.env.APPIMAGE ) {
-				debug( 'Auto Update' )
+				log.info( 'Auto Update' )
 				updater = new AutoUpdater( {
 					beta,
 				} );
 			} else {
-				debug( 'Manual Update' )
+				log.info( 'Manual Update' )
 				updater = new ManualUpdater( {
 					downloadUrl: Config.updater.downloadUrl,
 					apiUrl: Config.updater.apiUrl,
@@ -47,6 +47,6 @@ module.exports = function() {
 			setInterval( updater.ping.bind( updater ), Config.updater.interval );
 		} );
 	} else {
-		debug( 'Skipping Update – no configuration' )
+		log.info( 'Skipping Update – no configuration' )
 	}
 };

--- a/desktop/app-handlers/updater/manual-updater/index.js
+++ b/desktop/app-handlers/updater/manual-updater/index.js
@@ -39,7 +39,7 @@ class ManualUpdater extends Updater {
 	async ping() {
 		try {
 			const url = this.apiUrl;
-			log.info( 'Checking for update. Fetching: ', url );
+			log.info( 'Checking for update. Fetching: %s', url );
 			log.info( 'Checking for beta release:', this.beta )
 
 			const releaseResp = await fetch( url, requestOptions );

--- a/desktop/app-handlers/updater/manual-updater/index.js
+++ b/desktop/app-handlers/updater/manual-updater/index.js
@@ -39,7 +39,7 @@ class ManualUpdater extends Updater {
 	async ping() {
 		try {
 			const url = this.apiUrl;
-			log.info( 'Checking for update. Fetching: %s', url );
+			log.info( 'Checking for update. Fetching: ', url );
 			log.info( 'Checking for beta release:', this.beta )
 
 			const releaseResp = await fetch( url, requestOptions );

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -4,27 +4,24 @@
  * Internal dependencies
  */
 require( './env' );   // Must come first to setup the environment
-
-/**
- * External Dependencies
- */
-const debug = require( 'debug' )( 'desktop:index' );
+const log = require( 'lib/logger' )( 'desktop:index' );
 
 module.exports = function( finished_cb ) {
-	debug( 'Starting app handlers' );
+	log.info( 'Starting app handlers' );
 
 	// Stuff that can run before the main window
+	require( './app-handlers/logging' )();
 	require( './app-handlers/crash-reporting' )();
 	require( './app-handlers/updater' )();
 	require( './app-handlers/preferences' )();
 	require( './app-handlers/secrets' )();
 	require( './app-handlers/printer' )();
 
-	debug( 'Waiting for app window to load' );
+	log.info( 'Waiting for app window to load' );
 
 	// Start the main window
 	require( './server' )( function( mainWindow ) {
-		debug( 'Starting window handlers' );
+		log.info( 'Starting window handlers' );
 
 		// Stuff that needs a mainWindow handle
 		require( './window-handlers/failed-to-load' )( mainWindow );

--- a/desktop/env.js
+++ b/desktop/env.js
@@ -57,6 +57,7 @@ if ( Settings.isDebug() ) {
 const log = require( 'lib/logger' )( 'desktop:boot' );
 log.info( `Booting ${ config.appPathName + ' v' + config.version }` );
 log.info( `App Path: ${ app.getAppPath() }` );
+log.info( `App Data: ${ app.getPath( 'userData' ) }` );
 log.info( 'Server: ' + config.server_url + ':' + config.server_port );
 log.info( 'Settings:', Settings._getAll() );
 

--- a/desktop/env.js
+++ b/desktop/env.js
@@ -54,29 +54,26 @@ if ( Settings.isDebug() ) {
  * These setup things for Calypso. We have to do them inside the app as we can't set any env variables in the packaged release
  * This has to come after the DEBUG_* variables
  */
-const debug = require( 'debug' )( 'desktop:boot' );
-debug( '========================================================================================================' );
-debug( config.name + ' v' + config.version );
-debug( 'Path:', app.getAppPath() );
-debug( 'Server: ' + config.server_url + ':' + config.server_port );
-debug( 'Settings:', Settings._getAll() );
+const log = require( 'lib/logger' )( 'desktop:boot' );
+log.info( `Booting ${ config.appPathName + ' v' + config.version }` );
+log.info( `App Path: ${ app.getAppPath() }` );
+log.info( 'Server: ' + config.server_url + ':' + config.server_port );
+log.info( 'Settings:', Settings._getAll() );
 
 if ( Settings.getSetting( 'proxy-type' ) === '' ) {
-	debug( 'Proxy: none' );
+	log.info( 'Proxy: none' );
 	app.commandLine.appendSwitch( 'no-proxy-server' );
 } else if ( Settings.getSetting( 'proxy-type' ) === 'custom' ) {
-	debug( 'Proxy: ' + Settings.getSetting( 'proxy-url' ) + ':' + Settings.getSetting( 'proxy-port' ) );
+	log.info( 'Proxy: ' + Settings.getSetting( 'proxy-url' ) + ':' + Settings.getSetting( 'proxy-port' ) );
 	app.commandLine.appendSwitch( 'proxy-server', Settings.getSetting( 'proxy-url' ) + ':' + Settings.getSetting( 'proxy-port' ) );
 
 	if ( Settings.getSetting( 'proxy-pac' ) !== '' ) {
-		debug( 'Proxy PAC: ' + Settings.getSetting( 'proxy-pac' ) );
+		log.info( 'Proxy PAC: ' + Settings.getSetting( 'proxy-pac' ) );
 
 		// todo: this doesnt seem to work yet
 		app.commandLine.appendSwitch( 'proxy-pac-url', Settings.getSetting( 'proxy-pac' ) );
 	}
 }
-
-debug( '========================================================================================================' );
 
 // Define a global 'desktop' variable that can be used in browser windows to access config and settings
 global.desktop = {

--- a/desktop/lib/app-instance/index.js
+++ b/desktop/lib/app-instance/index.js
@@ -4,20 +4,20 @@
  * External Dependencies
  */
 const app = require( 'electron' ).app;
-const debug = require( 'debug' )( 'desktop:app-instance' );
 
 /**
  * Internal dependencies
  */
 const config = require( 'lib/config' );
 const platform = require( 'lib/platform' );
+const log = require( 'lib/logger' )( 'desktop:app-instance' );
 
 function AppInstance() {
 }
 
 // This is called whenever another instance is started
 AppInstance.prototype.anotherInstanceStarted = function() {
-	debug( 'Another instance started, bringing to the front' );
+	log.info( 'Another instance started, bringing to the front' );
 
 	platform.restore();
 
@@ -29,7 +29,7 @@ AppInstance.prototype.isSingleInstance = function() {
 		return true;
 	}
 
-	debug( 'App is already running, quitting' );
+	log.info( 'App is already running, quitting' );
 	app.quit();
 	return false;
 };

--- a/desktop/lib/archiver/index.js
+++ b/desktop/lib/archiver/index.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+const archiver = require( 'archiver' );
+
+/**
+ * Internal dependencies
+ */
+const log = require( 'lib/logger' )( 'desktop:lib:archiver' );
+
+module.exports = {
+
+	/**
+	 * Compresses `contents` to the archive at `dst`.
+	 *
+	 * @param {String[]} contents Paths to be zipped
+	 * @param {String} dst Path to destination archive
+	 * @param {function():void} onZipped Callback invoked when archive is complete
+	 */
+	zipContents: ( contents, dst, onZipped ) => {
+		let output = fs.createWriteStream( dst );
+		let archive = archiver( 'zip', {
+			zlib: { level: 9 }
+		} );
+
+		output.on( 'close', function() {
+			log.debug( 'Archive finalized: %s bytes written', archive.pointer() );
+			if ( typeof onZipped === 'function' ) {
+				onZipped();
+			}
+		} );
+
+		// Catch warnings (e.g. stat failures and other non-blocking errors)
+		archive.on( 'warning', function( err ) {
+			log.warn( 'Unexpected error: ', err );
+		} );
+
+		archive.on( 'error', function( err ) {
+			throw err;
+		} );
+
+		archive.pipe( output );
+
+		for ( let i = 0; i < contents.length; i++ ) {
+			const src = contents[i];
+			const zipSubdir = path.basename( dst ).replace( '.zip', '' );
+			const dstInZipSubdir = path.join( zipSubdir, path.basename( src ) );
+
+			const stat = fs.lstatSync( src );
+			if ( stat.isDirectory() ) {
+				archive.directory( path.join( src, path.sep ), dstInZipSubdir );
+				continue;
+			}
+			archive.file( src, { name: dstInZipSubdir } );
+		}
+
+		archive.finalize();
+	}
+}

--- a/desktop/lib/calypso-commands/index.js
+++ b/desktop/lib/calypso-commands/index.js
@@ -1,43 +1,43 @@
 'use strict';
 
 /**
- * External Dependencies
+ * Internal dependencies
  */
-const debug = require( 'debug' )( 'desktop:ipc' );
+const log = require( 'lib/logger' )( 'desktop:ipc' );
 
 module.exports = {
 	showMySites: function( mainWindow ) {
-		debug( 'showMySites triggered' );
+		log.info( 'showMySites triggered' );
 		mainWindow.webContents.send( 'page-my-sites' );
 	},
 
 	showReader: function( mainWindow ) {
-		debug( 'showReader triggered' );
+		log.info( 'showReader triggered' );
 		mainWindow.webContents.send( 'page-reader' );
 	},
 
 	showProfile: function( mainWindow ) {
-		debug( 'showProfile triggered' );
+		log.info( 'showProfile triggered' );
 		mainWindow.webContents.send( 'page-profile' );
 	},
 
 	newPost: function( mainWindow ) {
-		debug( 'newPost triggered' );
+		log.info( 'newPost triggered' );
 		mainWindow.webContents.send( 'new-post' );
 	},
 
 	toggleNotifications: function( mainWindow ) {
-		debug( 'toggleNotifications triggered' );
+		log.info( 'toggleNotifications triggered' );
 		mainWindow.webContents.send( 'toggle-notification-bar' );
 	},
 
 	showHelp: function( mainWindow ) {
-		debug( 'showHelp triggered' );
+		log.info( 'showHelp triggered' );
 		mainWindow.webContents.send( 'page-help' );
 	},
 
 	signOut: function( mainWindow ) {
-		debug( 'signOut triggered' );
+		log.info( 'signOut triggered' );
 		mainWindow.webContents.send( 'signout' );
 	}
 };

--- a/desktop/lib/crash-tracker/index.js
+++ b/desktop/lib/crash-tracker/index.js
@@ -7,19 +7,19 @@ const electron = require( 'electron' );
 const app = electron.app;
 const request = require( 'superagent' );
 const path = require( 'path' );
-const debug = require( 'debug' )( 'desktop:crash-tracker' );
 
 /**
  * Internal dependencies
  */
 const config = require( 'lib/config' );
 const system = require( 'lib/system' );
+const log = require( 'lib/logger' )( 'desktop:crash-tracker' );
 
 function finished( error, response, cb ) {
 	if ( error ) {
-		debug( 'Failed to upload crash report', error );
+		log.error( 'Failed to upload crash report', error );
 	} else {
-		debug( 'Uploaded crash report' );
+		log.info( 'Uploaded crash report' );
 	}
 
 	if ( typeof cb !== 'undefined' ) {
@@ -44,7 +44,7 @@ module.exports = {
 	track: function( errorType, errorData, cb ) {
 		if ( config.crash_reporter.tracker ) {
 			// Send to crash tracker
-			debug( 'Sending crash report to ' + config.crash_reporter.url );
+			log.info( 'Sending crash report to ' + config.crash_reporter.url );
 
 			request
 				.post( config.crash_reporter.url )
@@ -58,7 +58,7 @@ module.exports = {
 	trackLog: function( cb ) {
 		const logFile = path.join( app.getPath( 'userData' ), config.debug.log_file );
 
-		debug( 'Uploading log file: ' + logFile );
+		log.info( 'Uploading log file: ' + logFile );
 
 		request
 			.post( config.crash_reporter.url )

--- a/desktop/lib/debug-tools/README.md
+++ b/desktop/lib/debug-tools/README.md
@@ -1,5 +1,4 @@
-Debug Tools
-=========
+# Debug Tools
 
 Provides a few tools to debug the app.
 
@@ -10,5 +9,3 @@ Provides a few tools to debug the app.
 Where:
 
 - `message` - a message to display in a dialog
-
-`debug.log( values )` - log anything to a temporary file

--- a/desktop/lib/debug-tools/index.js
+++ b/desktop/lib/debug-tools/index.js
@@ -3,13 +3,7 @@
 /**
  * External Dependencies
  */
-const fs = require( 'fs' );
 const dialog = require( 'electron' ).dialog;
-
-/**
-* Module variables
-*/
-const LOGNAME = '/tmp/wordpress-app.log';
 
 module.exports = {
 	dialog: function( message ) {
@@ -20,14 +14,5 @@ module.exports = {
 			detail: message
 		}, function() {
 		} );
-	},
-
-	log: function() {
-		const args = Array.prototype.slice.call( arguments );
-		const logfile = fs.createWriteStream( LOGNAME, { flags: 'a' } );
-
-		for ( let x = 0; x < args.length; x++ ) {
-			logfile.write( args[x] + require( 'os' ).EOL );
-		}
 	}
 };

--- a/desktop/lib/desktop-analytics/index.js
+++ b/desktop/lib/desktop-analytics/index.js
@@ -1,4 +1,4 @@
-const debug = require( 'debug' )( 'desktop:analytics' );
+const log = require( 'lib/logger' )( 'desktop:analytics' );
 const fetch = require( 'electron-fetch' ).default
 
 function buildQuerystring( group, name ) {
@@ -19,9 +19,9 @@ function buildQuerystring( group, name ) {
 
 export async function bumpStat( group, name ) {
 	if ( 'object' === typeof group ) {
-		debug( 'Bumping stats %o', group );
+		log.info( 'Bumping stats %o', group );
 	} else {
-		debug( 'Bumping stat %s:%s', group, name );
+		log.info( 'Bumping stat %s:%s', group, name );
 	}
 
 	const uriComponent = buildQuerystring( group, name );
@@ -29,9 +29,9 @@ export async function bumpStat( group, name ) {
 
 	const resp = await fetch( url );
 	if ( resp.status === 200 ) {
-		debug( 'Sent analytics ping' );
+		log.info( 'Sent analytics ping' );
 	} else {
-		debug( 'Analytics ping failed', resp.status, resp.statusText );
+		log.warn( 'Analytics ping failed', resp.status, resp.statusText );
 	}
 };
 
@@ -56,9 +56,9 @@ export function getPlatform( platform ) {
 // Stats key and value is limited to 32 chars
 function checkLength( key, val ) {
 	if ( key.length > 32 ) {
-		debug( `WARNING: bumpStat() key '${key}' is longer than 32 chars` );
+		log.warn( `bumpStat() key '${key}' is longer than 32 chars` );
 	}
 	if ( val.length > 32 ) {
-		debug( `WARNING: bumpStat() value '${val}' is longer than 32 chars` );
+		log.warn( `bumpStat() value '${val}' is longer than 32 chars` );
 	}
 }

--- a/desktop/lib/desktop-analytics/index.js
+++ b/desktop/lib/desktop-analytics/index.js
@@ -21,7 +21,7 @@ export async function bumpStat( group, name ) {
 	if ( 'object' === typeof group ) {
 		log.info( 'Bumping stats %o', group );
 	} else {
-		log.info( 'Bumping stat %s:%s', group, name );
+		log.info( 'Bumping stat,' + `${ group ? ' group: ' + group : ''}` + `${ name ? ' name: ' + name : '' }` );
 	}
 
 	const uriComponent = buildQuerystring( group, name );

--- a/desktop/lib/logger/index.js
+++ b/desktop/lib/logger/index.js
@@ -36,10 +36,10 @@ module.exports = ( namespace, options ) => {
 	const formatMessageWithMeta = ( info, opts ) => {
 		const args = info[Symbol.for( 'splat' )];
 		if ( args ) {
-			if ( args instanceof Array && args[0] === undefined ) {
+			if ( args instanceof Array && args.length && ! args[0] ) {
 				return info;
 			}
-			info.message = util.format( info.message, ...args );
+			info.message = util.format( info.message, JSON.stringify( ...args ) );
 		}
 		return info;
 	}

--- a/desktop/lib/logger/index.js
+++ b/desktop/lib/logger/index.js
@@ -15,6 +15,7 @@
 /**
  * External dependencies
  */
+const util = require( 'util' );
 const { createLogger, format, transports } = require( 'winston' );
 
 /**
@@ -32,24 +33,27 @@ const maxsize = 15000000;
 module.exports = ( namespace, options ) => {
 	if ( !options || typeof options !== 'object' ) options = {}
 
-	const formatMeta = ( args ) => {
-		const isObject = typeof args === 'object';
-		if ( isObject ) {
-			return `${ Object.keys( args ).length ? JSON.stringify( args ) : '' }`;
+	const formatMessageWithMeta = ( info, opts ) => {
+		const args = info[Symbol.for( 'splat' )];
+		if ( args ) {
+			if ( args instanceof Array && args[0] === undefined ) {
+				return info;
+			}
+			info.message = util.format( info.message, ...args );
 		}
-		return args;
+		return info;
 	}
 
 	const baseformat = format.combine(
 		format.timestamp( {
 			format: 'YYYY-MM-DD HH:mm:ss.SSS'
 		} ),
-		format.splat(),
 		format.errors( { stack: true } ),
+		format( ( info, opts ) => formatMessageWithMeta( info, opts ) )(),
 		format.printf( ( info ) => {
-			const { timestamp, level, message, ...args } = info;
-			let meta = info.stack ? `\n${ info.stack }` : formatMeta( args );
-			return `[${ timestamp }] [${ namespace }] [${ level }] ${ message }` + meta;
+			const { timestamp, level, message } = info;
+			const stack = info.stack ? `\n${ info.stack }` : ''
+			return `[${timestamp}] [${namespace}] [${level}] ${message}` + stack;
 		} ) );
 
 	const baseOptions = {

--- a/desktop/lib/logger/index.js
+++ b/desktop/lib/logger/index.js
@@ -15,7 +15,6 @@
 /**
  * External dependencies
  */
-const util = require( 'util' );
 const { createLogger, format, transports } = require( 'winston' );
 
 /**
@@ -39,7 +38,7 @@ module.exports = ( namespace, options ) => {
 			if ( args instanceof Array && args.length && ! args[0] ) {
 				return info;
 			}
-			info.message = util.format( info.message, JSON.stringify( ...args ) );
+			info.message = info.message + JSON.stringify( ...args );
 		}
 		return info;
 	}

--- a/desktop/lib/menu/help-menu.js
+++ b/desktop/lib/menu/help-menu.js
@@ -5,13 +5,15 @@
  */
 const shell = require( 'electron' ).shell;
 const ipc = require( 'lib/calypso-commands' );
+const zipLogs = require( '../../window-handlers/get-logs' );
 
 /**
  * Internal dependencies
  */
+const state = require( 'lib/state' );
 const platform = require( 'lib/platform' );
 const WindowManager = require( 'lib/window-manager' );
-const state = require( 'lib/state' );
+const log = require( 'lib/logger' )( 'desktop:menu:help' );
 
 let menuItems = [];
 
@@ -52,5 +54,15 @@ module.exports = function( mainWindow ) {
 				shell.openExternal( 'https://automattic.com/privacy/' );
 			}
 		},
+		{
+			type: 'separator',
+		},
+		{
+			label: 'Get Application Logs',
+			click: function() {
+				log.info( 'User selected \'Get Application Logs\'...' );
+				zipLogs( mainWindow );
+			}
+		}
 	] );
 }

--- a/desktop/lib/menu/index.js
+++ b/desktop/lib/menu/index.js
@@ -4,13 +4,13 @@
  * External Dependencies
  */
 const Menu = require( 'electron' ).Menu;
-const debug = require( 'debug' )( 'desktop:menu' );
 
 /**
  * Internal dependencies
  */
 const template = require( './main-menu' );
 const menuSetter = require( 'lib/menu-setter' );
+const log = require( 'lib/logger' )( 'desktop:menu' );
 
 /**
  * Module variables
@@ -28,13 +28,13 @@ AppMenu.prototype.set = function( app, mainWindow ) {
 };
 
 AppMenu.prototype.enableLoggedInItems = function() {
-	debug( 'Enabling logged in menu items' );
+	log.info( 'Enabling logged in menu items' );
 
 	menuSetter.setRequiresUser( this.menu, true );
 };
 
 AppMenu.prototype.disableLoggedInItems = function() {
-	debug( 'Disabling logged in menu items' );
+	log.info( 'Disabling logged in menu items' );
 
 	menuSetter.setRequiresUser( this.menu, false );
 };

--- a/desktop/lib/platform/linux/index.js
+++ b/desktop/lib/platform/linux/index.js
@@ -5,23 +5,23 @@
  */
 const electron = require( 'electron' );
 const app = electron.app;
-const debug = require( 'debug' )( 'platform:linux' );
 
 /**
  * Internal dependencies
  */
+const log = require( 'lib/logger' )( 'platform:linux' );
 
 function LinuxPlatform( mainWindow ) {
 	this.window = mainWindow;
 
 	app.on( 'activate', function() {
-		debug( 'Window activated' );
+		log.info( 'Window activated' );
 		mainWindow.show();
 		mainWindow.focus();
 	} );
 
 	app.on( 'window-all-closed', function() {
-		debug( 'All windows closed, shutting down' );
+		log.info( 'All windows closed, shutting down' );
 		app.quit();
 	} );
 

--- a/desktop/lib/platform/mac/index.js
+++ b/desktop/lib/platform/mac/index.js
@@ -6,13 +6,13 @@
 const electron = require( 'electron' );
 const app = electron.app;
 const Menu = electron.Menu;
-const debug = require( 'debug' )( 'platform:mac' );
 
 /**
  * Internal dependencies
  */
 const appQuit = require( 'lib/app-quit' );
 const menuSetter = require( 'lib/menu-setter' );
+const log = require( 'lib/logger' )( 'platform:mac' );
 
 function MacPlatform( mainWindow ) {
 	this.window = mainWindow;
@@ -21,26 +21,26 @@ function MacPlatform( mainWindow ) {
 	app.dock.setMenu( this.dockMenu );
 
 	app.on( 'activate', function() {
-		debug( 'Window activated' );
+		log.info( 'Window activated' );
 
 		mainWindow.show();
 		mainWindow.focus();
 	} );
 
 	app.on( 'window-all-closed', function() {
-		debug( 'All windows closed, shutting down' );
+		log.info( 'All windows closed, shutting down' );
 		app.quit();
 	} );
 
 	app.on( 'before-quit', function() {
-		debug( 'Application quit triggered' );
+		log.info( 'Application quit triggered' );
 
 		appQuit.allowQuit();
 	} );
 
 	mainWindow.on( 'close', function( ev ) {
 		if ( appQuit.shouldQuitToBackground() ) {
-			debug( 'Window close puts app into background' );
+			log.info( 'Window close puts app into background' );
 			ev.preventDefault();
 			mainWindow.hide();
 		}

--- a/desktop/lib/platform/windows/index.js
+++ b/desktop/lib/platform/windows/index.js
@@ -6,7 +6,6 @@
 const electron = require( 'electron' );
 const Tray = electron.Tray;
 const Menu = electron.Menu;
-const debug = require( 'debug' )( 'platform:windows' );
 
 /**
  * Internal dependencies
@@ -17,6 +16,7 @@ const appQuit = require( 'lib/app-quit' );
 const platform = require( 'lib/platform' );
 const menuSetter = require( 'lib/menu-setter' );
 const assets = require( 'lib/assets' );
+const log = require( 'lib/logger' )( 'platform:windows' );
 
 /**
 * Module variables
@@ -39,7 +39,7 @@ function WindowsPlatform( mainWindow ) {
 
 WindowsPlatform.prototype.onClosed = function( ev ) {
 	if ( appQuit.shouldQuitToBackground() ) {
-		debug( 'Window close puts app into background & creates tray' );
+		log.info( 'Window close puts app into background & creates tray' );
 
 		ev.preventDefault();
 
@@ -50,7 +50,7 @@ WindowsPlatform.prototype.onClosed = function( ev ) {
 
 WindowsPlatform.prototype.showBackgroundBubble = function() {
 	if ( Settings.getSettingGroup( false, TRAY_SETTING ) === false ) {
-		debug( 'Showing tray balloon' );
+		log.info( 'Showing tray balloon' );
 
 		Settings.saveSetting( TRAY_SETTING, true );
 

--- a/desktop/lib/settings/index.js
+++ b/desktop/lib/settings/index.js
@@ -37,19 +37,19 @@ Settings.prototype.isDebug = function() {
  */
 Settings.prototype.getSetting = function( setting ) {
 	const value = this._getAll()[setting];
-	const debug = require( 'debug' )( 'desktop:settings' );
+	const log = require( 'lib/logger' )( 'desktop:settings' );
 
 	if ( typeof value === 'undefined' ) {
 		if ( typeof Config.default_settings[setting] !== 'undefined' ) {
-			debug( 'Get default setting for ' + setting + ' = ' + Config.default_settings[setting] );
+			log.info( 'Get default setting for ' + setting + ' = ' + Config.default_settings[setting] );
 			return Config.default_settings[setting];
 		}
 
-		debug( 'Get setting with no defaults for ' + setting );
+		log.info( 'Get setting with no defaults for ' + setting );
 		return false;
 	}
 
-	debug( 'Get setting for ' + setting + ' = ' + value );
+	log.info( 'Get setting for ' + setting + ' = ' + value );
 	return value;
 };
 
@@ -57,19 +57,23 @@ Settings.prototype.getSetting = function( setting ) {
  * Get a group of settings
  */
 Settings.prototype.getSettingGroup = function( existing, group, values ) {
-	const debug = require( 'debug' )( 'desktop:settings' );
+	const log = require( 'lib/logger' )( 'desktop:settings' );
 
-	debug( 'Get settings for ' + group + ' = ' + values );
+	const settingsGroup = this._getAll()[group];
 
-	if ( typeof this._getAll()[group] !== 'undefined' ) {
+	if ( typeof settingsGroup !== 'undefined' ) {
 		if ( values instanceof Array ) {
+			let updated = {};
 			for ( let x = 0; x < values.length; x++ ) {
 				let value = values[x];
-
-				existing[value] = this._getAll()[group][value];
+				existing[value] = settingsGroup[value];
+				updated[value] = settingsGroup[value];
 			}
+
+			log.info( `Updated settings for group '${ group }': `, updated );
 		} else {
-			return this._getAll()[group];
+			log.info( `Get settings for group '${ group }': `, settingsGroup );
+			return settingsGroup;
 		}
 	}
 

--- a/desktop/lib/settings/settings-file.js
+++ b/desktop/lib/settings/settings-file.js
@@ -62,7 +62,7 @@ module.exports = {
 			data = JSON.parse( data );
 			data[group] = groupData;
 
-			log.info( `Updating settings: '${ group }': ${ typeof groupData === 'object' ? '%o' : '%s' }`, groupData );
+			log.info( `Updating settings: '${ group }': `, groupData );
 			fs.writeFileSync( settingsFile, JSON.stringify( data ) );
 		} catch ( error ) {
 			log.error( 'Failed to read settings file', error );

--- a/desktop/lib/settings/settings-file.js
+++ b/desktop/lib/settings/settings-file.js
@@ -6,12 +6,12 @@
 const app = require( 'electron' ).app;
 const path = require( 'path' );
 const fs = require( 'fs' );
-const debug = require( 'debug' )( 'desktop:settings' );
 
 /**
  * Internal dependencies
  */
 const Config = require( '../config' );
+const log = require( 'lib/logger' )( 'desktop:settings' );
 
 let firstRun = false;
 
@@ -32,7 +32,7 @@ module.exports = {
 			try {
 				return JSON.parse( fs.readFileSync( settingsFile ) );
 			} catch ( e ) {
-				debug( 'Error reading settings file' );
+				log.error( 'Failed to read settings file' );
 			}
 		}
 
@@ -40,7 +40,7 @@ module.exports = {
 		try {
 			createSettingsFile( getSettingsFile() );
 		} catch ( e ) {
-			debug( 'Error creating settings file' );
+			log.error( 'Failed to create settings file' );
 		}
 		return {};
 	},
@@ -57,15 +57,15 @@ module.exports = {
 			// Read the existing settings
 			data = fs.readFileSync( settingsFile );
 
-			debug( 'Read settings from ' + settingsFile, data.toString( 'utf-8' ) );
+			log.info( `Read settings from '${ settingsFile }': ${ data.toString( 'utf-8' ) }` );
 
 			data = JSON.parse( data );
 			data[group] = groupData;
 
-			debug( 'Updating settings: ' + group, groupData );
+			log.info( `Updating settings: '${ group }': ${ typeof groupData === 'object' ? '%o' : '%s' }`, groupData );
 			fs.writeFileSync( settingsFile, JSON.stringify( data ) );
 		} catch ( error ) {
-			debug( 'Failed to read settings file', error );
+			log.error( 'Failed to read settings file', error );
 		}
 
 		return data;

--- a/desktop/lib/system/index.js
+++ b/desktop/lib/system/index.js
@@ -6,7 +6,6 @@
 
 const Platform = require( 'lib/platform' );
 const exec = require( 'child_process' ).execSync;
-const debug = require( 'debug' )( 'desktop:system' );
 const os = require( 'os' );
 
 /**
@@ -15,6 +14,7 @@ const os = require( 'os' );
 const config = require( 'lib/config' );
 const SettingsFile = require( 'lib/settings/settings-file' );
 const APPS_DIRECTORY = '/Applications';
+const log = require( 'lib/logger' )( 'desktop:system' );
 
 function isPinned() {
 	if ( Platform.isOSX() ) {
@@ -52,7 +52,7 @@ module.exports = {
 			firstRun: isFirstRun()
 		}
 
-		debug( 'System details: ', details );
+		log.info( 'System details: ', details );
 		return details;
 	},
 	getVersionData: function() {

--- a/desktop/lib/updater/index.js
+++ b/desktop/lib/updater/index.js
@@ -3,13 +3,13 @@
  */
 const { app, dialog } = require( 'electron' );
 const { EventEmitter } = require( 'events' );
-const debug = require( 'debug' )( 'desktop:updater' );
 
 /**
  * Internal dependencies
  */
 const platform = require( 'lib/platform' );
 const config = require( 'lib/config' );
+const log = require( 'lib/logger' )( 'desktop:updater' );
 
 class Updater extends EventEmitter {
 	constructor( options ) {
@@ -30,19 +30,19 @@ class Updater extends EventEmitter {
 	ping() {}
 
 	onDownloaded( info ) {
-		debug( 'Update downloaded', info );
+		log.info( 'Update downloaded', info );
 	}
 
 	onAvailable( info ) {
-		debug( 'Update is available', info );
+		log.info( 'Update is available', info );
 	}
 
 	onNotAvailable( info ) {
-		debug( 'Update is not available', info );
+		log.info( 'Update is not available', info );
 	}
 
 	onError( event ) {
-		debug( 'Update error', event );
+		log.error( 'Update failed: ', event );
 	}
 
 	onConfirm() {}
@@ -51,7 +51,7 @@ class Updater extends EventEmitter {
 
 	notify() {
 		const updateDialogOptions = {
-			buttons: [this.sanitizeButtonLabel( this.confirmLabel ), 'Cancel'],
+			buttons: [ this.sanitizeButtonLabel( this.confirmLabel ), 'Cancel' ],
 			title: 'Update Available',
 			message: this.expandMacros( this.dialogTitle ),
 			detail: this.expandMacros( this.dialogMessage ),

--- a/desktop/server/server.js
+++ b/desktop/server/server.js
@@ -4,7 +4,7 @@
  * External Dependencies
  */
 const portscanner = require( 'portscanner' );
-const debug = require( 'debug' )( 'desktop:server' );
+const log = require( 'lib/logger' )( 'desktop:server' );
 
 /**
  * Internal dependencies
@@ -30,29 +30,29 @@ function startServer( running_cb ) {
 	var http = require( 'http' );
 	var server = http.createServer( boot() );
 
-	debug( 'Server created, binding to ' + Config.server_port );
+	log.info( 'Server created, binding to ' + Config.server_port );
 
 	server.listen( {
 		port: Config.server_port,
 		host: Config.server_host
 	}, function() {
-		debug( 'Server started, passing back to app' );
+		log.info( 'Server started, passing back to app' );
 		running_cb();
 	} );
 }
 
 module.exports = {
 	start: function( app, running_cb ) {
-		debug( 'Checking server port: ' + Config.server_port + ' on host ' + Config.server_host );
+		log.info( 'Checking server port: ' + Config.server_port + ' on host ' + Config.server_host );
 
 		portscanner.checkPortStatus( Config.server_port, Config.server_host, function( error, status ) {
 			if ( error || status === 'open' ) {
-				debug( 'Port check failed - ' + status, error );
+				log.info( 'Port check failed - ' + status, error );
 				showFailure( app );
 				return;
 			}
 
-			debug( 'Starting server' );
+			log.info( 'Starting server' );
 			startServer( running_cb );
 		} );
 	}

--- a/desktop/window-handlers/debug-tools/index.js
+++ b/desktop/window-handlers/debug-tools/index.js
@@ -1,16 +1,8 @@
 'use strict';
 
-/**
- * External Dependencies
- */
-const ipc = require( 'electron' ).ipcMain;
-const debug = require( 'debug' )( 'desktop:browser' );
+const { ipcMain: ipc } = require( 'electron' );
 
 module.exports = function( mainWindow ) {
-	ipc.on( 'debug', function( event, payload ) {
-		debug.call( debug, payload[0].replace( /%c/g, '' ).replace( /\s\+\dms*/, '' ) );
-	} );
-
 	ipc.on( 'toggle-dev-tools', function() {
 		mainWindow.webContents.toggleDevTools();
 	} );

--- a/desktop/window-handlers/external-links/index.js
+++ b/desktop/window-handlers/external-links/index.js
@@ -4,13 +4,13 @@
  * External Dependencies
  */
 const shell = require( 'electron' ).shell;
-const debug = require( 'debug' )( 'desktop:external-links' );
 const { URL, format } = require( 'url' );
 
 /**
  * Internal dependencies
  */
 const Config = require( 'lib/config' );
+const log = require( 'lib/logger' )( 'desktop:external-links' );
 
 /**
  * Module variables
@@ -55,7 +55,7 @@ function openInBrowser( event, url ) {
 
 function replaceInternalCalypsoUrl( url ) {
 	if ( url.hostname === Config.server_host ) {
-		debug( 'Replacing internal url with public url', url.hostname, Config.wordpress_url );
+		log.info( 'Replacing internal url with public url', url.hostname, Config.wordpress_url );
 
 		url.hostname = Config.wordpress_host;
 		url.port = '';
@@ -76,7 +76,7 @@ module.exports = function( webContents ) {
 			}
 		}
 
-		debug( 'External link for ' + url );
+		log.info( `Using system default handler for URL: '${ url }'` );
 		openInBrowser( event, url );
 	} );
 
@@ -87,7 +87,7 @@ module.exports = function( webContents ) {
 			const dontOpenUrl = new URL( DONT_OPEN_IN_BROWSER[ x ] );
 
 			if ( domainAndPathSame( parsedUrl, dontOpenUrl ) ) {
-				debug( 'Open in new window for ' + url );
+				log.info( 'Open in new window for ' + url );
 
 				// When we do open another Electron window make it a bit smaller so we know it's there
 				// Having it exactly the same size means we just think the main window has changed page
@@ -103,7 +103,7 @@ module.exports = function( webContents ) {
 
 		const openUrl = format( parsedUrl );
 
-		debug( 'Open in new browser for ' + openUrl );
+		log.info( `Using system default handler for URL: ${ openUrl }` );
 		openInBrowser( event, openUrl );
 	} );
 };

--- a/desktop/window-handlers/failed-to-load/index.js
+++ b/desktop/window-handlers/failed-to-load/index.js
@@ -3,7 +3,6 @@
 /**
  * External Dependencies
  */
-const debug = require( 'debug' )( 'desktop:failed-to-load' );
 const dialog = require( 'electron' ).dialog;
 const app = require( 'electron' ).app;
 
@@ -12,6 +11,7 @@ const app = require( 'electron' ).app;
  */
 const settings = require( 'lib/settings' );
 const assets = require( 'lib/assets' );
+const log = require( 'lib/logger' )( 'desktop:failed-to-load' );
 
 /**
  * Module variables
@@ -75,7 +75,7 @@ module.exports = function( mainWindow ) {
 			if ( isErrorPage( event.sender ) ) {
 				failedToLoadError( mainWindow );
 			} else {
-				debug( 'Failed to load from server, showing fallback page: code=' + errorCode + ' ' + errorDescription );
+				log.error( 'Failed to load from server, showing fallback page: code=' + errorCode + ' ' + errorDescription );
 
 				mainWindow.webContents.session.setProxy( { proxyRules: 'direct://' }, function() {
 					mainWindow.loadURL( FAILED_FILE + '#' + errorCode );

--- a/desktop/window-handlers/get-logs/index.js
+++ b/desktop/window-handlers/get-logs/index.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const { app, dialog } = require( 'electron' );
+
+/**
+ * Internal dependencies
+ */
+const state = require( 'lib/state' );
+const system = require( 'lib/system' );
+const { zipContents } = require( 'lib/archiver' );
+const log = require( 'lib/logger' )( 'desktop:get-logs' );
+
+/**
+ * Module variables
+ */
+const logPath = state.getLogPath();
+
+const pad = n => `${n}`.padStart( 2, '0' );
+
+const localDateTime = () => {
+	const now = new Date();
+	return now.getFullYear() +
+		'-' +
+		pad( now.getMonth() + 1 ) +
+		'-' +
+		pad( now.getDate() ) +
+		'T' +
+		pad( now.getHours() ) +
+		'.' +
+		pad( now.getMinutes() ) +
+		'.' +
+		pad( now.getSeconds() ) +
+		'.' +
+		pad( now.getMilliseconds() );
+}
+
+module.exports = async function( window ) {
+	const onZipped = ( file ) => function() {
+		dialog.showMessageBox( window, {
+			type: 'info',
+			buttons: [ 'OK' ],
+			title: 'Application logs saved to your desktop',
+			message: 'Application logs saved to your desktop' +
+					'\n\n' +
+					`${path.basename( file )}`,
+			detail: 'For help with an issue, please contact help@wordpress.com and share your logs.'
+		} )
+	}
+
+	const onError = ( error ) =>
+		dialog.showMessageBox( window, {
+			type: 'info',
+			buttons: [ 'OK' ],
+			title: 'Error getting application logs',
+			message: 'Error getting application logs',
+			detail: 'Please contact help@wordpress.com and mention the error details below:' +
+				'\n\n' +
+				error.stack +
+				'\n\n' +
+				'System info: ' + JSON.stringify( system.getVersionData() )
+		} )
+
+	try {
+		const timestamp = localDateTime();
+		const desktop = app.getPath( 'desktop' );
+		const dst = path.join( desktop, `wpdesktop-${ timestamp }.zip` );
+
+		zipContents( [ logPath ], dst, onZipped( dst ) );
+	} catch ( error ) {
+		log.error( 'Failed to zip logs: ', error );
+		onError( error );
+	}
+}
+

--- a/desktop/window-handlers/notifications/index.js
+++ b/desktop/window-handlers/notifications/index.js
@@ -5,13 +5,13 @@
  */
 const electron = require( 'electron' );
 const ipc = electron.ipcMain;
-const debug = require( 'debug' )( 'desktop:notifications' );
 
 /**
  * Internal dependencies
  */
 const Settings = require( 'lib/settings' );
 const Platform = require( 'lib/platform' );
+const log = require( 'lib/logger' )( 'desktop:notifications' );
 
 /**
  * Module variables
@@ -21,7 +21,7 @@ var unreadNotificationCount = 0;
 function updateNotificationBadge( badgeEnabled ) {
 	var bounceEnabled = Settings.getSetting( 'notification-bounce' );
 
-	debug( 'Updating notification badge - badge enabled=' + badgeEnabled + ' bounce enabled=' + bounceEnabled );
+	log.info( 'Updating notification badge - badge enabled=' + badgeEnabled + ' bounce enabled=' + bounceEnabled );
 
 	if ( badgeEnabled && unreadNotificationCount > 0 ) {
 		Platform.showNotificationsBadge( unreadNotificationCount, bounceEnabled );
@@ -32,7 +32,7 @@ function updateNotificationBadge( badgeEnabled ) {
 
 module.exports = function() {
 	ipc.on( 'unread-notices-count', function( event, count ) {
-		debug( 'Notification count received: ' + count );
+		log.info( 'Notification count received: ' + count );
 		unreadNotificationCount = count;
 
 		updateNotificationBadge( Settings.getSetting( 'notification-badge' ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2748,6 +2748,95 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
+    "archiver": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
+      "integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "async": "^2.6.3",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.1.4",
+        "readable-stream": "^3.4.0",
+        "tar-stream": "^2.1.0",
+        "zip-stream": "^2.1.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "requires": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+        }
+      }
+    },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
@@ -3046,8 +3135,7 @@
     "base64-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
-      "dev": true
+      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE="
     },
     "bcp47": {
       "version": "1.1.2",
@@ -3084,6 +3172,42 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
+    },
+    "bl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "bluebird": {
       "version": "3.5.5",
@@ -3352,6 +3476,11 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -4013,6 +4142,17 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
+    "compress-commons": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
+      "integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
+      "requires": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^3.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.3.6"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4244,6 +4384,46 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "requires": {
+        "buffer": "^5.1.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
+      }
+    },
+    "crc32-stream": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+      "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
+      "requires": {
+        "crc": "^3.4.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -5411,7 +5591,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -6256,6 +6435,11 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "7.0.1",
@@ -7325,8 +7509,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -8105,6 +8288,14 @@
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.4.tgz",
       "integrity": "sha512-u93kb2fPbIrfzBuLjZE+w+fJbUUMhNDXxNmMfaqNgpfQf1CO5ZSe2LfsnBqVAk7i/2NF48OSoRj+Xe2VT+lE8Q=="
     },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "requires": {
+        "readable-stream": "^2.0.5"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -8196,6 +8387,21 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -8205,6 +8411,16 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
     "logform": {
       "version": "2.1.2",
@@ -8995,8 +9211,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-url": {
       "version": "4.5.0",
@@ -11084,6 +11299,30 @@
         }
       }
     },
+    "tar-stream": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+      "requires": {
+        "bl": "^4.0.1",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "temp-file": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.3.7.tgz",
@@ -12722,6 +12961,28 @@
       "dev": true,
       "requires": {
         "fd-slicer": "~1.0.1"
+      }
+    },
+    "zip-stream": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
+      "integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^2.1.1",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   "dependencies": {
     "@automattic/calypso-polyfills": "1.0.0",
     "acorn": "6.4.1",
-    "debug": "2.6.8",
     "electron-fetch": "1.2.1",
     "electron-spellchecker": "2.2.1",
     "electron-updater": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@automattic/calypso-polyfills": "1.0.0",
     "acorn": "6.4.1",
+    "archiver": "3.1.1",
     "electron-fetch": "1.2.1",
     "electron-spellchecker": "2.2.1",
     "electron-updater": "4.0.0",

--- a/public_desktop/desktop-app.js
+++ b/public_desktop/desktop-app.js
@@ -6,13 +6,9 @@ let startApp = function() {
 };
 
 let booted = false;
-let debug;
+let log;
 
 function startDesktopApp() {
-	if ( electron.isDebug() ) {
-		electron.enableDebug();
-	}
-
 	function showWarning( message ) {
 		var container = document.querySelector( '#wpcom' );
 		var warning = container.querySelector( '.warning' );
@@ -78,13 +74,14 @@ function startDesktopApp() {
 		}
 	}
 
-	debug = electron.debug( 'desktop:browser' );
+	// Uses the logger object instantiated by preload.js
+	log = logger( 'desktop:renderer:browser' ); // eslint-disable-line no-undef
 
 	// Everything is ready, start Calypso
-	debug( 'Received app configuration, starting in browser' );
+	log.info( 'Received app configuration, starting in browser' );
 
 	function startCalypso() {
-		debug( 'Calypso loaded, starting' );
+		log.info( 'Calypso loaded, starting' );
 		booted = true;
 		window.AppBoot();
 
@@ -131,10 +128,10 @@ function startDesktopApp() {
 // Wrap this in an exception handler. If it fails then it means Electron is not present, and we are in a browser
 // This will then cause the browser to redirect to hey.html
 try {
-	electron.ipcRenderer.on('is-calypso', function () {
-		electron.ipcRenderer.send('is-calypso-response', document.getElementById('wpcom') !== null);
-	});
-	
+	electron.ipcRenderer.on( 'is-calypso', function() {
+		electron.ipcRenderer.send( 'is-calypso-response', document.getElementById( 'wpcom' ) !== null );
+	} );
+
 	electron.ipcRenderer.on( 'app-config', function( event, config, debug, details ) {
 		// if this is the first run, and on the login page, show Windows and Mac users a pin app reminder
 		if ( details.firstRun && document.querySelectorAll( '.logged-out-auth' ).length > 0 ) {


### PR DESCRIPTION
# [2] Replace Debug With Custom Logger

## Description

This PR is a follow-on to #814 and replaces the `debug` module with the custom logger implementation. Existing logging items are converted from the usage of `debug` to `lib/logger`.

## Highlights

Conversion of existing log items is fairly straightforward. For the preload script, however, log items are transmitted via IPC from the renderer to the main process. This is to avoid use of the `remote` module, which is regarded as highly insecure (and in fact will be excluded from future versions of Electron starting with v9).

## To Test

Build and run the application (or download [built artifacts for this PR](https://app.circleci.com/pipelines/github/Automattic/wp-desktop/9418/workflows/a024e7b4-6b65-4d67-a304-f64b5c8d1b11/jobs/56585)). Verify application logs are persisted to the following locations on each platform:

_Note_: Mac artifact is not notarized (notarized on tag only), so will require opening via System Preferences -> Security.

  - Mac: `$HOME/Library/Application Support/WordPress.com/logs`
  - Linux: `/home/<username>/.config/WordPress.com/logs`
  - Windows 10: `C:\Users\<username>\AppData\Roaming\WordPress.com\logs` 