### PR TITLE
build: convert desktop/server/server module to ESM for better Calypso import compat

### DIFF
--- a/desktop/server/index.js
+++ b/desktop/server/index.js
@@ -13,7 +13,7 @@ const path = require( 'path' );
  * Internal dependencies
  */
 const Config = require( 'lib/config' );
-const server = require( './server' );
+const { start } = require( './server' );
 const Settings = require( 'lib/settings' );
 const settingConstants = require( 'lib/settings/constants' );
 const cookieAuth = require( 'lib/cookie-auth' );
@@ -107,7 +107,7 @@ function showAppWindow() {
 function startServer( started_cb ) {
 	log.info( 'App is ready, starting server' );
 
-	server.start( app, function() {
+	start( app, function() {
 		started_cb( showAppWindow() );
 	} );
 }

--- a/desktop/server/server.js
+++ b/desktop/server/server.js
@@ -4,12 +4,12 @@
 import { dialog } from 'electron';
 import http from 'http';
 import portscanner from 'portscanner';
-import logFactory from 'lib/logger';
 
 /**
  * Internal dependencies
  */
 import Config from 'lib/config';
+import logFactory from 'lib/logger';
 import boot from 'server/boot';
 
 const log = logFactory( 'desktop:server' );

--- a/desktop/server/server.js
+++ b/desktop/server/server.js
@@ -1,59 +1,62 @@
-'use strict';
-
 /**
  * External Dependencies
  */
-const portscanner = require( 'portscanner' );
-const log = require( 'lib/logger' )( 'desktop:server' );
+import { dialog } from 'electron';
+import http from 'http';
+import portscanner from 'portscanner';
+import logFactory from 'lib/logger';
 
 /**
  * Internal dependencies
  */
-const Config = require( 'lib/config' );
+import Config from 'lib/config';
+import boot from 'server/boot';
+
+const log = logFactory( 'desktop:server' );
 
 function showFailure( app ) {
-	const dialog = require( 'electron' ).dialog;
-
-	dialog.showMessageBox( {
-		type: 'warning',
-		title: 'WordPress',
-		message: 'Failed to start the app',
-		detail: 'Sorry but we failed to start the app. Are you running another copy of it?',
-		buttons: [ 'Quit' ]
-	}, function() {
-		app.quit();
-	} );
+	dialog.showMessageBox(
+		{
+			type: 'warning',
+			title: 'WordPress',
+			message: 'Failed to start the app',
+			detail: 'Sorry but we failed to start the app. Are you running another copy of it?',
+			buttons: [ 'Quit' ],
+		},
+		function() {
+			app.quit();
+		}
+	);
 }
 
 function startServer( running_cb ) {
-	var boot = require( 'server/boot' );
-	var http = require( 'http' );
 	var server = http.createServer( boot() );
 
 	log.info( 'Server created, binding to ' + Config.server_port );
 
-	server.listen( {
-		port: Config.server_port,
-		host: Config.server_host
-	}, function() {
-		log.info( 'Server started, passing back to app' );
-		running_cb();
-	} );
+	server.listen(
+		{
+			port: Config.server_port,
+			host: Config.server_host,
+		},
+		function() {
+			log.info( 'Server started, passing back to app' );
+			running_cb();
+		}
+	);
 }
 
-module.exports = {
-	start: function( app, running_cb ) {
-		log.info( 'Checking server port: ' + Config.server_port + ' on host ' + Config.server_host );
+export function start( app, running_cb ) {
+	log.info( 'Checking server port: ' + Config.server_port + ' on host ' + Config.server_host );
 
-		portscanner.checkPortStatus( Config.server_port, Config.server_host, function( error, status ) {
-			if ( error || status === 'open' ) {
-				log.info( 'Port check failed - ' + status, error );
-				showFailure( app );
-				return;
-			}
+	portscanner.checkPortStatus( Config.server_port, Config.server_host, function( error, status ) {
+		if ( error || status === 'open' ) {
+			log.info( 'Port check failed - ' + status, error );
+			showFailure( app );
+			return;
+		}
 
-			log.info( 'Starting server' );
-			startServer( running_cb );
-		} );
-	}
-};
+		log.info( 'Starting server' );
+		startServer( running_cb );
+	} );
+}


### PR DESCRIPTION
Converts the `desktop/server/server` module from CommonJS to ESM, with `import` and `export` statements.

The benefit is that this creates compatibility with Calypso https://github.com/Automattic/wp-calypso/pull/42643 PR, which converts `calypso/client/server/boot` to ESM, too. Importing that module with
```js
import boot from 'server/boot';
```
works equally well both for ESM and CJS, while
```js
const boot = require( 'server/boot' );
```
works only if `server/boot` is CJS. An ESM module would need
```js
const boot = require( 'server/boot' ).default;
```
Therefore, this PR makes `wp-desktop` compatible with Calypso both pre- and post- https://github.com/Automattic/wp-calypso/pull/42643

I also removed the `use strict` statement, as webpack adds it automatically to all processed modules.