### PR TITLE
fix: ensure Jetpack redirects don't block the app

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -27,7 +27,7 @@ module.exports = function( finished_cb ) {
 		require( './window-handlers/failed-to-load' )( mainWindow );
 		require( './window-handlers/login-status' )( mainWindow );
 		require( './window-handlers/notifications' )( mainWindow );
-		require( './window-handlers/external-links' )( mainWindow.webContents );
+		require( './window-handlers/external-links' )( mainWindow );
 		require( './window-handlers/window-saver' )( mainWindow );
 		require( './window-handlers/debug-tools' )( mainWindow );
 

--- a/desktop/window-handlers/external-links/editor/index.js
+++ b/desktop/window-handlers/external-links/editor/index.js
@@ -1,0 +1,177 @@
+'use strict';
+
+/**
+ * External Dependencies
+ */
+const { URL } = require( 'url' );
+const { promisify } = require( 'util' );
+const { dialog, ipcMain: ipc } = require( 'electron' );
+
+/**
+ * Internal dependencies
+ */
+const Settings = require( 'lib/settings' );
+const openInBrowser = require( '../open-in-browser' );
+const { showMySites } = require( 'lib/calypso-commands' );
+const settingConstants = require( 'lib/settings/constants' );
+const log = require( 'lib/logger' )( 'desktop:external-links:handle-jetpack' );
+
+/**
+ * Module variables
+ */
+const delay = promisify( setTimeout );
+
+// Invokes the activation of Secure Sign-On ("SSO") for the remote site
+// by sending messages over IPC to Calypso. Because we should not block
+// the renderer process by sending mesages synchronously, each step sets
+// and cleans up a handler that listens on a corresponding response channel.
+//
+// Steps:
+// 1. Enable option (set/clean up handler on response channel)
+// 2. Refresh site info (set/clean up handler on response channel)
+// 3. Navigate to the editor
+function selectedEnableSSOandContinue( mainWindow, info ) {
+	log.info( 'User selected \'Enable SSO and Continue\'...' );
+
+	const channelDidEnableSiteOption = 'enable-site-option-response';
+	const channelDidRequestSite = 'request-site-response';
+
+	const { siteId, origin, editorUrl } = info;
+
+	const handleDidRequestSite = ( _, { error } ) => {
+		ipc.removeAllListeners( channelDidRequestSite );
+		if ( error ) {
+			throw error;
+		}
+		log.info( `Refreshed info for site: '${ origin }', navigating to URL: '${ editorUrl }'` );
+		mainWindow.webContents.send( 'navigate', editorUrl );
+	}
+
+	const handleDidEnableSiteOption = ( _, { error } ) => {
+		ipc.removeAllListeners( channelDidEnableSiteOption );
+		if ( error ) {
+			throw error;
+		}
+		log.info( `SSO enabled for site: '${ origin }', requesting site refresh...`, );
+		ipc.on( channelDidRequestSite, handleDidRequestSite );
+		mainWindow.webContents.send( 'request-site', siteId );
+	}
+
+	ipc.on( channelDidEnableSiteOption, handleDidEnableSiteOption );
+	mainWindow.webContents.send( 'enable-site-option', { siteId, option: 'sso' } );
+}
+
+function selectedProceedInBrowser( mainWindow, { origin, wpAdminLoginUrl } ) {
+	log.info( 'User selected \'Proceed in Browser\'...' )
+	openInBrowser( null, wpAdminLoginUrl );
+	navigateToShowMySites( mainWindow, origin );
+}
+
+function selectedCancel( mainWindow, { origin } ) {
+	log.info( 'User selected \'Cancel\' with origin ...', origin );
+	navigateToShowMySites( mainWindow, origin );
+}
+
+function navigateToShowMySites( mainWindow, domain ) {
+	showMySites( mainWindow );
+	// Update last location so a redirect isn't automatically triggered on app relaunch.
+	Settings.saveSetting( settingConstants.LAST_LOCATION, `/stats/day/${ ( new URL( domain ) ).hostname }` );
+}
+
+/**
+ * Prompts the user when they are unable to navigate to the Gutenberg editor due to lack
+ * of sufficient permissions for the self-hosted site.
+ *
+ * The user may select one of three options to continue:
+ *
+ *	1. Enable Secure Sign On and Continue
+ *	2. Proceed in Browser (via wpAdmin redirect)
+ *	3. Cancel
+ * Users that can manage site options will be presented with all three options. All others
+ * are presented with the option to Cancel or Proceed in Browser only.
+ *
+ * FIXME: Implementing this logic (including UI dialogs) may be a lot cleaner if done
+ * wholly within Calypso (minimize necessity of async workarounds over IPC).
+ *
+ * @param {object} mainWindow Reference to the main window object.
+ * @param {object} info Payload from Calypso containing relevant user- and site-specific information.
+ */
+async function handleJetpackEnableSSO( mainWindow, info ) {
+	log.info( `Prompting user to enable SSO for site: '${ info.origin }'...` );
+
+	const { origin, canUserManageOptions } = info;
+
+	const buttons = [ 'Proceed in Browser', 'Cancel' ];
+	if ( canUserManageOptions ) {
+		buttons.unshift( 'Enable SSO and Continue' );
+	}
+
+	try {
+		// Allow sufficient time for Gutenberg's "placeholder" UI to render.
+		// Otherwise, exiting the placeholder UI will make Calypso's master- and
+		// sidebars disappear.
+		await delay( 300 );
+
+		let message = 'This feature requires that Secure Sign-On is enabled in the Jetpack settings of the site:' +
+					'\n\n' +
+					`${ origin }`;
+		if ( ! canUserManageOptions ) {
+			// If the user cannot manage site options,
+			// prompt them to contact the site admin.
+			message += '\n\n' +
+					'Please contact the site admin.'
+		}
+
+		const selected = dialog.showMessageBox( mainWindow, {
+			type: 'info',
+			buttons: buttons,
+			title: 'Jetpack Authorization Required',
+			message,
+			detail: 'You may proceed after changing the site\'s Jetpack settings ' +
+					'or you can proceed in an external browser.'
+		} );
+
+		switch ( selected ) {
+			case 0:
+				if ( canUserManageOptions ) {
+					selectedEnableSSOandContinue( mainWindow, info );
+				} else {
+					selectedProceedInBrowser( mainWindow, info );
+				}
+				break;
+			case 1:
+				if ( canUserManageOptions ) {
+					selectedProceedInBrowser( mainWindow, info );
+				} else {
+					selectedCancel( mainWindow, info );
+				}
+				break;
+			case 2:
+				selectedCancel( mainWindow, info );
+				break;
+		}
+	} catch ( error ) {
+		log.error( 'Failed to prompt for Jetpack authorization: ', error );
+		navigateToShowMySites( mainWindow, origin );
+	}
+}
+
+function handleUndefined( mainWindow, info ) {
+	log.info( 'Cannot use editor, unhandled reason: ', info );
+
+	dialog.showMessageBox( mainWindow, {
+		type: 'info',
+		buttons: [ 'OK' ],
+		title: 'Unable to Use the Editor',
+		message: 'An unhnadled error occurred. ' +
+			+ 'Please contact help@wordpress.com for help.',
+	} );
+
+	const { origin } = info;
+	navigateToShowMySites( mainWindow, origin );
+}
+
+module.exports = {
+	handleJetpackEnableSSO,
+	handleUndefined,
+}

--- a/desktop/window-handlers/external-links/open-in-browser/index.js
+++ b/desktop/window-handlers/external-links/open-in-browser/index.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const { URL } = require( 'url' );
+const shell = require( 'electron' ).shell;
+
+/**
+ * Internal dependencies
+ */
+const log = require( 'lib/logger' )( 'desktop:external-links' );
+
+function isValidBrowserUrl( url ) {
+	const parsedUrl = new URL( url );
+
+	if ( parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:' ) {
+		return url;
+	}
+
+	return false;
+}
+
+module.exports = function( event, url ) {
+	if ( isValidBrowserUrl( url ) ) {
+		log.info( `Using system default handler for URL: ${ url }` );
+		shell.openExternal( url );
+	}
+
+	if ( event ) {
+		event.preventDefault();
+	}
+}


### PR DESCRIPTION
### Description

This PR addresses #640, in which a number of Jetpack users have reported the app being left in an unusable state when trying to use the Gutenberg editor.

<p align="center">
<img width=500 src="https://user-images.githubusercontent.com/8979548/81417735-9fd57d80-9119-11ea-9025-66e0afd070a9.png">
<p>

[Closer investigation](https://github.com/Automattic/wp-desktop/issues/640#issuecomment-621268932) confirmed that because the Desktop app does not support Jetpack authentication, this happens when Calypso remains stuck in a "pending" state while the user is redirected to their remote site for re-authentication. **Workaround**: in order for Gutenberg to work in the Desktop app, the user has to enable Single Sign-On in the remote site's Jetpack settings.

~~This PR intercepts the authentication redirect from Jetpack and lets the user know that SSO is required. The user can then choose to cancel the navigation or proceed in an external browser. With either selection, the user is automatically navigated to the `my-sites` landing page so they are not left in an unusable state.~~

~~This fix is regarded as a stopgap while a more ideal solution is pending (that will likely require support from both Jetpack and Calypso). Ideally, Jetpack users should have a more seamless way/less disruptive way to authenticate within the Desktop app without having to know _in advance_ that SSO should be enabled.~~

<p align="center">
<img width="500" alt="enable-sso-prompt" src="https://user-images.githubusercontent.com/8979548/82944830-e32d4a00-9f69-11ea-98c1-dcfde167cf8d.png">
</p>

This PR intercepts the authentication redirect from Jetpack and allows the user to enable SSO, proceed in a browser or cancel navigation to the editor. When proceeding to an external browser or canceling, the user is automatically navigated to the `my-sites` landing page so they are not left in an unusable state.

This PR pairs with the changes in Automattic/wp-calypso#42183.

### Additional Context: Classic Editor Deprecation

Using the Classic Editor as a fallback was considered but is a no-go as the Classic Editor will imminently be deprecated from Calypso (see [this master Github issue](Automattic/Dotcom-roadmap/issues/124) for progress).

### To Test

- Download and extract the [mac artifact built with this branch](https://app.circleci.com/pipelines/github/Automattic/wp-desktop/14504/workflows/0c5ce06d-acf9-4fbf-9bed-7f3011be3ae4/jobs/62610/artifacts) (use `ditto -x -k wordpress.com-macOS-app-5.1.1-beta1.zip .` to extract. Double-click to open and then select "Open Anyway" in MacOS `Security & Privacy` preferences since the app not notarized)
- Set up a self-hosted site (with Jurassic Ninja) and add a WordPress.com user. Connect and activate Jetpack!
- Log into the desktop app as the WordPress.com user 

With Gutenberg enabled:

- Attempt to use the editor in a simple site: expect the editor to work as before
- Attempt to use the editor in a remote site: UI prompt to continue in a browser is displayed. If the user is an admin (i.e. can manage site options), they will also have the option to enable SSO and proceed to the Gutenberg editor.

Related: Automattic/wp-calypso/issues/41417