### PR TITLE
style: use title case for menu items

### DIFF
--- a/desktop/lib/menu/help-menu.js
+++ b/desktop/lib/menu/help-menu.js
@@ -31,7 +31,7 @@ if ( platform.isWindows() || platform.isLinux() ) {
 module.exports = function( mainWindow ) {
 	return menuItems.concat( [
 		{
-			label: 'How can we help?',
+			label: 'How Can We Help?',
 			click: function() {
 				// on login page - user logged out
 				if ( state.isLoggedIn() ) {


### PR DESCRIPTION
### Description

Per @SylvesterWilmott's recommendation, use Title Case for all menu items.

Performed an audit of the app and this appeared to be the only straggler. 