### PR TITLE
build(release notes): improve git tag sorting

### DIFF
--- a/make-changelog.sh
+++ b/make-changelog.sh
@@ -2,7 +2,7 @@
 
 # fetch all tags in descending lexicographical order
 # (exclude current tag with `awk`)
-tags=$(git tag --sort=-v:refname | awk '{if(NR>1)print}')
+tags=$(git tag | tr - \~ | sort -V -r | tr \~ - | awk '{if(NR>1)print}')
 
 # get tag for previous stable release from the sorted list
 # (first match without `-`, e.g. v1.2.3, not v1.2.3-alpha1)


### PR DESCRIPTION
### Description

Refinement/fix for tag sort used for release note generation. Prior logic worked fine but in some cases would lead to current and prior tags being the same (hence an empty diff).

Before (incorrect):

```
> git tag --sort=-v:refname

v5.1.0-beta1
v5.1.0 		<<-- nope!
v5.0.1-beta2
v5.0.1-beta1
v5.0.1		<<-- nope!
```

After:

```
> git tag | tr - \~ | sort -V -r | tr \~ -

v5.1.0
v5.1.0-beta1
v5.0.1
v5.0.1-beta2
v5.0.1-beta1
```

### To Test

Verify the above command output locally 