### PR TITLE
ci: add a new Gardening action

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -1,0 +1,39 @@
+name: Repo gardening
+
+on:
+  # Listen to this event for PRs from forks (see Flag OSS task).
+  pull_request_target:
+    types: [opened]
+  # We need to listen to all these events to catch all scenarios
+  pull_request:
+    types: ['opened', 'synchronize', 'edited', 'closed', 'labeled']
+
+jobs:
+  repo-gardening:
+    name: 'Assign issues, Clean up labels, and notify Design and Editorial when necessary'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v2
+
+     - name: Setup Node
+       uses: actions/setup-node@v2
+       with:
+         node-version: 12
+
+     - name: Wait for prior instances of the workflow to finish
+       uses: softprops/turnstyle@v1
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+     - name: 'Run gardening action'
+       uses: automattic/action-repo-gardening@v1.2.0
+       with:
+         github_token: ${{ secrets.GITHUB_TOKEN }}
+         slack_token: ${{ secrets.SLACK_TOKEN }}
+         slack_design_channel: ${{ secrets.SLACK_DESIGN_CHANNEL }}
+         slack_editorial_channel: ${{ secrets.SLACK_EDITORIAL_CHANNEL }}
+         slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
+         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss'


### PR DESCRIPTION
Fixes #978

### Description:

This will allow us to do a few things automatically:

- Add assignee for issues which are being worked on, and adds the "In Progress" label.
- Remove Status labels once a PR has been merged.
- Send a Slack Notification to the Design team to request feedback, based on labels applied to a PR.
- Send a Slack notification to the Editorial team to request feedback, based on labels.
- Add a label and post a Slack message every time someone opens a PR from a fork.

For more info:
- https://github.com/Automattic/jetpack/pull/19239
- https://github.com/Automattic/action-repo-gardening

### Motivation and Context:

Some of these things are already handled via webhooks today; this would allow us to switch from the webhooks to the action. For more info about this, see this internal reference: p3btAN-1nR-p2

### How Has This Been Tested:

* See the label that will be added to #978, and the assignment.
* See how the status label will be removed once I merge this PR.
* See the actions running in https://github.com/Automattic/wp-desktop/actions/new

