### PR TITLE
build: persist e2e app executables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,14 +358,9 @@ jobs:
       - run:
           name: Archive win-unpacked directories
           command: |
-                # If this isn't a full artifact build, ensure to persist the built application for inspection
+                tar -zcf release/win-unpacked-x64.tar.gz release/win-unpacked
 
-                If ( $(Test-Path -Path release\win-unpacked) ) {
-                  tar -zcf release/win-unpacked-x64.tar.gz release/win-unpacked
-                } else {
-                  echo "'release\win-unpacked' not built, skipping tar archive..."
-                }
-
+                # If this isn't a full artifact build, the win-ia32-unpacked executable will not be generated
                 If ( $(Test-Path -Path release\win-ia32-unpacked) ) {
                   tar -zcf release/win-unpacked-ia32.tar.gz release/win-ia32-unpacked
                 } else {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,6 +289,11 @@ jobs:
           name: e2e Tests
           command: make e2e
       - run:
+          name: Persist Linux Executable
+          command: |
+                  # If this isn't a full build, ensure to persist the built application for inspection
+                  test -f release/*.tar.gz || tar -zcf release/linux-unpacked-x64.tar.gz release/linux-unpacked
+      - run:
           name: Release cleanup
           command: |
                   set +e
@@ -353,14 +358,18 @@ jobs:
       - run:
           name: Archive win-unpacked directories
           command: |
-                # Archive only when both `-unpacked` targets have been built
-                # (as triggered by project config change or dependency update).
-                If ( $(Test-Path -Path release\win-unpacked) -AND $(Test-Path -Path release\win-ia32-unpacked) ) {
+                # If this isn't a full build, ensure to persist the built application for inspection
+
+                If ( $(Test-Path -Path release\win-unpacked) {
                   tar -zcf release/win-unpacked-x64.tar.gz release/win-unpacked
+                } else {
+                  echo "'release\win-unpacked' not built, skipping tar archive..."
+                }
+
+                If ( $(Test-Path -Path release\win-ia32-unpacked) {
                   tar -zcf release/win-unpacked-ia32.tar.gz release/win-ia32-unpacked
                 } else {
-                  echo "Project configuration and dependencies are unchanged: only some of the project's artifacts have been built."
-                  echo "Skipping tar archive..."
+                  echo "'release\win-ia32-unpacked' not built, skipping tar archive..."
                 }
       - run:
           name: Release cleanup
@@ -428,6 +437,11 @@ jobs:
                   killall UserNotificationCenter
 
                   make e2e
+      - run:
+          name: Persist Mac Executable
+          command: |
+                  # If this isn't a full build, ensure to persist the built application for inspection
+                  test -f release/*.zip || ditto ditto -ck --rsrc --sequesterRsrc release/mac/WordPress.com.app release/mac.zip
       - run:
           name: Release cleanup
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,13 +360,13 @@ jobs:
           command: |
                 # If this isn't a full artifact build, ensure to persist the built application for inspection
 
-                If $(Test-Path -Path release\win-unpacked) {
+                If ( $(Test-Path -Path release\win-unpacked) ) {
                   tar -zcf release/win-unpacked-x64.tar.gz release/win-unpacked
                 } else {
                   echo "'release\win-unpacked' not built, skipping tar archive..."
                 }
 
-                If $(Test-Path -Path release\win-ia32-unpacked) {
+                If ( $(Test-Path -Path release\win-ia32-unpacked) ) {
                   tar -zcf release/win-unpacked-ia32.tar.gz release/win-ia32-unpacked
                 } else {
                   echo "'release\win-ia32-unpacked' not built, skipping tar archive..."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,7 +292,7 @@ jobs:
           name: Persist Linux Executable
           command: |
                   # If this isn't a full artifact build, ensure to persist the built application for inspection
-                  test -f release/*.tar.gz || tar -zcf release/linux-unpacked-x64.tar.gz release/linux-unpacked
+                  test -f release/*.tar.gz || tar -zcf release/linux-unpacked.tar.gz release/linux-unpacked
       - run:
           name: Release cleanup
           command: |
@@ -436,7 +436,7 @@ jobs:
           name: Persist Mac Executable
           command: |
                   # If this isn't a full artifact build, ensure to persist the built application for inspection
-                  test -f release/*.zip || ditto -ck --rsrc --sequesterRsrc release/mac/WordPress.com.app release/mac.zip
+                  test -f release/*.zip || ditto -ck --rsrc --sequesterRsrc release/mac/WordPress.com.app release/mac.app.zip
       - run:
           name: Release cleanup
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ jobs:
       - run:
           name: Persist Linux Executable
           command: |
-                  # If this isn't a full build, ensure to persist the built application for inspection
+                  # If this isn't a full artifact build, ensure to persist the built application for inspection
                   test -f release/*.tar.gz || tar -zcf release/linux-unpacked-x64.tar.gz release/linux-unpacked
       - run:
           name: Release cleanup
@@ -358,7 +358,7 @@ jobs:
       - run:
           name: Archive win-unpacked directories
           command: |
-                # If this isn't a full build, ensure to persist the built application for inspection
+                # If this isn't a full artifact build, ensure to persist the built application for inspection
 
                 If ( $(Test-Path -Path release\win-unpacked) {
                   tar -zcf release/win-unpacked-x64.tar.gz release/win-unpacked
@@ -440,7 +440,7 @@ jobs:
       - run:
           name: Persist Mac Executable
           command: |
-                  # If this isn't a full build, ensure to persist the built application for inspection
+                  # If this isn't a full artifact build, ensure to persist the built application for inspection
                   test -f release/*.zip || ditto ditto -ck --rsrc --sequesterRsrc release/mac/WordPress.com.app release/mac.zip
       - run:
           name: Release cleanup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,7 +441,7 @@ jobs:
           name: Persist Mac Executable
           command: |
                   # If this isn't a full artifact build, ensure to persist the built application for inspection
-                  test -f release/*.zip || ditto ditto -ck --rsrc --sequesterRsrc release/mac/WordPress.com.app release/mac.zip
+                  test -f release/*.zip || ditto -ck --rsrc --sequesterRsrc release/mac/WordPress.com.app release/mac.zip
       - run:
           name: Release cleanup
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,13 +360,13 @@ jobs:
           command: |
                 # If this isn't a full artifact build, ensure to persist the built application for inspection
 
-                If ( $(Test-Path -Path release\win-unpacked) {
+                If $(Test-Path -Path release\win-unpacked) {
                   tar -zcf release/win-unpacked-x64.tar.gz release/win-unpacked
                 } else {
                   echo "'release\win-unpacked' not built, skipping tar archive..."
                 }
 
-                If ( $(Test-Path -Path release\win-ia32-unpacked) {
+                If $(Test-Path -Path release\win-ia32-unpacked) {
                   tar -zcf release/win-unpacked-ia32.tar.gz release/win-ia32-unpacked
                 } else {
                   echo "'release\win-ia32-unpacked' not built, skipping tar archive..."

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The app is split between Electron code and Calypso code, and so the [development
 1. Set the environment variables `E2EUSERNAME` and `E2EPASSWORD`.
 2. Use `npm run e2e` or `make e2e` to invoke the test suite.
 
+To manually start each platform's _pre-packaged_ executable used for end-to-end testing:
+
+- Mac: Double-click `WordPress.com.app`
+- Windows: Double-click WordPress.com.exe in `win-unpacked` directory
+- Linux: `npx electron /path/to/linux-unpacked/resources/app`
+
 # MacOS Notarization
 
 Per the current [Electron docs](https://www.electron.build/configuration/dmg), DMG signing is disabled by default as it will "lead to unwanted errors in combination with notarization requirements." Only the app bundle is zipped and submitted to Apple for notarization.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The app is split between Electron code and Calypso code, and so the [development
 
 To manually start each platform's _pre-packaged_ executable used for end-to-end testing:
 
-- Mac: Double-click `WordPress.com.app`
+- Mac: Double-click `WordPress.com.app` (extract with [`ditto`](##Extracting-Published-ZIP-Archive-in-MacOS-10.15-(Catalina)))
 - Windows: Double-click WordPress.com.exe in `win-unpacked` directory
 - Linux: `npx electron /path/to/linux-unpacked/resources/app`
 


### PR DESCRIPTION
### Description

This PR persists the unpacked application executables used during end-to-end testing for ad-hoc inspection.

### Motivation/Context

In order to streamline non-release build times, installer artifacts are no longer persisted when the project configuration doesn't change (#869). For convenience, we should persist the executables used during end-to-end testing anyway for as-needed inspection.