### PR TITLE
ci: Add check to fail build if tag version doesn't match package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,6 +229,26 @@ references:
         }'
 
 jobs:
+  validate_version:
+    docker:
+      - image: circleci/node:12.16.2-browsers
+    environment:
+      VERSION: << pipeline.git.tag >>
+    steps:
+      - when:
+          condition: << pipeline.git.tag >>
+          steps:
+            - checkout
+            - run:
+                name: Ensure package.json Version And Tag Match
+                command: node ./validate_tag.js $VERSION
+      - unless:
+          condition: << pipeline.git.tag >>
+          steps:
+            - run:
+                name: Skip Validation
+                command: echo "Not on a tag. Skipping version validation."
+
   build:
     docker:
       - image: circleci/node:12.16.2-browsers
@@ -597,7 +617,15 @@ workflows:
   wp-desktop:
     unless: << pipeline.parameters.isCalypsoCanaryRun >>
     jobs:
+      - validate_version:
+          filters:
+            branches:
+              ignore: /tests\/.*/
+            tags:
+              only: /.*/
       - build:
+          requires:
+          - validate_version
           filters:
             branches:
               ignore: /tests\/.*/

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/validate_tag.js
+++ b/validate_tag.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+//
+// Checks whether the version value in the package.json is the same as the
+// given input.
+//
+
+if (process.argv.length === 2) {
+	console.error(`Usage: ${process.argv[1]} 1.2.3-beta4`);
+	console.error('\nExpected version parameter to check.');
+	process.exit(1);
+}
+
+const version = process.argv[2];
+// Remove the leading v that a tag from version control may have.
+// This regex means "a letter v at the start of the string"
+const sanitizedVersion = version.replace(/^v/, '');
+
+console.log(`Validating package.json version matches ${version}...`);
+
+const fs = require('fs');
+const package = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+const packageVersion = package['version'];
+
+if (package['version'] !== sanitizedVersion) {
+	console.error(`Expected version in package.json to match ${version}, got ${packageVersion}`);
+	process.exit(1);
+}
+
+console.log(`Version in package.json matches expected value ${version}. 👍`);


### PR DESCRIPTION
### Description

@nsakaimbo rightly noticed that when I pushed beta 1 for version 6.0.1, I used the wrong version. That is, `package.json` said `6.0.1` while the tag `v6.0.1-beta1`. Other than not being correct, this also causes issues with the auto-updater.

This PR adds a script to be run on CI when the build is from a tag that checks whether a given version matches the one from the `package.json`. If the versions don't match, the build will fail.

### How Has This Been Tested

I pushed a test tag and verified [the build doesn't get to the publish step](https://app.circleci.com/pipelines/github/Automattic/wp-desktop/18849/workflows/adf57785-f02b-4bbf-94b2-922b87d4df0a/jobs/67292).

![image](https://user-images.githubusercontent.com/1218433/87420175-22961f80-c618-11ea-8b8a-52bf47fc895e.png)

When the build [is not on a tag](https://app.circleci.com/pipelines/github/Automattic/wp-desktop/18850/workflows/0a99909d-9555-4b55-b907-ac402dbf37a5/jobs/67293), the validation is skipped.

![image](https://user-images.githubusercontent.com/1218433/87420297-61c47080-c618-11ea-94c4-0bd1c90dd93d.png)