### PR TITLE
build: Update CI to work with calypso's yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,13 +64,13 @@ references:
     restore_cache:
       name: Restore npm cache
       keys:
-        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/package-lock.json" }}
+        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/yarn.lock" }}
         - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}
         - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
   npm_save_cache: &npm_save_cache
     save_cache:
       name: Save npm cache
-      key: v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/package-lock.json" }}
+      key: v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "package-lock.json" }}-{{ checksum "calypso/yarn.lock" }}
       paths:
         - ~/.npm
   npm_install: &npm_install
@@ -81,7 +81,7 @@ references:
               nvm use
               npm ci
               cd calypso
-              npm ci
+              yarn install --frozen-lockfile
   install_linux_dependencies: &install_linux_dependencies
     run:
       name: Install linux dev dependencies
@@ -98,7 +98,7 @@ references:
     - calypso/config
     - calypso/package.json
     - calypso/packages
-    - calypso/package-lock.json
+    - calypso/yarn.lock
     - calypso/.nvmrc
   setup_calypso: &setup_calypso
     run:

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ CALYPSO_DIR := $(THIS_DIR)/calypso
 CHECKMARK = OK
 
 # Environment Variables
-CONFIG_ENV = 
+CONFIG_ENV =
 CALYPSO_ENV = desktop
 NODE_ENV = production
-DEBUG = 
+DEBUG =
 TEST_PRODUCTION_BINARY = false
 MINIFY_JS = true
 NODE_ARGS = --max_old_space_size=8192
@@ -71,7 +71,7 @@ dev-server: checks
 # Start app in dev mode
 dev: NODE_ENV = development
 dev: DEBUG = desktop:*
-dev: 
+dev:
 	$(MAKE) start NODE_ENV=$(NODE_ENV) DEBUG=$(DEBUG)
 
 BASE_CONFIG := $(THIS_DIR)/desktop-config/config-base.json
@@ -85,22 +85,22 @@ else
 	$(eval EXTENDED = true)
 endif
 	@node -e "const base = require('$(BASE_CONFIG)'); let env; try { env = require('$(TARGET_CONFIG)'); } catch(err) {} console.log( JSON.stringify( Object.assign( base, env ), null, 2 ) )" > $@
-	
+
 	@echo "$(GREEN)$(CHECKMARK) Config built $(if $(EXTENDED),(extended: config-$(CONFIG_ENV).json),)$(RESET)"
 
 # Build calypso bundle
-build-calypso: 
+build-calypso:
 	$(info Building calypso... )
 
-	@cd $(CALYPSO_DIR) && CALYPSO_ENV=$(CALYPSO_ENV) MINIFY_JS=$(MINIFY_JS) NODE_ARGS=$(NODE_ARGS) npm run -s build
+	@cd $(CALYPSO_DIR) && CALYPSO_ENV=$(CALYPSO_ENV) MINIFY_JS=$(MINIFY_JS) NODE_ARGS=$(NODE_ARGS) yarn run --silent build
 
 	@echo "$(CYAN)$(CHECKMARK) Calypso built$(RESET)"
 
 # Run Calypso server
-calypso-dev: 
+calypso-dev:
 	@echo "$(CYAN)Starting Calypso...$(RESET)"
 
-	@cd $(CALYPSO_DIR) && CALYPSO_ENV=$(CALYPSO_ENV) npm run -s start
+	@cd $(CALYPSO_DIR) && CALYPSO_ENV=$(CALYPSO_ENV) yarn run --silent start
 
 # Build desktop bundle
 build-desktop-source:
@@ -125,7 +125,7 @@ package:
 
 	@echo "$(CYAN)$(CHECKMARK) App built$(RESET)"
 
-# Combined steps for building app 
+# Combined steps for building app
 build: build-source package
 
 # Perform checks
@@ -140,7 +140,7 @@ ifneq (43452,$(shell node -p "require('$(SECRETS)').desktop_oauth_client_id"))
 	$(error "desktop_oauth_client_id" must be "43452" in $(SECRETS))
 endif
 endif
-else 
+else
 	$(error $(SECRETS) does not exist)
 endif
 
@@ -156,18 +156,18 @@ check-version-parity: check-node-version-parity check-electron-version-parity
 check-node-version-parity:
 ifneq ("$(CALYPSO_NODE_VERSION)", "$(CURRENT_NODE_VERSION)")
 	$(error Please ensure that wp-desktop is using NodeJS $(CALYPSO_NODE_VERSION) to match wp-calypso before continuing. 	Current NodeJS version: $(CURRENT_NODE_VERSION))
-else 
+else
 	@echo $(GREEN)$(CHECKMARK) Current NodeJS version is on par with Calypso \($(CALYPSO_NODE_VERSION)\) $(RESET)
 endif
 
 # Check that the electron version specified in .npmrc and package.json are consistent.
 # This is to ensure that when native dependencies have an auto-build postinstall script,
-# node-gyp will compile against Electron and not the host environment's node version 
-# required by Calypso. 
+# node-gyp will compile against Electron and not the host environment's node version
+# required by Calypso.
 check-electron-version-parity:
 ifneq ("$(NPMRC_ELECTRON_VERSION)", "$(PACKAGE_ELECTRON_VERSION)")
 	$(error Please ensure that the Electron version in package.json (set to $(PACKAGE_ELECTRON_VERSION)) is consistent with .npmrc (set to $(NPMRC_ELECTRON_VERSION)))
-else 
+else
 	@echo $(GREEN)$(CHECKMARK) Electron version in package.json matches .npmrc  \($(PACKAGE_ELECTRON_VERSION)\) $(RESET)
 endif
 
@@ -180,7 +180,7 @@ test: rebuild-deps
 	@echo "$(CYAN)Building test...$(RESET)"
 
 	@$(MAKE) desktop/config.json CONFIG_ENV=$(CONFIG_ENV)
-	
+
 	@NODE_PATH=calypso$/server$(ENV_PATH_SEP)calypso$/client npx webpack --mode production --config .$/webpack.config.test.js
 	@CALYPSO_PATH=`pwd` npx electron-mocha --inline-diffs --timeout 15000 .$/build$/desktop-test.js
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ WordPress.com for Desktop is an [Electron](https://github.com/atom/electron) wra
 - `git submodule init`
 - `git submodule update`
 
-1. Create a `calypso/config/secrets.json` file and fill it with [secrets](docs/secrets.md)
-1. `npm install` will download all the required packages
-1. `make build` to create the builds
-1. Find the built apps in the `release` folder
+1. Inside `./calypso`, run `yarn` to install all required packages
+1. Inside `./calypso`, create a `./config/secrets.json` file and fill it with [secrets](docs/secrets.md)
+1. In the project root, `npm install` will download all the required packages
+1. In the project root, `make build` to create the builds
+1. Find the built apps in the `release` folder in the project root
 
 Need more detailed instructions? [We have them.](docs/install.md)
 


### PR DESCRIPTION
Note: this PR is a copy of https://github.com/Automattic/wp-desktop/pull/806

### Description:
Updates CircleCI cache key to use `calypso/yarn.lock`

### Motivation and Context:

Calypso is moving to `yarn`, the old lockfile `package-lock.json` does not exists anymore.

### How Has This Been Tested:

Check CircleCI results

### Screenshots (if appropriate):

### Todos:
