### PR TITLE
build: automate Github release notes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,14 +435,16 @@ jobs:
   publish:
     docker:
       - image: circleci/golang:1.12
+    working_directory: /home/circleci/wp-desktop
     environment:
       VERSION: << pipeline.git.tag >>
     steps:
       - when:
           condition: << pipeline.git.tag >>
           steps:
+            - checkout
             - attach_workspace:
-                at: .
+                at: /home/circleci/wp-desktop
             - run:
                 name: Install Dependencies
                 command: go get github.com/tcnksm/ghr
@@ -453,12 +455,16 @@ jobs:
 
                   NAME=${VERSION#?}
 
+                  chmod +x make-changelog.sh
+                  ./make-changelog.sh > CHANGELOG.md
+
                   ghr \
                     --token $GH_TOKEN \
                     --username $CIRCLE_PROJECT_USERNAME \
                     --repository $CIRCLE_PROJECT_REPONAME \
                     --commitish $CIRCLE_SHA1 \
                     --name $NAME \
+                    --body "$(cat CHANGELOG.md)" \
                     --delete \
                     --draft \
                     $VERSION release/

--- a/make-changelog.sh
+++ b/make-changelog.sh
@@ -6,7 +6,10 @@ tags=$(git tag --sort=-v:refname | awk '{if(NR>1)print}')
 
 # get tag for previous stable release from the sorted list
 # (first match without `-`, e.g. v1.2.3, not v1.2.3-alpha1)
-last_stable_tag=$(for tag in $tags; do if [[ ! "$tag" == *"-"* ]]; then echo "$tag"; break; fi; done)
+last_stable_tag=$(for tag in $tags; do if [[ ! "$tag" == *"-"* ]]; then
+  echo "$tag"
+  break
+fi; done)
 
 # get the current tag, fall back to HEAD
 current_tag=$VERSION
@@ -30,20 +33,20 @@ commit_filter="^($git_log_incl_types)(\([a-z]+\))?:\s.+"
 echo "## What's Changed"
 
 # Fill and sort changelog
-git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag...$current_tag \
-    | grep -E "$commit_filter" \
-    | sort -k 1 )
+git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag...$current_tag |
+  grep -E "$commit_filter" |
+  sort -k 1)
 
 # Map of each type to its human-readable heading
-type_heading_map=(	"feat:New Features"
-				"fix:Fixes"
-				"improvement:Improvements"
-				"refactor:Refactors"
-				"perf:Performance Improvements"
-				"test:testing"
-				"build:Build"
-				"ci:Continous Integration"
-				"revert:Reverts" )
+type_heading_map=("feat:New Features"
+  "fix:Fixes"
+  "improvement:Improvements"
+  "refactor:Refactors"
+  "perf:Performance Improvements"
+  "test:testing"
+  "build:Build"
+  "ci:Continous Integration"
+  "revert:Reverts")
 
 # Returns the human-readable heading for a type
 function get_type_heading() {
@@ -77,16 +80,16 @@ last_type=""
 last_scope=""
 echo "$git_log" | while IFS=$'\r' read change; do
 
-	type=$(echo "$change" | egrep -o '^[^:(]+' )
+  type=$(echo "$change" | egrep -o '^[^:(]+')
   if [ "$last_type" != "$type" ]; then
     last_type=$type
     last_scope=""
     echo ""
-		echo "### $(get_type_heading $type)"
-  fi;
+    echo "### $(get_type_heading $type)"
+  fi
 
-  scope=$( echo "$change" | grep -o "\(([^)]*)\):" | tr -d '():' )
-  description=$( echo "$change" | sed 's/.*://' )
+  scope=$(echo "$change" | grep -o "\(([^)]*)\):" | tr -d '():')
+  description=$(echo "$change" | sed 's/.*://')
 
   if [ "$scope" != "$last_scope" ]; then
     last_scope=$scope
@@ -95,11 +98,11 @@ echo "$git_log" | while IFS=$'\r' read change; do
       echo "#### General"
     else
       echo ""
-      echo "#### $( make_title_case "$scope" )"
-    fi;
-  fi;
+      echo "#### $(make_title_case "$scope")"
+    fi
+  fi
 
   print_prefix='{print "- " $0}'
-	echo $( make_first_letter_upper "$description" ) | awk "$print_prefix"
+  echo $(make_first_letter_upper "$description") | awk "$print_prefix"
 
 done

--- a/make-changelog.sh
+++ b/make-changelog.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# fetch all tags in descending lexicographical order
+# (exclude current tag with `awk`)
+tags=$(git tag --sort=-v:refname | awk '{if(NR>1)print}')
+
+# get tag for previous stable release from the sorted list
+# (first match without `-`, e.g. v1.2.3, not v1.2.3-alpha1)
+last_stable_tag=$(for tag in $tags; do if [[ ! "$tag" == *"-"* ]]; then echo "$tag"; break; fi; done)
+
+# get the current tag, fall back to HEAD
+current_tag=$VERSION
+if [ -z "$current_tag" ]; then
+  current_tag=HEAD
+fi
+
+# Include commit message (%s). Other elements such as
+# commit author (_%aN_) and commit short hash (%h) can
+# be included as well.
+git_log_format="%s"
+
+# ignore types: chore, docs, style, merge
+# this can be amended based on what types should be included/excluded from the release notes
+git_log_incl_types="feat|fix|improvement|refactor|perf|test|build|ci|revert"
+
+# Filter commits that satisfy conventional commit format
+# See: https://www.conventionalcommits.org/
+commit_filter="^($git_log_incl_types)(\([a-z]+\))?:\s.+"
+
+echo "## What's Changed"
+
+# Fill and sort changelog
+git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag...$current_tag \
+    | grep -E "$commit_filter" \
+    | sort -k 1 )
+
+# Map of each type to its human-readable heading
+type_heading_map=(	"feat:New Features"
+				"fix:Fixes"
+				"improvement:Improvements"
+				"refactor:Refactors"
+				"perf:Performance Improvements"
+				"test:testing"
+				"build:Build"
+				"ci:Continous Integration"
+				"revert:Reverts" )
+
+# Returns the human-readable heading for a type
+function get_type_heading() {
+  for type in "${type_heading_map[@]}"; do
+    KEY=${type%%:*}
+    VALUE=${type#*:}
+    if [[ "$KEY" == "$1" ]]; then
+      echo "$VALUE"
+    fi
+  done
+}
+
+# Capitalizes first letter of each word
+function make_title_case() {
+  echo "$1" | awk '{for(i=1;i<=NF;i++){ $i=toupper(substr($i,1,1)) substr($i,2) }}1'
+}
+
+# Capitalizes beginning of string only
+function make_first_letter_upper() {
+  ## note: don't use ^ syntax as it is limited to bash >= v4.x
+  echo "$1" | awk '{for (i=1;i<=1;i++) $i=toupper(substr($i,1,1)) substr($i,2)} 1'
+}
+
+## Print each change by doing the following:
+## - parse format 'type(optional scope): description' into type, scope and description components
+## - map each type to human-readable heading (as mapped in the type_heading_map array)
+## - use each item scope as a human-readable subheading (formatted as "Title Cased")
+## - print each item under its designated heading and subheading (formatted as "Sentence cased")
+
+last_type=""
+last_scope=""
+echo "$git_log" | while IFS=$'\r' read change; do
+
+	type=$(echo "$change" | egrep -o '^[^:(]+' )
+  if [ "$last_type" != "$type" ]; then
+    last_type=$type
+    last_scope=""
+    echo ""
+		echo "### $(get_type_heading $type)"
+  fi;
+
+  scope=$( echo "$change" | grep -o "\(([^)]*)\):" | tr -d '():' )
+  description=$( echo "$change" | sed 's/.*://' )
+
+  if [ "$scope" != "$last_scope" ]; then
+    last_scope=$scope
+    if [ -z "$scope" ]; then
+      echo ""
+      echo "#### General"
+    else
+      echo ""
+      echo "#### $( make_title_case "$scope" )"
+    fi;
+  fi;
+
+  print_prefix='{print "- " $0}'
+	echo $( make_first_letter_upper "$description" ) | awk "$print_prefix"
+
+done


### PR DESCRIPTION
### Description

This PR adds a script that gathers changes since the last stable release of the application and formats them using markdown. This markdown-formatted changelog is published with every release to provide a baseline, readily-available view of changes.

In addition, the script is designed such that it can also be executed locally on any branch, and will output the set of changes since the last stable release through the current branch's `HEAD`.

<p align="center">
<img width="600" alt="automated-release-notes-example" src="https://user-images.githubusercontent.com/8979548/79580039-6e2b4280-8096-11ea-962d-8c10ff3e06e7.png">
</p>

There are a number of frameworks out there that help parse and format changes in the conventional commit format. Inspired by [this blog post](https://nikoheikkila.fi/blog/generating-conventional-changelogs/), I chose to go with a relatively lightweight approach and use a custom bash script instead (that ends up being ~100 LOC). Without the overhead of an entire framework, using bash is also more portable between environments. If we find this concept useful after trialing it out, we can always use a more fully-fleshed framework if we want any additional functionality.

### To Test

* _Release Notes on Publish_: Tag this branch with a temporary, dummy tag (greater than the current stable release version) to create a release draft in Github. Note that the release notes section of the draft will be pre-populated.

* _Using the Script Locally_: Check out this branch and run `./make-changelog.sh` from the root of the repo.