### PR TITLE
Enable tests in v5.0.1

### DIFF
--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -98,7 +98,7 @@ describe( 'Publish a New Post', function() {
 	} );
 } );
 
-describe.skip( 'Can Log Out', function() {
+describe( 'Can Log Out', function() {
 	this.timeout( 30000 );
 
 	step( 'Can view profile to log out', async function() {
@@ -116,7 +116,7 @@ describe.skip( 'Can Log Out', function() {
 	} );
 } );
 
-describe.skip( 'Can Sign up', function() {
+describe( 'Can Sign up', function() {
 	this.timeout( 90000 );
 	const blogName = dataHelper.getNewBlogName();
 	const emailAddress = blogName + '@e2edesktop.test';


### PR DESCRIPTION
### Description

e2e tests in the `release/5.0.1 branch` were temporarily disabled due to failures. The primary driver of the failures was determined to be the auto-updater being triggered by the new tag, which was fixed in #818. Re-enabling tests in the release branch as performance of the test suite appears to be stable over the last few days.