### PR TITLE
ci: ignore wp-desktop migration branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -661,6 +661,7 @@ workflows:
           filters:
             branches:
               only: /tests\/.*/
+              ignore: import/wp-desktop
       - mac-canary:
           requires:
             - build


### PR DESCRIPTION
### Description

While work to migrate wp-desktop to Calypso is underway, the bridge should ignore the `import/wp-desktop` branch in Automattic/wp-calypso#43324.