### PR TITLE
fix(auto-updater): ensure existing version is quit and replaced

### DIFF
--- a/desktop/lib/app-quit/index.js
+++ b/desktop/lib/app-quit/index.js
@@ -10,12 +10,12 @@ function AppQuit() {
 }
 
 AppQuit.prototype.shouldQuitToBackground = function() {
-	if ( this.canQuit === false ) {
-		return true;
+	if ( this.canQuit ) {
+		this.canQuit = false;
+		return false;
 	}
 
-	this.canQuit = false;
-	return false;
+	return true;
 };
 
 AppQuit.prototype.allowQuit = function() {

--- a/desktop/lib/platform/windows/index.js
+++ b/desktop/lib/platform/windows/index.js
@@ -3,9 +3,7 @@
 /**
  * External Dependencies
  */
-const electron = require( 'electron' );
-const Tray = electron.Tray;
-const Menu = electron.Menu;
+const { Tray, Menu, app } = require( 'electron' );
 const debug = require( 'debug' )( 'platform:windows' );
 
 /**
@@ -35,6 +33,11 @@ function WindowsPlatform( mainWindow ) {
 	this.tray.on( 'click', this.restore.bind( this ) );
 
 	mainWindow.on( 'close', this.onClosed.bind( this ) );
+
+	app.on( 'before-quit', function( event ) {
+		debug( 'Responding to app event \'before-quit\', destroying tray' );
+		this.tray.destroy();
+	} )
 }
 
 WindowsPlatform.prototype.onClosed = function( ev ) {
@@ -45,7 +48,12 @@ WindowsPlatform.prototype.onClosed = function( ev ) {
 
 		this.window.hide();
 		this.showBackgroundBubble();
+
+		return;
 	}
+
+	debug( 'Quitting application...' );
+	app.quit();
 };
 
 WindowsPlatform.prototype.showBackgroundBubble = function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2273,8 +2273,15 @@
     "@types/node": {
       "version": "10.17.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.15.tgz",
-      "integrity": "sha512-daFGV9GSs6USfPgxceDA8nlSe48XrVCJfDeYm7eokxq/ye7iuOH87hKXgMtEAVLFapkczbZsx868PMDT1Y0a6A==",
-      "dev": true
+      "integrity": "sha512-daFGV9GSs6USfPgxceDA8nlSe48XrVCJfDeYm7eokxq/ye7iuOH87hKXgMtEAVLFapkczbZsx868PMDT1Y0a6A=="
+    },
+    "@types/semver": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz",
+      "integrity": "sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "15.0.4",
@@ -3088,12 +3095,14 @@
     "bluebird": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+      "dev": true
     },
     "bluebird-lst": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
       "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+      "dev": true,
       "requires": {
         "bluebird": "^3.5.5"
       }
@@ -3356,7 +3365,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -3507,13 +3517,11 @@
       }
     },
     "builder-util-runtime": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.0.2.tgz",
-      "integrity": "sha512-46AjyMQ1/yBvGnXWmqNGlg8te7jCPCs7TJ0zDC2+4vV/t5iZp2dR1H9UfVpcBxlvBq3dlAOmwb9fz1d9xZN1+Q==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.6.2.tgz",
+      "integrity": "sha512-9QnIBISfhgQ2BxtRLidVqf/v5HD73vSKZDllpUmGd2L6VORGQk7cZAPmPtw4HQM3gPBelyVJ5yIjMNZ8xjmd1A==",
       "requires": {
-        "bluebird-lst": "^1.0.6",
-        "debug": "^4.1.0",
-        "fs-extra-p": "^7.0.0",
+        "debug": "^4.1.1",
         "sax": "^1.2.4"
       },
       "dependencies": {
@@ -3523,15 +3531,6 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "fs-extra-p": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-7.0.1.tgz",
-          "integrity": "sha512-yhd2OV0HnHt2oitlp+X9hl2ReX4X/7kQeL7/72qzPHTZj5eUPGzAKOvEglU02Fa1OeG2rSy/aKB4WGVaLiF8tw==",
-          "requires": {
-            "bluebird-lst": "^1.0.7",
-            "fs-extra": "^7.0.1"
           }
         },
         "ms": {
@@ -4851,11 +4850,6 @@
         "encoding": "^0.1.12"
       }
     },
-    "electron-is-dev": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.1.0.tgz",
-      "integrity": "sha512-Z1qA/1oHNowGtSBIcWk0pcLEqYT/j+13xUw/MYOrBUOL4X7VN0i0KCTf5SqyvMPmW5pSPKbo28wkxMxzZ20YnQ=="
-    },
     "electron-mocha": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-2.3.1.tgz",
@@ -5278,30 +5272,53 @@
       "dev": true
     },
     "electron-updater": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.0.0.tgz",
-      "integrity": "sha512-qsD3JSR1ELY4JpP/GnZ2CXS2KabUDDJJ7/NcjC5rPfQBOT0+Z0p7+1gfUolJssTeIY1c3DT65Pd3k+eWMuns9w==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.2.5.tgz",
+      "integrity": "sha512-ir8SI3capF5pN4LTQY79bP7oqiBKjgtdDW378xVId5VcGUZ+Toei2j+fgx1mq3y4Qg19z4HqLxEZ9FqMD0T0RA==",
       "requires": {
-        "bluebird-lst": "^1.0.6",
-        "builder-util-runtime": "~8.0.0",
-        "electron-is-dev": "^1.0.1",
-        "fs-extra-p": "^7.0.0",
-        "js-yaml": "^3.12.0",
-        "lazy-val": "^1.0.3",
+        "@types/semver": "^7.1.0",
+        "builder-util-runtime": "8.6.2",
+        "fs-extra": "^8.1.0",
+        "js-yaml": "^3.13.1",
+        "lazy-val": "^1.0.4",
         "lodash.isequal": "^4.5.0",
-        "pako": "^1.0.6",
-        "semver": "^5.6.0",
-        "source-map-support": "^0.5.9"
+        "pako": "^1.0.11",
+        "semver": "^7.1.3"
       },
       "dependencies": {
-        "fs-extra-p": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-7.0.1.tgz",
-          "integrity": "sha512-yhd2OV0HnHt2oitlp+X9hl2ReX4X/7kQeL7/72qzPHTZj5eUPGzAKOvEglU02Fa1OeG2rSy/aKB4WGVaLiF8tw==",
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "requires": {
-            "bluebird-lst": "^1.0.7",
-            "fs-extra": "^7.0.1"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+        },
+        "semver": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
         }
       }
     },
@@ -6193,6 +6210,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -9172,7 +9190,8 @@
     "pako": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
+      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+      "dev": true
     },
     "parallel-transform": {
       "version": "1.1.0",
@@ -10498,7 +10517,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -10517,6 +10537,7 @@
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
       "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "debug": "2.6.8",
     "electron-fetch": "1.2.1",
     "electron-spellchecker": "2.2.1",
-    "electron-updater": "4.0.0",
+    "electron-updater": "4.2.5",
     "express": "4.15.3",
     "js-yaml": "3.12.0",
     "lodash.clonedeep": "4.5.0",


### PR DESCRIPTION
### Description

This PR fixes a bug in the Windows auto-update logic where - when the user clicked `Install and Restart` - the current version was not shut down correctly, and the auto-updater did not completely/correctly replace the prior version. A reference to the prior version would be left in `Add/Remove Programs` (requiring a fix in the user's Registry) and the application's shortcut would potentially be unresponsive when clicked.

This issue is relatively easy to replicate and has been reported by at least one user (zen-2796859).

Debugging this issue seems indicates a couple of root causes at play:

* Existing logic that backgrounds the application when the main window is closed (instead of respecting the auto-updater's directive to quit the app), and
* Faulty logic in the current version of `electron-updater`, ([ref](https://github.com/electron-userland/electron-builder/issues/4143))

Updating the backgrounding logic and electron-builder version to latest seems to correct this issue.

### To Test

1. Uninstall any existing WordPress.com installation on Windows. Verify that no entries for `WordPress.com` are in `Add/Remove Programs` (may need to use the registry fix in https://support.microsoft.com/en-us/help/243723/removing-invalid-entries-in-the-add-remove-programs-tool if so).
1. Download and install the Windows artifact built from this branch
1. This version is set to `v5.0.0` (same as `develop`), and after launch should detect and prompt for (v5.0.1-beta) which is currently available (this may take a couple minutes).
1. Click `Install & Restart` when prompted.
1. Verify auto-update happens successfully, and that there is only one entry for `WordPress.com` in `Add/Remove Programs`).