### PR TITLE
improvement(tooling): add Windows dev tooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,7 @@ jobs:
                 Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
 
                 # $env:CSC_KEY_PASSWORD=$env:WIN_CSC_KEY_PASSWORD
-                make package
+                make package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
       - run:
           name: Archive win-unpacked directories
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dev-app-update.yml
 resource/certificates/mac.p12
 resource/certificates/win.p12
 test/logs/
+id_rsa

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM debian:latest
+
+ARG NODE_VERSION=12.16.1
+
+# prepare .ssh dir
+RUN mkdir -p /root/.ssh/
+COPY id_rsa /root/.ssh/id_rsa
+
+WORKDIR /usr/src/wp-desktop
+
+# replace shell with bash so we can source files
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# update the repository sources list
+# and install dependencies
+RUN apt-get update \
+    && apt-get install -y git curl build-essential \
+    && apt-get -y autoclean
+
+# nvm environment variables
+ENV NVM_DIR /usr/local/nvm
+
+# install nvm
+# https://github.com/creationix/nvm#install-script
+RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.2/install.sh | bash
+
+# install node and npm
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+# confirm installation
+RUN node -v
+RUN npm -v
+
+EXPOSE 3000
+
+CMD /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -209,10 +209,10 @@ docker-build:
 # !! Ensure this file is removed regardless of success/failure !!
 # Note: Ideally we could use a build argument for this, but Docker CE on Windows
 # has trouble consuming the SSH key contents when passed as a build arg.
-	function cleanUp {
+	function cleanup {
 		rm "$(THIS_DIR)/id_rsa"
 	}
-	trap cleanUp EXIT
+	trap cleanup EXIT
 
 	cp "$(SSH_PRIVATE_KEY_FILE)" "$(THIS_DIR)/id_rsa"
 
@@ -220,7 +220,7 @@ docker-build:
 
 .PHONY:
 docker-run:
-	$(info Initializing docker container for wpdesktop', type 'exit' to quit)
+	$(info Initializing docker container for 'wpdesktop', type 'exit' to quit)
 
 	docker run -it --rm -v "$(THIS_DIR)"://usr/src/wp-desktop -p 3000:3000 -e SHELL='//bin/bash' wpdesktop bash
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -121,3 +121,25 @@ Debug from Calypso will appear inside the renderer. To enable, open Chrome dev t
 ```js
 localStorage.setItem( 'debug', '*' );
 ```
+
+## Building and Debugging on Windows
+
+Building Calypso on Windows is not supported, and therefore a virtual Linux environment is required to build the application source. Application binaries, however, should be built natively on Windows prior to packaging the app.
+
+- For convenience, a Docker configuration is included [here](../Dockerfile). The image can be built and ran via the Makefile.
+
+- An alternative to using Docker on Windows is the Windows Subsystem for Linux ("WSL"), which will have to be manually configured.
+
+### Recommended Windows Environment and Tooling
+
+- [MSYS2](https://www.msys2.org/) is recommended to maximize compatibility of the Makefile across platforms. This can be installed explicitly and added to your `PATH`, or implicitly by installing [Git Bash](https://gitforwindows.org/) for Windows.
+
+  - IMPORTANT: Historically, developers expect the "bash" executable to refer to Git/MSYS2 bash. To avoid collisions with Windows Subsystem for Linux ("WSL"), you can rename the WSL bash executable in PowerShell:
+
+  ```
+  takeown /F "$env:SystemRoot\System32\bash.exe"
+  icacls "$env:SystemRoot\System32\bash.exe" /grant administrators:F
+  ren "$env:SystemRoot\System32\bash.exe" wsl-bash.exe
+  ```
+
+- Install the npm package `windows-build-tools` to allow compilation of native node modules.

--- a/package.json
+++ b/package.json
@@ -143,8 +143,7 @@
           "x64",
           "ia32"
         ]
-      },
-      "certificateSubjectName": "Automattic, Inc."
+      }
     },
     "nsis": {
       "oneClick": false


### PR DESCRIPTION
### Description

To-date, debugging issues locally on Windows has been virtually non-existent (due to the fact that building the application source is not supported on Windows). When troubleshooting Windows-specific issues locally, a developer has to rely on artifacts built via Circle for each code change when attempting to debug. This PR adds some tooling to make building and debugging the application locally on Windows a little more convenient:

* Docker environment for building the application source
* Convenience Docker invocation added to the Makefile
* Documentation of recommended Windows environment

These changes facilitate being able to build both the packaged app and the developer environment locally. 🎉

The Docker environment is configured with NVM and all essential build tools, meaning that the image does not have to be re-built each time and can serve as a literal virtual Linux environment persistent on the user's Windows installation. 

### To Test

1. Set up Windows environment (MSYS2/Git Bash), Docker, windows-build-tools
2. Build the Docker image with `make docker-build`. Invoke with `make docker-run`. Clean with `make docker-clean`.
3. As with CI, the application source must be built in Linux, but packaged natively in Windows. 

_Instructions_

* To build the packaged (i.e. "final") app artifacts, run `make build-source` within the Docker environment, and `make package` on Windows. 
* To run the application in developer mode, execute `make dev-server` in Docker and `make dev` on Windows.