### PR TITLE
style: add "merge" semantic PR title type

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,1 +1,15 @@
 titleOnly: true
+types:
+    - feat
+    - fix
+    - improvement
+    - docs
+    - style
+    - refactor
+    - perf
+    - test
+    - build
+    - ci
+    - chore
+    - revert
+    - merge


### PR DESCRIPTION
### Description

Adding a "merge" type to the default spec to enable filtering of code freeze branch merges ([example](https://github.com/Automattic/wp-desktop/pull/823)).