### PR TITLE
build: Add mac build step to calypso canary workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ references:
               "payload": {
                 "outcome": "'"success"'",
                 "status": "'"success"'",
-                "branch": "'"$BRANCHNAME"'",
+                "branch": "'"$CIRCLE_BRANCH"'",
                 "build_url": "'"$CIRCLE_BUILD_URL"'",
                 "build_parameters": {
                   "build_num": '"$CIRCLE_BUILD_NUM"',
@@ -208,7 +208,7 @@ references:
             "payload": {
               "outcome": "'"failed"'",
               "status": "'"failed"'",
-              "branch": "'"$BRANCHNAME"'",
+              "branch": "'"$CIRCLE_BRANCH"'",
               "build_url": "'"$CIRCLE_BUILD_URL"'",
               "build_parameters": {
                 "build_num": '"$CIRCLE_BUILD_NUM"',
@@ -227,7 +227,6 @@ jobs:
       CONFIG_ENV: release
       MINIFY_JS: true
       NODE_ARGS: --max_old_space_size=3072
-      BRANCHNAME: << pipeline.git.branch >>
       CALYPSO_HASH: << pipeline.parameters.CALYPSO_HASH >>
       sha: << pipeline.parameters.sha >>
       calypsoProject: << pipeline.parameters.calypsoProject >>
@@ -378,7 +377,6 @@ jobs:
     shell: /bin/bash --login
     working_directory: /Users/distiller/wp-desktop
     environment:
-      BRANCHNAME: << pipeline.git.branch >>
       sha: << pipeline.parameters.sha >>
       calypsoProject: << pipeline.parameters.calypsoProject >>
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,24 +198,24 @@ references:
       when: on_fail
       command: |
         set +o errexit
-        if [[ $BRANCHNAME != "tests/"* ]]; then
+        if [[ $CIRCLE_BRANCH != "tests/"* ]]; then
           exit
         fi
         curl -X POST "https://a8c-gh-desktop-bridge.go-vip.co/circleciwebhook" \
         -H 'Cache-Control: no-cache'	\
         -H 'Content-Type: application/json'	\
         -d '{
-          "payload": {
-            "outcome": "'"failed"'",
-            "status": "'"failed"'",
-            "branch": "'"$BRANCHNAME"'",
-            "build_url": "'"$CIRCLE_BUILD_URL"'",
-            "build_parameters": {
-              "build_num": '"$CIRCLE_BUILD_NUM"',
-              "sha": "'"$sha"'",
-              "calypsoProject": "'"$calypsoProject"'"
+            "payload": {
+              "outcome": "'"failed"'",
+              "status": "'"failed"'",
+              "branch": "'"$BRANCHNAME"'",
+              "build_url": "'"$CIRCLE_BUILD_URL"'",
+              "build_parameters": {
+                "build_num": '"$CIRCLE_BUILD_NUM"',
+                "sha": "'"$sha"'",
+                "calypsoProject": "'"$calypsoProject"'"
+              }
             }
-          }
         }'
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,10 +248,6 @@ jobs:
       - *test
       - *calypso_finalize_cache
       - *calypso_save_cache
-      - run:
-          name: Install Node Modules
-          command: |
-            exit 1
       - *webhook_notify_failed
       - persist_to_workspace:
           root: ~/wp-desktop
@@ -389,6 +385,10 @@ jobs:
       - *setup_nvm
       - *save_nvm
       - *restore_node_module_cache
+      - run:
+          name: Install Node Modules
+          command: |
+              exit 1
       - run:
           name: Install Node Modules
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,10 +392,6 @@ jobs:
       - run:
           name: Install Node Modules
           command: |
-              exit 1
-      - run:
-          name: Install Node Modules
-          command: |
             source $HOME/.nvm/nvm.sh
             nvm use
             yarn install --frozen-lockfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,6 +248,10 @@ jobs:
       - *test
       - *calypso_finalize_cache
       - *calypso_save_cache
+      - run:
+          name: Install Node Modules
+          command: |
+            exit 1
       - *webhook_notify_failed
       - persist_to_workspace:
           root: ~/wp-desktop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,6 @@ jobs:
       - *test
       - *calypso_finalize_cache
       - *calypso_save_cache
-      - *webhook_notify_success
       - *webhook_notify_failed
       - persist_to_workspace:
           root: ~/wp-desktop
@@ -430,6 +429,8 @@ jobs:
                   set +e
                   rm -rf release/github
                   rm -rf release/mac
+      - *webhook_notify_success
+      - *webhook_notify_failed
       - persist_to_workspace:
           root: /Users/distiller/wp-desktop
           paths:
@@ -559,6 +560,12 @@ workflows:
     when: << pipeline.parameters.isCalypsoCanaryRun >>
     jobs:
       - build:
+          filters:
+            branches:
+              only: /tests\/.*/
+	  - mac:
+          requires:
+            - build
           filters:
             branches:
               only: /tests\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -563,7 +563,7 @@ workflows:
           filters:
             branches:
               only: /tests\/.*/
-	  - mac:
+      - mac:
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,10 +377,10 @@ jobs:
       xcode: "10.1.0"
     shell: /bin/bash --login
     working_directory: /Users/distiller/wp-desktop
-	environment:
-	  BRANCHNAME: << pipeline.git.branch >>
-	  sha: << pipeline.parameters.sha >>
-	  calypsoProject: << pipeline.parameters.calypsoProject >>
+    environment:
+      BRANCHNAME: << pipeline.git.branch >>
+      sha: << pipeline.parameters.sha >>
+      calypsoProject: << pipeline.parameters.calypsoProject >>
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,6 +377,10 @@ jobs:
       xcode: "10.1.0"
     shell: /bin/bash --login
     working_directory: /Users/distiller/wp-desktop
+	environment:
+	  BRANCHNAME: << pipeline.git.branch >>
+	  sha: << pipeline.parameters.sha >>
+	  calypsoProject: << pipeline.parameters.calypsoProject >>
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
<!--- Describe your changes in detail. -->
This change adds the Mac build in to the Calypso canaries workflow. 

### Motivation and Context:
The purpose behind this is that we would like to be able to run the desktop e2e tests on Calypso changes so we can have more confidence that it works

### How Has This Been Tested:
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, tests completed to see 
how your change affects other areas of the code, etc. -->

Here is a test build I triggered from the gh bridge https://circleci.com/workflow-run/01bd7a82-b85b-4675-ac61-c60ab74a9000
