### PR TITLE
chore(build): archive mac executable parent folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,7 +436,7 @@ jobs:
           name: Persist Mac Executable
           command: |
                   # If this isn't a full artifact build, ensure to persist the built application for inspection
-                  test -f release/*.zip || ditto -ck --rsrc --sequesterRsrc release/mac/WordPress.com.app release/mac.app.zip
+                  test -f release/*.zip || ditto -ck --rsrc --sequesterRsrc release/mac release/mac.app.zip
       - run:
           name: Release cleanup
           command: |


### PR DESCRIPTION
### Description

This PR makes it so that unarchiving the e2e executable works without having to specify `WordPress.com.app`.

### To Test

1. Download the [mac.zip artifact](https://app.circleci.com/pipelines/github/Automattic/wp-desktop/14748/workflows/f441c962-f300-4995-97a9-ab6607d1f0fe/jobs/62846/steps) of this PR
2. Extract the app with `ditto -x -k mac.app.zip .` (per the README)  