### PR TITLE
build: deploy with ghr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,9 +420,56 @@ jobs:
     steps:
       - attach_workspace:
           at: /wp-desktop
+      - run:
+          name: Cleaning Up
+          command: |
+            find release -type f -name "._*" -delete
+            rm -rf release/.icon-set
+      - persist_to_workspace:
+          root: /wp-desktop
+          paths:
+            - release
       - store_artifacts:
           path: release
 
+  publish:
+    docker:
+      - image: circleci/golang:1.12
+    environment:
+      VERSION: << pipeline.git.tag >>
+    steps:
+      - when:
+          condition: << pipeline.git.tag >>
+          steps:
+            - attach_workspace:
+                at: .
+            - run:
+                name: Install Dependencies
+                command: go get github.com/tcnksm/ghr
+            - run:
+                name: Publish Github Release
+                command: |
+                  echo "Publishing draft release for $VERSION..."
+
+                  NAME=${VERSION#?}
+
+                  ghr \
+                    --token $GH_TOKEN \
+                    --username $CIRCLE_PROJECT_USERNAME \
+                    --repository $CIRCLE_PROJECT_REPONAME \
+                    --commitish $CIRCLE_SHA1 \
+                    --name $NAME \
+                    --delete \
+                    --draft \
+                    $VERSION release/
+
+                  echo "Publish complete"
+      - unless:
+          condition: << pipeline.git.tag >>
+          steps:
+            - run:
+                name: Skip Publish
+                command: echo "Not on a tag, skipping publish"
 
 workflows:
   version: 2
@@ -463,6 +510,14 @@ workflows:
             - windows
             - linux
             - mac
+          filters:
+            branches:
+              ignore: /tests\/.*/
+            tags:
+              only: /.*/
+      - publish:
+          requires:
+            - artifacts
           filters:
             branches:
               ignore: /tests\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,6 +461,7 @@ jobs:
                     --name $NAME \
                     --delete \
                     --draft \
+                    --prerelease \
                     $VERSION release/
 
                   echo "Publish complete"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,7 +461,6 @@ jobs:
                     --name $NAME \
                     --delete \
                     --draft \
-                    --prerelease \
                     $VERSION release/
 
                   echo "Publish complete"

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ package: ELECTRON_BUILDER_ARGS =
 package:
 	$(info Packaging app... )
 
-	@npx electron-builder $(ELECTRON_BUILDER_ARGS) build
+	@npx electron-builder $(ELECTRON_BUILDER_ARGS) build --publish never
 
 	@echo "$(CYAN)$(CHECKMARK) App built$(RESET)"
 


### PR DESCRIPTION
### Description

This PR decouples publishing the application to Github from electron-builder by using the [ghr](https://github.com/tcnksm/ghr) utility. This is primarily to hook into the ability to upload release notes to Github (using ghr's `-b BODY` flag). In addition, having more control over the `publish` step could also be useful when re-architecting the publish flow to transition away from deploying via Phabricator.

**The behavior with respect to our release flow is 100% unchanged.** This addition simply gives us the flexibility to add Github release notes, as well as to further customize built artifacts and artifact publishing down the road. (Side note, decoupling the "build" from "publish" steps also gives us flexibility to explore other Electron build tooling, such as [Electron Forge](https://www.electronforge.io/)).

Reference: I used [this guide](https://circleci.com/blog/publishing-to-github-releases-via-circleci/) from Circle CI to set up ghr.

### Motivation/Context

- `electron-builder` does have a `releaseInfo` property. I tested this API, but it turns out populating this field populates the `latest.yml` used during auto-update, and not the Github release notes.
- `electron-builder` is also constrained by the fact that the "build" and "publish" steps are tightly coupled (i.e. you cannot invoke "publish"  separately from "build"). Having a discrete "publish" step gives us more flexibility to make overrides at each step (e.g. including custom files such as a changelog in the uploaded artifacts, publishing to multiple sources, etc.)
- Side note: because `electron-builder` builds and publishes the different platforms in parallel, publishing with `electron-builder` can also lead to a partially corrupt release draft if some, but not all, platforms are built successfully (which has happened in the past). This scenario requires some manual cleanup prior to attempting the build again. Making it so that the release draft isn't created _at all_ if any of the upstream platform jobs fail is ideal (which is what this PR does).

Note: This change is also fairly trivial to revert, if we choose to fall back on electron-builder in the future.

### To Test

1. Check out this branch locally
2. Tag the HEAD of this branch with a dummy release, e.g. `v1.0.0`
3. Push the tag to remote (`git push origin v1.0.0`)
4. Verify that the artifacts are built and uploaded per business-as-usual
5. Don't forget to clean up any test tags! (discard the draft release and `git push origin --delete v1.0.0`)