### PR TITLE
revert(os x): com.apple.quarantine attr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ references:
     restore_cache:
       name: Restoring NVM cache
       keys:
-        - v1-nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
-        - v1-nvm-0-33-11-{{ arch }}
+        - v1-nvm-0-33-11-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+        - v1-nvm-0-33-11-{{ .Environment.CACHE_VERSION }}-{{ arch }}
   setup_nvm: &setup_nvm
     run:
       name: Install nvm and calypso node version
@@ -50,7 +50,7 @@ references:
   save_nvm: &save_nvm
     save_cache:
       name: Saving NVM cache
-      key: v1-nvm-0-33-11-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+      key: v1-nvm-0-33-11-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
       paths:
         - ~/.nvm
   decrypt_assets: &decrypt_assets
@@ -64,9 +64,9 @@ references:
     restore_cache:
       name: Restore Node Module Cache
       keys:
-        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "yarn.lock" }}-{{ checksum "calypso/yarn.lock" }}
-        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "yarn.lock" }}
-        - v2-npm-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
+        - v2-npm-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "yarn.lock" }}-{{ checksum "calypso/yarn.lock" }}
+        - v2-npm-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "calypso/.nvmrc" }}-{{ checksum "yarn.lock" }}
+        - v2-npm-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ checksum "calypso/.nvmrc" }}
   save_node_module_cache: &save_node_module_cache
     save_cache:
       name: Save node module cache
@@ -126,7 +126,7 @@ references:
     restore_cache:
       name: Restore calypso cache
       keys:
-        - v6-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
+        - v6-calypso-{{ .Environment.CACHE_VERSION }}-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
   calypso_finalize_cache: &calypso_finalize_cache
     run:
       name: Finalize calypso cache
@@ -137,7 +137,7 @@ references:
   calypso_save_cache: &calypso_save_cache
     save_cache:
       name: Save calypso cache
-      key: v6-calypso-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
+      key: v6-calypso-{{ .Environment.CACHE_VERSION }}-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "calypso-current-hash" }}
       paths: *app_cache_paths
   build_sources: &build_sources
     run:

--- a/package.json
+++ b/package.json
@@ -116,9 +116,6 @@
       "entitlements": "./resource/macos/entitlements.mac.plist",
       "entitlementsInherit": "./resource/macos/entitlements.mac.inherit.plist",
       "hardenedRuntime": true,
-      "extendInfo": {
-        "LSFileQuarantineEnabled": true
-      },
       "artifactName": "wordpress.com-macOS-app-${version}.${ext}"
     },
     "dmg": {


### PR DESCRIPTION
### Description

This PR reverts the addition of the `com.apple.quarantine` attribute (introduced in [this](https://github.com/Automattic/wp-desktop/pull/738) PR), which can have unintended side effects w.r.t. the Electron's auto-updater.

TL;DR: the `com.apple.quarantine` attribute can make it so the auto-updater is unable to successfully update the app. This manifests as the error `Update error: Cannot update while running on a read-only volume.` in the Electron Updater logs. (Note: this doesn't occur 100% of the time, but does seem to be an unresolved issue that occurs intermittently).

Github Issue: https://github.com/Squirrel/Squirrel.Mac/issues/182

Manual Workarounds:

- Option 1: Remove `com.apple.quarantine` attribute prior to updating: `xattr -dr com.apple.quarantine `
- Option 2: Using Finder, move the application from the /Applications directory to another location and back

While a more robust workaround is pending, will revert the addition of this attribute.

Note: This fix is forward-looking - the auto-update code lives within the app that's currently installed, not the app being deployed, so we can't override this attribute retroactively. This fix will help mitigate the issue for users of the app going forward (i.e. those users that install >=5.1.1), but we'll have to let Happiness know about the manual workarounds for users that may encounter it in the interim.