### PR TITLE
tests: temporarily disable flakey signup test

### DIFF
--- a/test/tests/e2e.js
+++ b/test/tests/e2e.js
@@ -116,7 +116,7 @@ describe( 'Can Log Out', function() {
 	} );
 } );
 
-describe( 'Can Sign up', function() {
+describe.skip( 'Can Sign up', function() {
 	this.timeout( 90000 );
 	const blogName = dataHelper.getNewBlogName();
 	const emailAddress = blogName + '@e2edesktop.test';


### PR DESCRIPTION
### Description

Temporarily disabling sign-up tests. Been observing higher-than-normal frequency of failure with the error message:

```
  1) Can Sign up Can see the "Site Topic" page, and enter the site topic:
     TimeoutError: Timed out waiting for element with css selector of '.signup__steps' to be present and displayed
 ```

Example ref: [Circle](https://app.circleci.com/pipelines/github/Automattic/wp-desktop/14116/workflows/9baa33e2-1978-4c33-a398-59c84a2e620a/jobs/61954/steps)