### PR TITLE
enhancement: print handler

### DIFF
--- a/desktop/app-handlers/printer/index.js
+++ b/desktop/app-handlers/printer/index.js
@@ -3,9 +3,7 @@
 /**
  * External Dependencies
  */
-const electron = require( 'electron' );
-const ipc = electron.ipcMain;
-const BrowserWindow = electron.BrowserWindow;
+const { BrowserWindow, ipcMain: ipc } = require( 'electron' );
 
 /**
  * Internal dependencies
@@ -18,11 +16,17 @@ module.exports = function() {
 
 		log.debug( 'Printing HTML' );
 
-		printer.loadURL( 'data:text/html,' + encodeURIComponent( html ) );
+		const file = 'data:text/html;charset=UTF-8,' + encodeURIComponent( html );
+		printer.loadURL( file );
 
 		printer.webContents.on( 'dom-ready', function() {
+			const options = { silent: false }; // ask the user for print settings
 			setTimeout( function() {
-				printer.webContents.print();
+				printer.webContents.print( options, ( success, error ) => {
+					if ( ! success ) {
+						log.error( 'Failed to print: ', error );
+					}
+				} );
 			}, 500 );
 		} );
 

--- a/desktop/app-handlers/printer/index.js
+++ b/desktop/app-handlers/printer/index.js
@@ -11,12 +11,12 @@ const { BrowserWindow, ipcMain: ipc } = require( 'electron' );
 const log = require( 'lib/logger' )( 'desktop:printer' );
 
 module.exports = function() {
-	ipc.on( 'print', function( event, title, html ) {
+	ipc.on( 'print', function( event, title, contents ) {
 		let printer = new BrowserWindow( { width: 350, height: 300, title: title } );
 
-		log.debug( 'Printing HTML' );
+		log.info( `Printing contents '${ title }'...` );
 
-		const file = 'data:text/html;charset=UTF-8,' + encodeURIComponent( html );
+		const file = 'data:text/html;charset=UTF-8,' + encodeURIComponent( contents );
 		printer.loadURL( file );
 
 		printer.webContents.on( 'dom-ready', function() {


### PR DESCRIPTION
### Description

This PR contains some minor tweaks to the print handler in the desktop app, discovered while debugging the "Print Recovery Codes" feature which was silently not working.

Works in conjunction with the changes in Automattic/wp-calypso#43523 (merged).

<p align="center">
<img src="https://user-images.githubusercontent.com/8979548/85303563-a6754580-b478-11ea-805a-7b44be6377f6.gif">
</p>

Fixes #910 

### Description

When the "print recovery codes" button was selected, it would silently fail - no action and no error message displayed to the user. This action was [wired up in Calypso](https://github.com/Automattic/wp-calypso/pull/43523/files#diff-dd80c6b9bd20574564ee8c195e71d232L92) and looks like it used to work, but at some point silently broke (appears to be a CommonJS vs ES6 import/export misspecification). 

The root cause of the breakage has already been fixed in Automattic/wp-calypso#43523, but during the course of debugging I found some minor quality-of-life improvements for the desktop print handler (namely, adding some logging and explicitly specifying the charset).

### To Test

Download, extract and install an artifact from this PR (built with with Calypso SHA noted above: [link](https://app.circleci.com/pipelines/github/Automattic/wp-desktop/16967/workflows/0f468659-8f7b-4cf3-992e-cbf9f604696d/jobs/65456/artifacts)). From your profile, enable two-factor authentication and select the "Print Recovery Codes" button.
