### PR TITLE
build: Add symlink to calypso .nvmrc to the root of the project

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+calypso/.nvmrc


### PR DESCRIPTION
<!-- Thanks for contributing to Wordpress.com for Desktop! Pick a clear title ("Editor: add spell check") and proceed. -->

### Description:
<!--- Describe your changes in detail. -->
`ln -s calypso/.nvmrc .nvmrc`


### Motivation and Context:
<!--- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->
Every time I build the app for release, I get an error because my Node version is different from the Calypso one.

This should make it easier to keep the two versions in sync.

I don't think we should remove the version sync check in the build process, just in case.


### How Has This Been Tested:
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, tests completed to see
how your change affects other areas of the code, etc. -->
- Set your system's Node version to something different from 12.16.2 (`cat ./calypso/.nvmrc`).
- `cd` into the project and run `yarn`
	- On `master`, it'll fail;
	- On this branch, it'll pass