### PR TITLE
build: update semantic types

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -2,14 +2,15 @@ titleOnly: true
 types:
     - feat
     - fix
-    - improvement
+    - enhancement
     - docs
     - style
     - refactor
     - perf
-    - test
+    - tests
     - build
     - ci
     - chore
     - revert
-    - merge
+    - calypso
+

--- a/make-changelog.sh
+++ b/make-changelog.sh
@@ -24,7 +24,7 @@ git_log_format="%s"
 
 # ignore types: chore, docs, style, merge
 # this can be amended based on what types should be included/excluded from the release notes
-git_log_incl_types="feat|fix|improvement|refactor|perf|test|build|ci|revert"
+git_log_incl_types="feat|fix|enhancement|refactor|perf|tests|build|ci|revert|calypso"
 
 # Filter commits that satisfy conventional commit format
 # See: https://www.conventionalcommits.org/
@@ -40,12 +40,13 @@ git_log=$(git log --oneline --pretty=format:"$git_log_format" $last_stable_tag..
 # Map of each type to its human-readable heading
 type_heading_map=("feat:New Features"
   "fix:Fixes"
-  "improvement:Improvements"
+  "enhancement:Enhancements"
   "refactor:Refactors"
   "perf:Performance Improvements"
-  "test:testing"
+  "tests:Testing"
   "build:Build"
   "ci:Continous Integration"
+  "calypso:Calypso"
   "revert:Reverts")
 
 # Returns the human-readable heading for a type


### PR DESCRIPTION
### Description

Some tweaks to semantic categories:

- `improvement` (lol) -> `enhancement`
- `test` -> `tests` (seems more natural)
- remove `merge` (unnecessary)
- add `calypso` type to explicitly call out Calypso updates