### PR TITLE
chore(auto-updater): disable auto-updater in DEBUG mode

### DIFF
--- a/desktop/app-handlers/updater/auto-updater/index.js
+++ b/desktop/app-handlers/updater/auto-updater/index.js
@@ -51,8 +51,8 @@ class AutoUpdater extends Updater {
 	}
 
 	ping() {
-		if ( process.env.WP_AUTO_UPDATE_DISABLE ) {
-			dialogDebug( 'WP_AUTO_UPDATE_DISABLE is set: skipping auto-update check' );
+		if ( process.env.DEBUG ) {
+			dialogDebug( 'DEBUG is set: skipping auto-update check' );
 			return;
 		}
 		dialogDebug( 'Checking for update' );

--- a/test/run/run-e2e-tests.js
+++ b/test/run/run-e2e-tests.js
@@ -79,7 +79,7 @@ async function run() {
 			'--disable-http-cache',
 			'--start-maximized',
 			'--remote-debugging-port=9222',
-		], null, { WP_DEBUG_LOG: appLog.path, WP_AUTO_UPDATE_DISABLE: true } );
+		], null, { WP_DEBUG_LOG: appLog.path, DEBUG: true } );
 
 		await delay( 5000 );
 


### PR DESCRIPTION
### Description

This PR makes it so the auto-updater is disabled with the `DEBUG` env var (not a custom `WP_AUTO_UPDATE_DISABLE` variable).

This ensures that the auto-updater is disabled both in tests and in Developer Mode (i.e. when using `make dev`) locally.