### PR TITLE
ci: fix ignore path for import branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -661,7 +661,7 @@ workflows:
           filters:
             branches:
               only: /tests\/.*/
-              ignore: import/wp-desktop
+              ignore: tests/import/wp-desktop
       - mac-canary:
           requires:
             - build


### PR DESCRIPTION
### Description

Adding `tests` prefix of ignore path for migration branch.