### PR TITLE
build: optimize BAU non-release build times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,7 +353,7 @@ jobs:
           name: Archive win-unpacked directories
           command: |
                 # Archive only when both `-unpacked` targets have been built
-                # (as triggered by project config or dependency update).
+                # (as triggered by project config change or dependency update).
                 If ( $(Test-Path -Path release\win-unpacked) -AND $(Test-Path -Path release\win-ia32-unpacked) ) {
                   tar -zcf release/win-unpacked-x64.tar.gz release/win-unpacked
                   tar -zcf release/win-unpacked-ia32.tar.gz release/win-ia32-unpacked

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,7 +283,7 @@ jobs:
                   nvm use
 
                   # Build all artifacts only when project config changes.
-                  # Otherwise build application bundle only for end-to-end testing.
+                  # Otherwise only build application executable required for end-to-end testing.
                   ! git diff --name-only origin/develop...HEAD | grep -E -q 'package.json|yarn.lock' && ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
 
                   make package ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS
@@ -344,7 +344,7 @@ jobs:
                 # $env:CSC_KEY_PASSWORD=$env:WIN_CSC_KEY_PASSWORD
 
                 # Build all artifacts only when project config changes.
-                # Otherwise build application bundle only for end-to-end testing.
+                # Otherwise only build application executable required for end-to-end testing.
                 $env:ARG1='-c.win.certificateSubjectName=""Automattic, Inc.""'
                 If ( -Not $(git diff --name-only origin/develop...HEAD | Select-String -Pattern package.json,yarn.lock) ) { $env:ARG2='-c.win.target=dir' }
 
@@ -352,11 +352,13 @@ jobs:
       - run:
           name: Archive win-unpacked directories
           command: |
+                # Archive only when both `-unpacked` targets have been built
+                # (as triggered by project config or dependency update).
                 If ( $(Test-Path -Path release\win-unpacked) -AND $(Test-Path -Path release\win-ia32-unpacked) ) {
                   tar -zcf release/win-unpacked-x64.tar.gz release/win-unpacked
                   tar -zcf release/win-unpacked-ia32.tar.gz release/win-ia32-unpacked
                 } else {
-                  echo "No win-unpacked directories: skipping tar..."
+                  echo "Project configuration or dependencies are unchanged: skipping tar archive..."
                 }
       - run:
           name: Release cleanup
@@ -402,7 +404,7 @@ jobs:
                   nvm use
 
                   # Build all artifacts only when project config changes.
-                  # Otherwise build application bundle only for end-to-end testing.
+                  # Otherwise only build application executable required for end-to-end testing.
                   ! git diff --name-only origin/develop...HEAD | grep -E -q 'package.json|yarn.lock' && ELECTRON_BUILDER_ARGS='-c.mac.target=dir'
 
                   make package ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
 
                   # Build all artifacts only when project config changes.
                   # Otherwise build application bundle only for end-to-end testing.
-                  ! git diff --name-only origin/develop...HEAD | grep -q 'package.json' && ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
+                  ! git diff --name-only origin/develop...HEAD | grep -E -q 'package.json|yarn.lock' && ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
 
                   make package ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS
       - run:
@@ -346,7 +346,7 @@ jobs:
                 # Build all artifacts only when project config changes.
                 # Otherwise build application bundle only for end-to-end testing.
                 $env:ARG1='-c.win.certificateSubjectName=""Automattic, Inc.""'
-                If ( -Not $(git diff --name-only origin/develop...HEAD | Select-String -Pattern package.json) ) { $env:ARG2='-c.win.target=dir' }
+                If ( -Not $(git diff --name-only origin/develop...HEAD | Select-String -Pattern package.json,yarn.lock) ) { $env:ARG2='-c.win.target=dir' }
 
                 make package ELECTRON_BUILDER_ARGS=$($env:ARG1,$env:ARG2 -join " ")
       - run:
@@ -403,7 +403,7 @@ jobs:
 
                   # Build all artifacts only when project config changes.
                   # Otherwise build application bundle only for end-to-end testing.
-                  ! git diff --name-only origin/develop...HEAD | grep -q 'package.json' && ELECTRON_BUILDER_ARGS='-c.mac.target=dir'
+                  ! git diff --name-only origin/develop...HEAD | grep -E -q 'package.json|yarn.lock' && ELECTRON_BUILDER_ARGS='-c.mac.target=dir'
 
                   make package ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS
       # Temporarily disable the test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,12 @@ jobs:
           command: |
                   source $HOME/.nvm/nvm.sh
                   nvm use
-                  make package
+
+                  # Build all artifacts only when project config changes.
+                  # Otherwise build application bundle only for end-to-end testing.
+                  ! git diff --name-only origin/develop...HEAD | grep -q 'package.json' && ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
+
+                  make package ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS
       - run:
           name: Release cleanup
           command: |
@@ -337,12 +342,22 @@ jobs:
                 Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
 
                 # $env:CSC_KEY_PASSWORD=$env:WIN_CSC_KEY_PASSWORD
-                make package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
+
+                # Build all artifacts only when project config changes.
+                # Otherwise build application bundle only for end-to-end testing.
+                $env:ARG1='-c.win.certificateSubjectName=""Automattic, Inc.""'
+                If ( -Not $(git diff --name-only origin/develop...HEAD | Select-String -Pattern package.json) ) { $env:ARG2='-c.win.target=dir' }
+
+                make package ELECTRON_BUILDER_ARGS=$($env:ARG1,$env:ARG2 -join " ")
       - run:
           name: Archive win-unpacked directories
           command: |
-                tar -zcf release/win-unpacked-x64.tar.gz release/win-unpacked
-                tar -zcf release/win-unpacked-ia32.tar.gz release/win-ia32-unpacked
+                If ( $(Test-Path -Path release\win-unpacked) -AND $(Test-Path -Path release\win-ia32-unpacked) ) {
+                  tar -zcf release/win-unpacked-x64.tar.gz release/win-unpacked
+                  tar -zcf release/win-unpacked-ia32.tar.gz release/win-ia32-unpacked
+                } else {
+                  echo "No win-unpacked directories: skipping tar..."
+                }
       - run:
           name: Release cleanup
           command: |
@@ -385,7 +400,12 @@ jobs:
                   set +e
                   source $HOME/.nvm/nvm.sh
                   nvm use
-                  make package
+
+                  # Build all artifacts only when project config changes.
+                  # Otherwise build application bundle only for end-to-end testing.
+                  ! git diff --name-only origin/develop...HEAD | grep -q 'package.json' && ELECTRON_BUILDER_ARGS='-c.mac.target=dir'
+
+                  make package ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS
       # Temporarily disable the test
       # TODO: Fixme – seems to be an issue with `portscanner`
       # - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,8 @@ jobs:
                   tar -zcf release/win-unpacked-x64.tar.gz release/win-unpacked
                   tar -zcf release/win-unpacked-ia32.tar.gz release/win-ia32-unpacked
                 } else {
-                  echo "Project configuration or dependencies are unchanged: skipping tar archive..."
+                  echo "Project configuration and dependencies are unchanged: only some of the project's artifacts have been built."
+                  echo "Skipping tar archive..."
                 }
       - run:
           name: Release cleanup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "5.1.0-beta999",
+  "version": "5.1.0-beta1",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "5.1.0-beta1",
+  "version": "5.1.0-beta999",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"


### PR DESCRIPTION
### Description

**TL;DR**: This change *significantly* reduces business-as-usual build times for all WP Desktop branches/PRs going forward. This is especially notable on Mac, where builds have been taking **~17 minutes** (yep - you read that right) to complete *after* the Calypso and desktop JavaScript source is built. Mac build times now take **~5 minutes (*including* execution of end-to-end tests)**, **which is a **70%** reduction in build times**. This is a significant win for the day-to-day workflow for both wp-desktop and wp-calypso developers. 🎉

### Overview and Comparison

* The full artifact build is completed only when the project's configuration or dependencies (`package.json`, `yarn.lock`) change (this includes version bump at release)
* In all other cases (which is the majority of jobs, including all jobs triggered by Calypso PRs), artifact generation is limited to the application binary/bundle necessary for end-to-end testing.

For branches/PRs that do not modify the project's configuration or dependencies , a comparison of before/after build times is shown below :

|   | Before  | After  | % delta |
|---|---|---|---|
| Windows  |9|4|-55%|
| Mac (incl. e2e tests) |17|5|-70%|
| Linux | 7  |2|-70%|
| All pipeline (incl. Calypso) |23|12|-48%|

By drilling down further into the packaging step within the build job of each platform, we can see that the performance benefits are even more notable:

|   | Before  | Optimized  | % delta |
|---|---|---|---|
| Build Windows  |3|1|-66%|
| Build Mac |10|1|-90%|
| Build Linux |8|30s|-93%|

The delta between platform packaging and the total runtime of each platform's build job is primarily driven by the node module installation step.  With smarter node module cache restoration we can further drive build times down even further. However, this optimization is incremental and can be visited in a downstream PR.

#### Detail

**TL;DR**: For each platform, the entire artifact set is only generated when the project's configuration or dependencies change. Otherwise, only the application bundle is generated (which is the bare minimum required for end-to-end testing).

This ensures that: (1) whenever dependencies or project configuration change, we _always_ check that the entire artifact set continues to build successfully, and (2) we significantly reduce the turnaround of CI jobs where dependencies have *not* changed (which, generally speaking, should be the majority of the time and is certainly the case for all desktop CI jobs triggered by Calypso PRs). Finally, (3) with significantly lower additional time, desktop end-to-end tests can now be integrated into the Calypso PR pipeline.

### Motivation/Context

1. Because the desktop end-to-end suite is gated by very slow artifact build times, Calypso-Desktop CI has been limited only to verification that the desktop code _builds_. This is a good but still leaves the risk of _ runtime_ errors falling through the cracks (as exemplified by recent Calypso issue [40789](https://github.com/Automattic/wp-calypso/issues/40789), in which the JavaScript bundle was built successfully but did not execute when ran). Hunting down these sorts of breakages is significantly time-consuming. Ideally, to mitigate this scenario, the desktop end-to-end test suite should also be executed with every Calypso PR. 

	This optimization now allows the desktop end-to-end tests to be integrated into Calypso CI since the added time (~5 minutes) is within an acceptable range.

1. To-date, the slow turnaround of CI jobs has slowed down development velocity.

### To Test

Clone this branch and make a change to package.json (e.g. add/change deps or bump version).

To illustrate, a temporary change was made to package.json in this branch and then reverted from this branch to verify the logic works.

See [here](https://app.circleci.com/pipelines/github/Automattic/wp-desktop/12204/workflows/250a156d-0712-4aa1-b30a-61c80ef7715c) for workflow with a change to project config (total build time **~ 21 minutes**)

See [here](https://app.circleci.com/pipelines/github/Automattic/wp-desktop/12205/workflows/656dc296-a64b-402e-8f99-68227546e52b) for workflow with no changes to project config (total time **~12 minutes**)