### PR TITLE
fix: ensure clicking "View Post" opens in an external browser

### DIFF
--- a/desktop/window-handlers/external-links/index.js
+++ b/desktop/window-handlers/external-links/index.js
@@ -102,4 +102,9 @@ module.exports = function( mainWindow ) {
 				handleUndefined( mainWindow, info );
 		}
 	} );
+
+	ipc.on( 'view-post-clicked', ( _, url ) => {
+		log.info( `View Post handler for URL: ${ url }` );
+		openInBrowser( null, url );
+	} );
 };


### PR DESCRIPTION
### Description

This PR pairs with Automattic/wp-calypso#43301 and fixes a bug in which clicking "View Post" in the bottom-left "snackbar" or the "Publish" panel would leave the app in an unusable state due to leaving Calypso's iframe context when the window's location was overriden.

To address this, this behavior in the wp.com editor and Calypso has been changed such that clicking "View Post" will send a custom IPC event which the desktop can respond to by opening an external browser.

### To Test

1. Sync the `wpcom-block-editor` changes in Automattic/wp-calypso#43301 with your `wp.com` sandbox
1. Sandbox a Simple test site, as well as `public-api.wordpress.com` and `widgets.wp.com`
1. With your sandbox running, build and run the app.
1. Navigate to the Simple site in the app and attempt to update or publish a post. Clicking "View Post" should open in an external browser.

Fixes #908