### PR TITLE
fix: handle unknown editor load failures

### DIFF
--- a/desktop/window-handlers/external-links/editor/index.js
+++ b/desktop/window-handlers/external-links/editor/index.js
@@ -157,17 +157,26 @@ async function handleJetpackEnableSSO( mainWindow, info ) {
 }
 
 function handleUndefined( mainWindow, info ) {
-	log.info( 'Cannot use editor, unhandled reason: ', info );
+	log.error( 'Cannot use editor, unhandled reason: ', info );
 
 	dialog.showMessageBox( mainWindow, {
 		type: 'info',
 		buttons: [ 'OK' ],
 		title: 'Unable to Use the Editor',
 		message: 'An unhnadled error occurred. ' +
-			+ 'Please contact help@wordpress.com for help.',
+			'Please contact help@wordpress.com for help.',
 	} );
 
-	const { origin } = info;
+	const { origin, wpAdminLoginUrl, editorUrl } = info;
+	if ( wpAdminLoginUrl ) {
+		log.info( `Falling back to opening editor in browser with admin login URL: '${ wpAdminLoginUrl }'` );
+		openInBrowser( null, wpAdminLoginUrl );
+	} else if ( editorUrl ) {
+		log.info( `Falling back to opening editor in browser with editor URL: '${ editorUrl }'` );
+		openInBrowser( null, editorUrl );
+	} else {
+		log.error( 'Failed to open editor in browser as fallback: invalid admin and editor urls' );
+	}
 	navigateToShowMySites( mainWindow, origin );
 }
 


### PR DESCRIPTION
### Description

We've been getting an increased number of reports of users running into an "unhandled error" resulting from a timeout when trying to load the block editor:

```
[2020-07-06 16:59:08.701] [desktop:external-links] [info] Cannot 
open editor for site: 
{"siteId":175060405,"reason":"REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE","editorUrl":"https://xxxxx.com/wp-admin/post.php?post=470&action=edit&calypsoify=1&block-editor=1&frame-nonce=nnnnnnnnn%3A2%3xxxxxxxxxxxxxxxxxxxxxxxxxxxx&origin=http%3A%2F%2F127.0.0.1%3A41050&environment-id=desktop","wpAdminLoginUrl":null,"origin":"https://xxxxxxxxxx.com","canUserManageOptions":true}
```

This timeout was introduced in Automattic/wp-calypso#43248 and makes it so loading the editor times out after 6 (now 8) seconds. However, this timeout is likely too strict for the desktop app (and to be fair, even browsers) as it has been observed that Gutenberg can take as long as 22 seconds when loading an Atomic site from a cold cache (see p58i-95P-p2).

The timeout for desktop has been bumped in Automattic/wp-calypso#44073, which is by no means an acceptable threshold for an ideal user experience, but at least mitigates this issue while performance optimization of Gutenberg is pending (p4TIVU-p2). In addition, this PR adds more comprehensive fallback behavior for editor load failures (i.e. re-routes the user to an external browser).

Ref: #3110882-zen