### PR TITLE
feat(logging): archive and export logs [3]

### DIFF
--- a/desktop/lib/archiver/index.js
+++ b/desktop/lib/archiver/index.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+const archiver = require( 'archiver' );
+
+/**
+ * Internal dependencies
+ */
+const log = require( 'lib/logger' )( 'desktop:lib:archiver' );
+
+module.exports = {
+
+	/**
+	 * Compresses `contents` to the archive at `dst`.
+	 *
+	 * @param {String[]} contents Paths to be zipped
+	 * @param {String} dst Path to destination archive
+	 * @param {function():void} onZipped Callback invoked when archive is complete
+	 */
+	zipContents: ( contents, dst, onZipped ) => {
+		let output = fs.createWriteStream( dst );
+		let archive = archiver( 'zip', {
+			zlib: { level: 9 }
+		} );
+
+		output.on( 'close', function() {
+			log.debug( 'Archive finalized: %s bytes written', archive.pointer() );
+			if ( typeof onZipped === 'function' ) {
+				onZipped();
+			}
+		} );
+
+		// Catch warnings (e.g. stat failures and other non-blocking errors)
+		archive.on( 'warning', function( err ) {
+			log.warn( 'Unexpected error: ', err );
+		} );
+
+		archive.on( 'error', function( err ) {
+			throw err;
+		} );
+
+		archive.pipe( output );
+
+		for ( let i = 0; i < contents.length; i++ ) {
+			const src = contents[i];
+			const zipSubdir = path.basename( dst ).replace( '.zip', '' );
+			const dstInZipSubdir = path.join( zipSubdir, path.basename( src ) );
+
+			const stat = fs.lstatSync( src );
+			if ( stat.isDirectory() ) {
+				archive.directory( path.join( src, path.sep ), dstInZipSubdir );
+				continue;
+			}
+			archive.file( src, { name: dstInZipSubdir } );
+		}
+
+		archive.finalize();
+	}
+}

--- a/desktop/lib/menu/help-menu.js
+++ b/desktop/lib/menu/help-menu.js
@@ -55,6 +55,9 @@ module.exports = function( mainWindow ) {
 			}
 		},
 		{
+			type: 'separator',
+		},
+		{
 			label: 'Get activity logs',
 			click: function() {
 				log.info( 'User selected \'Get Activity Logs\'...' );

--- a/desktop/lib/menu/help-menu.js
+++ b/desktop/lib/menu/help-menu.js
@@ -58,9 +58,9 @@ module.exports = function( mainWindow ) {
 			type: 'separator',
 		},
 		{
-			label: 'Get application logs',
+			label: 'Get Application Logs',
 			click: function() {
-				log.info( 'User selected \'Get application logs\'...' );
+				log.info( 'User selected \'Get Application Logs\'...' );
 				zipLogs( mainWindow );
 			}
 		}

--- a/desktop/lib/menu/help-menu.js
+++ b/desktop/lib/menu/help-menu.js
@@ -5,13 +5,15 @@
  */
 const shell = require( 'electron' ).shell;
 const ipc = require( 'lib/calypso-commands' );
+const zipLogs = require( '../../window-handlers/get-logs' );
 
 /**
  * Internal dependencies
  */
+const state = require( 'lib/state' );
 const platform = require( 'lib/platform' );
 const WindowManager = require( 'lib/window-manager' );
-const state = require( 'lib/state' );
+const log = require( 'lib/logger' )( 'desktop:menu:help' );
 
 let menuItems = [];
 
@@ -52,5 +54,12 @@ module.exports = function( mainWindow ) {
 				shell.openExternal( 'https://automattic.com/privacy/' );
 			}
 		},
+		{
+			label: 'Get activity logs',
+			click: function() {
+				log.info( 'User selected \'Get Activity Logs\'...' );
+				zipLogs( mainWindow );
+			}
+		}
 	] );
 }

--- a/desktop/lib/menu/help-menu.js
+++ b/desktop/lib/menu/help-menu.js
@@ -58,9 +58,9 @@ module.exports = function( mainWindow ) {
 			type: 'separator',
 		},
 		{
-			label: 'Get activity logs',
+			label: 'Get application logs',
 			click: function() {
-				log.info( 'User selected \'Get Activity Logs\'...' );
+				log.info( 'User selected \'Get application logs\'...' );
 				zipLogs( mainWindow );
 			}
 		}

--- a/desktop/window-handlers/get-logs/index.js
+++ b/desktop/window-handlers/get-logs/index.js
@@ -43,8 +43,8 @@ module.exports = async function( window ) {
 		dialog.showMessageBox( window, {
 			type: 'info',
 			buttons: [ 'OK' ],
-			title: 'Logs saved to your desktop',
-			message: 'Logs saved to your desktop' +
+			title: 'Application logs saved to your desktop',
+			message: 'Application logs saved to your desktop' +
 					'\n\n' +
 					`${path.basename( file )}`,
 			detail: 'For help with an issue, please contact help@wordpress.com and share your logs.'

--- a/desktop/window-handlers/get-logs/index.js
+++ b/desktop/window-handlers/get-logs/index.js
@@ -19,9 +19,7 @@ const log = require( 'lib/logger' )( 'desktop:get-logs' );
  */
 const logPath = state.getLogPath();
 
-function pad( n ) {
-	return n < 10 ? '0' + n : n;
-}
+const pad = n => `${n}`.padStart( 2, '0' );
 
 const localDateTime = () => {
 	const now = new Date();

--- a/desktop/window-handlers/get-logs/index.js
+++ b/desktop/window-handlers/get-logs/index.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const { app, dialog } = require( 'electron' );
+
+/**
+ * Internal dependencies
+ */
+const state = require( 'lib/state' );
+const system = require( 'lib/system' );
+const { zipContents } = require( 'lib/archiver' );
+const log = require( 'lib/logger' )( 'desktop:get-logs' );
+
+/**
+ * Module variables
+ */
+const logPath = state.getLogPath();
+
+function pad( n ) {
+	return n < 10 ? '0' + n : n;
+}
+
+const localDateTime = () => {
+	const now = new Date();
+	return now.getFullYear() +
+		'-' +
+		pad( now.getMonth() + 1 ) +
+		'-' +
+		pad( now.getDate() ) +
+		'T' +
+		pad( now.getHours() ) +
+		'.' +
+		pad( now.getMinutes() ) +
+		'.' +
+		pad( now.getSeconds() ) +
+		'.' +
+		pad( now.getMilliseconds() );
+}
+
+module.exports = async function( window ) {
+	const onZipped = async () => {
+		await dialog.showMessageBox( window, {
+			type: 'info',
+			buttons: [ 'OK' ],
+			title: 'Zipped logs to desktop',
+			message: 'Logs saved to your desktop'
+		} )
+	}
+
+	const onError = async ( error ) => {
+		await dialog.showErrorBox(
+			'Error zipping activity logs.' +
+			'\n\n' +
+			'Please contact help@wordpress.com and mention the error details below:' +
+			'\n\n' +
+			error.stack +
+			'\n\n' +
+			'System info: ' + JSON.stringify( system.getVersionData() )
+		)
+	}
+
+	try {
+		const timestamp = localDateTime();
+		const desktop = app.getPath( 'desktop' );
+		const dst = path.join( desktop, `wpdesktop-${ timestamp }.zip` );
+
+		zipContents( [ logPath ], dst, onZipped );
+	} catch ( error ) {
+		log.error( 'Failed to zip logs: ', error );
+		onError( error );
+	}
+}
+

--- a/desktop/window-handlers/get-logs/index.js
+++ b/desktop/window-handlers/get-logs/index.js
@@ -41,12 +41,15 @@ const localDateTime = () => {
 }
 
 module.exports = async function( window ) {
-	const onZipped = async () => {
+	const onZipped = async ( file ) => {
 		await dialog.showMessageBox( window, {
 			type: 'info',
 			buttons: [ 'OK' ],
-			title: 'Zipped logs to desktop',
-			message: 'Logs saved to your desktop'
+			title: 'Logs saved to your desktop',
+			message: 'Logs saved to your desktop' +
+				'\n\n' +
+				`${ path.basename( file ) }`,
+			detail: 'For help with an issue, please contact help@wordpress.com and share your logs.'
 		} )
 	}
 
@@ -67,7 +70,7 @@ module.exports = async function( window ) {
 		const desktop = app.getPath( 'desktop' );
 		const dst = path.join( desktop, `wpdesktop-${ timestamp }.zip` );
 
-		zipContents( [ logPath ], dst, onZipped );
+		zipContents( [ logPath ], dst, onZipped( dst ) );
 	} catch ( error ) {
 		log.error( 'Failed to zip logs: ', error );
 		onError( error );

--- a/desktop/window-handlers/get-logs/index.js
+++ b/desktop/window-handlers/get-logs/index.js
@@ -53,26 +53,18 @@ module.exports = async function( window ) {
 		}
 	}
 
+	const onError = ( error ) => {
+		dialog.showMessageBox( window, {
 			type: 'info',
 			buttons: [ 'OK' ],
-			title: 'Logs saved to your desktop',
-			message: 'Logs saved to your desktop' +
+			title: 'Error getting application logs',
+			message: 'Error getting application logs',
+			detail: 'Please contact help@wordpress.com and mention the error details below:' +
 				'\n\n' +
-				`${ path.basename( file ) }`,
-			detail: 'For help with an issue, please contact help@wordpress.com and share your logs.'
+				error.stack +
+				'\n\n' +
+				'System info: ' + JSON.stringify( system.getVersionData() )
 		} )
-	}
-
-	const onError = async ( error ) => {
-		dialog.showErrorBox(
-			'Error zipping activity logs.' +
-			'\n\n' +
-			'Please contact help@wordpress.com and mention the error details below:' +
-			'\n\n' +
-			error.stack +
-			'\n\n' +
-			'System info: ' + JSON.stringify( system.getVersionData() )
-		)
 	}
 
 	try {

--- a/desktop/window-handlers/get-logs/index.js
+++ b/desktop/window-handlers/get-logs/index.js
@@ -52,7 +52,7 @@ module.exports = async function( window ) {
 	}
 
 	const onError = async ( error ) => {
-		await dialog.showErrorBox(
+		dialog.showErrorBox(
 			'Error zipping activity logs.' +
 			'\n\n' +
 			'Please contact help@wordpress.com and mention the error details below:' +

--- a/desktop/window-handlers/get-logs/index.js
+++ b/desktop/window-handlers/get-logs/index.js
@@ -39,8 +39,20 @@ const localDateTime = () => {
 }
 
 module.exports = async function( window ) {
-	const onZipped = async ( file ) => {
-		await dialog.showMessageBox( window, {
+	const onZipped = ( file ) => {
+		return function() {
+			dialog.showMessageBox( window, {
+				type: 'info',
+				buttons: [ 'OK' ],
+				title: 'Logs saved to your desktop',
+				message: 'Logs saved to your desktop' +
+					'\n\n' +
+					`${path.basename( file )}`,
+				detail: 'For help with an issue, please contact help@wordpress.com and share your logs.'
+			} )
+		}
+	}
+
 			type: 'info',
 			buttons: [ 'OK' ],
 			title: 'Logs saved to your desktop',

--- a/desktop/window-handlers/get-logs/index.js
+++ b/desktop/window-handlers/get-logs/index.js
@@ -39,21 +39,19 @@ const localDateTime = () => {
 }
 
 module.exports = async function( window ) {
-	const onZipped = ( file ) => {
-		return function() {
-			dialog.showMessageBox( window, {
-				type: 'info',
-				buttons: [ 'OK' ],
-				title: 'Logs saved to your desktop',
-				message: 'Logs saved to your desktop' +
+	const onZipped = ( file ) => function() {
+		dialog.showMessageBox( window, {
+			type: 'info',
+			buttons: [ 'OK' ],
+			title: 'Logs saved to your desktop',
+			message: 'Logs saved to your desktop' +
 					'\n\n' +
 					`${path.basename( file )}`,
-				detail: 'For help with an issue, please contact help@wordpress.com and share your logs.'
-			} )
-		}
+			detail: 'For help with an issue, please contact help@wordpress.com and share your logs.'
+		} )
 	}
 
-	const onError = ( error ) => {
+	const onError = ( error ) =>
 		dialog.showMessageBox( window, {
 			type: 'info',
 			buttons: [ 'OK' ],
@@ -65,7 +63,6 @@ module.exports = async function( window ) {
 				'\n\n' +
 				'System info: ' + JSON.stringify( system.getVersionData() )
 		} )
-	}
 
 	try {
 		const timestamp = localDateTime();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2748,6 +2748,95 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
+    "archiver": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
+      "integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "async": "^2.6.3",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.1.4",
+        "readable-stream": "^3.4.0",
+        "tar-stream": "^2.1.0",
+        "zip-stream": "^2.1.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "requires": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+        }
+      }
+    },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
@@ -3046,8 +3135,7 @@
     "base64-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
-      "dev": true
+      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE="
     },
     "bcp47": {
       "version": "1.1.2",
@@ -3084,6 +3172,42 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
+    },
+    "bl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "bluebird": {
       "version": "3.5.5",
@@ -3352,6 +3476,11 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -4013,6 +4142,17 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
+    "compress-commons": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
+      "integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
+      "requires": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^3.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.3.6"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4244,6 +4384,46 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "requires": {
+        "buffer": "^5.1.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
+      }
+    },
+    "crc32-stream": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+      "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
+      "requires": {
+        "crc": "^3.4.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -5411,7 +5591,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -6256,6 +6435,11 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "7.0.1",
@@ -7325,8 +7509,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -8105,6 +8288,14 @@
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.4.tgz",
       "integrity": "sha512-u93kb2fPbIrfzBuLjZE+w+fJbUUMhNDXxNmMfaqNgpfQf1CO5ZSe2LfsnBqVAk7i/2NF48OSoRj+Xe2VT+lE8Q=="
     },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "requires": {
+        "readable-stream": "^2.0.5"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -8196,6 +8387,21 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -8205,6 +8411,16 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
     "logform": {
       "version": "2.1.2",
@@ -8995,8 +9211,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-url": {
       "version": "4.5.0",
@@ -11084,6 +11299,30 @@
         }
       }
     },
+    "tar-stream": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+      "requires": {
+        "bl": "^4.0.1",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "temp-file": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.3.7.tgz",
@@ -12722,6 +12961,28 @@
       "dev": true,
       "requires": {
         "fd-slicer": "~1.0.1"
+      }
+    },
+    "zip-stream": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
+      "integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^2.1.1",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@automattic/calypso-polyfills": "1.0.0",
     "acorn": "6.4.1",
+    "archiver": "3.1.1",
     "electron-fetch": "1.2.1",
     "electron-spellchecker": "2.2.1",
     "electron-updater": "4.0.0",


### PR DESCRIPTION
# [3] Export Application Logs to User's Desktop

<p align="center">
<img width="430" alt="wp-desktop-export-logs-to-desktop" src="https://user-images.githubusercontent.com/8979548/77325823-4b07b000-6cef-11ea-8fb8-54db8c44f05a.png">
</p>

## Description

This PR is a follow-on to #814 and #815, and adds a `Get activity logs` item to the application's `Help` menu. When selected, this menu item exports the user's logs to their desktop and prompts them to share their logs when requesting help. This feature makes use of [`archiverjs`](https://github.com/archiverjs/node-archiver) for cross-platform compression.

## To Test

1. Build and run the application, or download one of the [built artifacts](https://app.circleci.com/pipelines/github/Automattic/wp-desktop/9444/workflows/c9ca5cb0-5649-43de-9ab4-9f09bb06dcc2/jobs/56621/artifacts) from this PR
2. Export your activity logs via the `Help` menu, and confirm the archive has been saved to your desktop.

_Note_: Mac artifact is not notarized (notarized on tag only), so will require opening via System Preferences -> Security.

(See detailed installation instructions in [this](https://github.com/Automattic/wp-desktop/pull/816#issuecomment-606065206) comment.)