### PR TITLE
chore: Merge v6.0.0-beta2 into develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "5.2.0",
+  "version": "6.0.0-beta1",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPressDesktop",
-  "version": "6.0.0-beta1",
+  "version": "6.0.0-beta2",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-desktop/"


### PR DESCRIPTION
### Description:
Merges `v6.0.0-beta2` into `develop` as part of the release process for v6.0.0.