### PR TITLE
fix: showMessageBox API usage (updater and SSO prompt)

### DIFF
--- a/desktop/app-handlers/updater/auto-updater/index.js
+++ b/desktop/app-handlers/updater/auto-updater/index.js
@@ -85,6 +85,8 @@ class AutoUpdater extends Updater {
 	}
 
 	onConfirm() {
+		log.info( `User selected 'Update & Restart'...` );
+
 		AppQuit.allowQuit();
 		autoUpdater.quitAndInstall();
 

--- a/desktop/lib/updater/index.js
+++ b/desktop/lib/updater/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app, dialog } = require( 'electron' );
+const { app, dialog, BrowserWindow } = require( 'electron' );
 const { EventEmitter } = require( 'events' );
 
 /**
@@ -49,7 +49,9 @@ class Updater extends EventEmitter {
 
 	onCancel() {}
 
-	notify() {
+	async notify() {
+		const mainWindow = BrowserWindow.getFocusedWindow();
+
 		const updateDialogOptions = {
 			buttons: [ this.sanitizeButtonLabel( this.confirmLabel ), 'Cancel' ],
 			title: 'Update Available',
@@ -60,8 +62,8 @@ class Updater extends EventEmitter {
 		if ( !this._hasPrompted ) {
 			this._hasPrompted = true;
 
-			dialog.showMessageBox( updateDialogOptions, button => {
-				this._hasPrompted = false;
+			const selected = await dialog.showMessageBox( mainWindow, updateDialogOptions );
+			const button = selected.response;
 
 				if ( button === 0 ) {
 					// Confirm
@@ -70,8 +72,8 @@ class Updater extends EventEmitter {
 					this.onCancel();
 				}
 
-				this.emit( 'end' );
-			} );
+			this._hasPrompted = false;
+			this.emit( 'end' );
 		}
 	}
 

--- a/desktop/window-handlers/external-links/editor/index.js
+++ b/desktop/window-handlers/external-links/editor/index.js
@@ -122,7 +122,7 @@ async function handleJetpackEnableSSO( mainWindow, info ) {
 					'Please contact the site admin.'
 		}
 
-		const selected = dialog.showMessageBox( mainWindow, {
+		const selected = await dialog.showMessageBox( mainWindow, {
 			type: 'info',
 			buttons: buttons,
 			title: 'Jetpack Authorization Required',
@@ -131,7 +131,9 @@ async function handleJetpackEnableSSO( mainWindow, info ) {
 					'or you can proceed in an external browser.'
 		} );
 
-		switch ( selected ) {
+		const button = selected.response;
+
+		switch ( button ) {
 			case 0:
 				if ( canUserManageOptions ) {
 					selectedEnableSSOandContinue( mainWindow, info );
@@ -163,7 +165,7 @@ function handleUndefined( mainWindow, info ) {
 		type: 'info',
 		buttons: [ 'OK' ],
 		title: 'Unable to Use the Editor',
-		message: 'An unhnadled error occurred. ' +
+		message: 'An unhandled error occurred. ' +
 			'Please contact help@wordpress.com for help.',
 	} );
 


### PR DESCRIPTION
### Description

This PR fixes the native message boxes used to prompt the user (currently used for auto-update and SSO).

Turns out the `showMessageBox` API was updated in Electron v8 (undocumented breaking change) to return (1) a promise, and (2) a object `MessageBoxReturnValue` object (previously was a synchronous API that returned the index of the button tapped).