### PR TITLE
chore: rename built artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,8 @@
       "hardenedRuntime": true,
       "extendInfo": {
         "LSFileQuarantineEnabled": true
-      }
+      },
+      "artifactName": "wordpress.com-macOS-app-${version}.${ext}"
     },
     "dmg": {
       "title": "WordPress.com Installer",
@@ -135,7 +136,8 @@
           "y": 179,
           "type": "file"
         }
-      ]
+      ],
+      "artifactName": "wordpress.com-macOS-dmg-${version}.${ext}"
     },
     "win": {
       "target": {
@@ -147,7 +149,8 @@
       }
     },
     "nsis": {
-      "oneClick": false
+      "oneClick": false,
+      "artifactName": "wordpress.com-win32-setup-${version}.${ext}"
     },
     "linux": {
       "target": [
@@ -160,7 +163,8 @@
       "category": "Development",
       "desktop": {
         "StartupNotify": true
-      }
+      },
+      "artifactName": "wordpress.com-linux-x64-${version}.${ext}"
     },
     "deb": {
       "fpm": [
@@ -172,7 +176,8 @@
         "libnotify4",
         "libxtst6",
         "libnss3"
-      ]
+      ],
+      "artifactName": "wordpress.com-linux-deb-${version}.${ext}"
     },
     "afterSign": "./after_sign_hook.js"
   }


### PR DESCRIPTION
### Description:

There's a few manual steps in the release process that involve renaming built artifacts prior to uploading via Phabricator. This PR amends the build artifact names to match those used uploaded to Phabricator so manual renaming isn't necessary.

Amending the artifact names inline in the package.json config ensures that each platform's `latest.yml` also reflects the correct URL for auto-update. (We will test this with the upcoming beta release and can always revert if this isn't the case.)

<p align="center">
<img width="449" alt="rename-artifacts" src="https://user-images.githubusercontent.com/8979548/78398394-03233b80-75c1-11ea-8486-ce28e1200ac3.png">
</p>



